### PR TITLE
Remove resetting of key states after sending a report

### DIFF
--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -137,10 +137,7 @@ impl<
                 Ok(()) => {}
                 Err(e) => error!("Send keyboard report error: {}", e),
             };
-            // Reset report key states
-            for bit in &mut self.report.keycodes {
-                *bit = 0;
-            }
+
             self.need_send_key_report = false;
         }
     }

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -133,10 +133,26 @@ impl<
     pub(crate) async fn send_keyboard_report<W: HidWriterWrapper>(&mut self, writer: &mut W) {
         if self.need_send_key_report {
             debug!("Sending keyboard report: {=[u8]:#X}", self.report.keycodes);
-            match writer.write_serialize(&self.report).await {
-                Ok(()) => {}
-                Err(e) => error!("Send keyboard report error: {}", e),
-            };
+
+            const MAX_RETRIES: usize = 3;
+
+            let mut retries = 0;
+            loop {
+                match writer.write_serialize(&self.report).await {
+                    Ok(()) => {
+                        break;
+                    }
+                    Err(e) => {
+                        error!("Send keyboard report error: {}", e);
+                        retries += 1;
+                        if retries >= MAX_RETRIES {
+                            error!("Maximum retry count reached. Failed to send keyboard report.");
+                            break;
+                        }
+                        // We could wait before retrying
+                    }
+                };
+            }
 
             self.need_send_key_report = false;
         }


### PR DESCRIPTION
This pull request aims to improve the behavior of the keyboard events. Currently, the `report.keycodes` is being cleared immediately after sending a report. However, this approach can lead to the loss of the current state of pressed keys, hindering the ability to handle multiple key presses.

The proposed change removes the resetting of `report.keycodes` after sending a report. By retaining the current state of pressed keys until they are released, we ensure that the `report.keycodes` accurately reflects the keyboard's state, enabling better management of key presses and releases.
