### PR TITLE
Refactor debouncer module

### DIFF
--- a/rmk/src/debounce.rs
+++ b/rmk/src/debounce.rs
@@ -28,15 +28,6 @@ impl DebounceCounter {
     }
 }
 
-/// Debounce state
-pub(crate) enum DebounceState {
-    Debounced,
-    InProgress,
-    HeldHigh,
-    HeldLow,
-    Ignored,
-}
-
 /// Default per-key debouncer. The debouncing algorithm is same as ZMK's [default debouncer](https://github.com/zmkfirmware/zmk/blob/19613128b901723f7b78c136792d72e6ca7cf4fc/app/module/lib/zmk_debounce/debounce.c)
 pub(crate) struct Debouncer<const INPUT_PIN_NUM: usize, const OUTPUT_PIN_NUM: usize> {
     last_tick: u32,

--- a/rmk/src/debounce.rs
+++ b/rmk/src/debounce.rs
@@ -5,35 +5,42 @@ use crate::matrix::KeyState;
 /// Default DEBOUNCE_THRESHOLD in ms.
 static DEBOUNCE_THRESHOLD: u16 = 10;
 
-/// Debounce info for each key.
+/// Debounce counter info for each key.
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct DebounceState {
-    pub(crate) counter: u16,
-}
+struct DebounceCounter(u16);
 
-impl DebounceState {
+impl DebounceCounter {
     fn increase(&mut self, elapsed_ms: u16) {
         // Prevent overflow
-        if u16::MAX - self.counter <= elapsed_ms {
-            self.counter = u16::MAX;
+        if u16::MAX - self.0 <= elapsed_ms {
+            self.0 = u16::MAX;
         } else {
-            self.counter += 1;
+            self.0 += 1;
         }
     }
 
     fn decrease(&mut self, elapsed_ms: u16) {
-        if elapsed_ms > self.counter {
-            self.counter = 0;
+        if elapsed_ms > self.0 {
+            self.0 = 0;
         } else {
-            self.counter -= 1;
+            self.0 -= 1;
         }
     }
+}
+
+/// Debounce state
+pub(crate) enum DebounceState {
+    Debounced,
+    InProgress,
+    HeldHigh,
+    HeldLow,
+    Ignored,
 }
 
 /// Default per-key debouncer. The debouncing algorithm is same as ZMK's [default debouncer](https://github.com/zmkfirmware/zmk/blob/19613128b901723f7b78c136792d72e6ca7cf4fc/app/module/lib/zmk_debounce/debounce.c)
 pub(crate) struct Debouncer<const INPUT_PIN_NUM: usize, const OUTPUT_PIN_NUM: usize> {
     last_tick: u32,
-    pub(crate) debounce_state: [[DebounceState; INPUT_PIN_NUM]; OUTPUT_PIN_NUM],
+    counters: [[DebounceCounter; INPUT_PIN_NUM]; OUTPUT_PIN_NUM],
 }
 
 impl<const INPUT_PIN_NUM: usize, const OUTPUT_PIN_NUM: usize>
@@ -42,7 +49,7 @@ impl<const INPUT_PIN_NUM: usize, const OUTPUT_PIN_NUM: usize>
     /// Create a default debouncer
     pub(crate) fn new() -> Self {
         Debouncer {
-            debounce_state: [[DebounceState { counter: 0 }; INPUT_PIN_NUM]; OUTPUT_PIN_NUM],
+            counters: [[DebounceCounter(0); INPUT_PIN_NUM]; OUTPUT_PIN_NUM],
             last_tick: 0,
         }
     }
@@ -60,17 +67,17 @@ impl<const INPUT_PIN_NUM: usize, const OUTPUT_PIN_NUM: usize>
         let elapsed_ms = (cur_tick - self.last_tick) as u16;
 
         if elapsed_ms > 0 {
-            let state: &mut DebounceState = &mut self.debounce_state[out_idx][in_idx];
+            let counter: &mut DebounceCounter = &mut self.counters[out_idx][in_idx];
 
             if key_state.pressed == pin_state {
-                state.decrease(elapsed_ms);
+                counter.decrease(elapsed_ms);
             } else {
                 // Use 10khz tick, so the debounce threshold should * 10
-                if state.counter < DEBOUNCE_THRESHOLD * 10 {
-                    state.increase(elapsed_ms);
+                if counter.0 < DEBOUNCE_THRESHOLD * 10 {
+                    counter.increase(elapsed_ms);
                 } else {
                     self.last_tick = cur_tick;
-                    state.counter = 0;
+                    counter.0 = 0;
                     return true;
                 }
             }


### PR DESCRIPTION
This pull request refactors the `debounce` module.

### Changes:

- Adjusted the visibility of the counter struct.
- Renamed `DebounceState` to `DebounceCounter` to reflect its purpose better.

The rationale behind the name change is to introduce a new enum like this next:

```rust
pub(crate) enum DebounceState {
    Debounced,
    InProgress,
    HeldHigh,
    HeldLow,
    Ignored,
}
```

The `detect_change_with_debounce` function can return this enum instead of a bool. This adjustment facilitates the reinsertion of held-down keys.