### PR TITLE
Improve readability

### DIFF
--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -475,21 +475,15 @@ impl<
 
     /// Register a key to be sent in hid report.
     fn register_keycode(&mut self, key: KeyCode) {
-        for bit in &mut self.report.keycodes {
-            if *bit == 0 {
-                *bit = key as u8;
-                break;
-            }
+        if let Some(index) = self.report.keycodes.iter().position(|&k| k == 0) {
+            self.report.keycodes[index] = key as u8;
         }
     }
 
     /// Unregister a key from hid report.
     fn unregister_keycode(&mut self, key: KeyCode) {
-        for bit in &mut self.report.keycodes {
-            if *bit == (key as u8) {
-                *bit = 0;
-                break;
-            }
+        if let Some(index) = self.report.keycodes.iter().position(|&k| k == key as u8) {
+            self.report.keycodes[index] = 0;
         }
     }
 


### PR DESCRIPTION
This pull request proposes enhancements to the `register_keycode` and `unregister_keycode` functions to improve the readability and clarity.

By using the `iter().position()`, we can directly express the intent of finding an empty slot or a previously registered key, resulting in clearer and more concise code.