### PR TITLE
Remove redundant assignment

### DIFF
--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -311,7 +311,6 @@ impl<
     /// Tap action, send a key when the key is pressed, then release the key.
     async fn process_key_action_tap(&mut self, action: Action, mut key_state: KeyState) {
         if key_state.changed && key_state.pressed {
-            key_state.pressed = true;
             self.process_key_action_normal(action, key_state);
 
             // Wait 10ms, then send release


### PR DESCRIPTION
This pull request removes a redundant assignment of `key_state.pressed` to `true` in the `process_key_action_tap` function. The assignment is unnecessary as the condition already checks if the key state is pressed. 