### PR TITLE
Refactor `scan` and `debounce` functions

### DIFF
--- a/rmk/src/debounce.rs
+++ b/rmk/src/debounce.rs
@@ -48,7 +48,7 @@ impl<const INPUT_PIN_NUM: usize, const OUTPUT_PIN_NUM: usize>
     }
 
     /// Per-key debounce, same with zmk's debounce algorithm
-    pub(crate) fn has_changed(
+    pub(crate) fn detect_change_with_debounce(
         &mut self,
         in_idx: usize,
         out_idx: usize,

--- a/rmk/src/debounce.rs
+++ b/rmk/src/debounce.rs
@@ -48,13 +48,13 @@ impl<const INPUT_PIN_NUM: usize, const OUTPUT_PIN_NUM: usize>
     }
 
     /// Per-key debounce, same with zmk's debounce algorithm
-    pub(crate) fn debounce(
+    pub(crate) fn has_changed(
         &mut self,
         in_idx: usize,
         out_idx: usize,
         pin_state: bool,
-        key_state: &mut KeyState,
-    ) {
+        key_state: &KeyState,
+    ) -> bool {
         // Record debounce state per ms
         let cur_tick = Instant::now().as_ticks() as u32;
         let elapsed_ms = (cur_tick - self.last_tick) as u16;
@@ -62,23 +62,20 @@ impl<const INPUT_PIN_NUM: usize, const OUTPUT_PIN_NUM: usize>
         if elapsed_ms > 0 {
             let state: &mut DebounceState = &mut self.debounce_state[out_idx][in_idx];
 
-            key_state.changed = false;
             if key_state.pressed == pin_state {
                 state.decrease(elapsed_ms);
-                return;
+            } else {
+                // Use 10khz tick, so the debounce threshold should * 10
+                if state.counter < DEBOUNCE_THRESHOLD * 10 {
+                    state.increase(elapsed_ms);
+                } else {
+                    self.last_tick = cur_tick;
+                    state.counter = 0;
+                    return true;
+                }
             }
-
-            // Use 10khz tick, so the debounce threshold should * 10
-            if state.counter < DEBOUNCE_THRESHOLD * 10 {
-                state.increase(elapsed_ms);
-                return;
-            }
-
-            self.last_tick = cur_tick;
-            state.counter = 0;
-            key_state.pressed = !key_state.pressed;
-            key_state.changed = true;
         }
+        false
     }
 }
 

--- a/rmk/src/matrix.rs
+++ b/rmk/src/matrix.rs
@@ -84,12 +84,19 @@ impl<
             Timer::after_micros(1).await;
             for (in_idx, in_pin) in self.input_pins.iter_mut().enumerate() {
                 // Check input pins and debounce
-                self.debouncer.debounce(
+                let changed = self.debouncer.has_changed(
                     in_idx,
                     out_idx,
                     in_pin.is_high()?,
-                    &mut self.key_states[out_idx][in_idx],
+                    &self.key_states[out_idx][in_idx],
                 );
+
+                if changed {
+                    self.key_states[out_idx][in_idx].pressed =
+                        !self.key_states[out_idx][in_idx].pressed;
+                }
+
+                self.key_states[out_idx][in_idx].changed = changed;
             }
             out_pin.set_low()?;
         }

--- a/rmk/src/matrix.rs
+++ b/rmk/src/matrix.rs
@@ -84,7 +84,7 @@ impl<
             Timer::after_micros(1).await;
             for (in_idx, in_pin) in self.input_pins.iter_mut().enumerate() {
                 // Check input pins and debounce
-                let changed = self.debouncer.has_changed(
+                let changed = self.debouncer.detect_change_with_debounce(
                     in_idx,
                     out_idx,
                     in_pin.is_high()?,


### PR DESCRIPTION
This pull request refactors the `scan` and `debounce` functions for improved clarity and separation of concerns.

In the original implementation, the `debounce` function handled both debounce logic and updating key states. This mixing of responsibilities could potentially complicate code comprehension and maintenance.

In the refactored code, the `debounce` module exclusively focuses on determining if a state change has occurred, without directly modifying key states. Subsequently, the `matrix` module takes action based on the returned value, thereby clarifying the respective responsibilities of each component and enhancing code understandability.

Additionally, the `debounce` function is renamed to `has_changed` to more accurately reflect its purpose of detecting changes in state, such as the passing of a debounce period.

By passing immutable references instead of mutable ones, the refactor ensures that the debounce logic can operate on the key state without needing mutable access. This improves code readability and reduces the risk of unintended side effects.