### PR TITLE
Use `bitfield-struct` to replace`packed_struct`, making it possible to compile for esp32s3

### DIFF
--- a/boards/esp32c3_ble/Cargo.lock
+++ b/boards/esp32c3_ble/Cargo.lock
@@ -100,6 +100,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitfield-struct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0fe3d90b1534e1b0e92008ad2d9f9a3ddb650965ae0592ed1d1031b9dea94f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,18 +121,6 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bstr"
@@ -860,12 +859,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,27 +1241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "packed_struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
-dependencies = [
- "bitvec",
- "packed_struct_codegen",
-]
-
-[[package]]
-name = "packed_struct_codegen"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,12 +1311,6 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "redox_syscall"
@@ -1435,8 +1401,10 @@ dependencies = [
 name = "rmk"
 version = "0.1.12"
 dependencies = [
+ "bitfield-struct",
  "byteorder",
  "defmt",
+ "document-features",
  "embassy-embedded-hal",
  "embassy-executor",
  "embassy-futures",
@@ -1451,7 +1419,6 @@ dependencies = [
  "futures",
  "heapless 0.8.0",
  "num_enum",
- "packed_struct",
  "sequential-storage",
  "ssmarshal",
  "static_cell",
@@ -1670,12 +1637,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2120,15 +2081,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "xz2"

--- a/boards/nrf52832_ble/Cargo.lock
+++ b/boards/nrf52832_ble/Cargo.lock
@@ -58,22 +58,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitfield-struct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0fe3d90b1534e1b0e92008ad2d9f9a3ddb650965ae0592ed1d1031b9dea94f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bytemuck"
@@ -577,12 +576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,27 +949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "packed_struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
-dependencies = [
- "bitvec",
- "packed_struct_codegen",
-]
-
-[[package]]
-name = "packed_struct_codegen"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "panic-probe"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,12 +1025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,8 +1063,10 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 name = "rmk"
 version = "0.1.12"
 dependencies = [
+ "bitfield-struct",
  "byteorder",
  "defmt",
+ "document-features",
  "embassy-embedded-hal",
  "embassy-executor",
  "embassy-futures",
@@ -1114,7 +1082,6 @@ dependencies = [
  "nrf-softdevice",
  "num_enum",
  "once_cell",
- "packed_struct",
  "sequential-storage",
  "ssmarshal",
  "static_cell",
@@ -1276,12 +1243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "thiserror"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,15 +1350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/boards/nrf52840/Cargo.lock
+++ b/boards/nrf52840/Cargo.lock
@@ -39,22 +39,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitfield-struct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0fe3d90b1534e1b0e92008ad2d9f9a3ddb650965ae0592ed1d1031b9dea94f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bytemuck"
@@ -524,12 +523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,27 +834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "packed_struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
-dependencies = [
- "bitvec",
- "packed_struct_codegen",
-]
-
-[[package]]
-name = "packed_struct_codegen"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "panic-probe"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,12 +910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,8 +919,10 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 name = "rmk"
 version = "0.1.12"
 dependencies = [
+ "bitfield-struct",
  "byteorder",
  "defmt",
+ "document-features",
  "embassy-embedded-hal",
  "embassy-executor",
  "embassy-futures",
@@ -967,7 +935,6 @@ dependencies = [
  "futures",
  "heapless 0.8.0",
  "num_enum",
- "packed_struct",
  "sequential-storage",
  "ssmarshal",
  "static_cell",
@@ -976,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "rmk-nrf52840"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "const-gen",
  "cortex-m",
@@ -1129,12 +1096,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "thiserror"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,15 +1197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/boards/nrf52840_ble/Cargo.lock
+++ b/boards/nrf52840_ble/Cargo.lock
@@ -58,22 +58,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitfield-struct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0fe3d90b1534e1b0e92008ad2d9f9a3ddb650965ae0592ed1d1031b9dea94f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bytemuck"
@@ -577,12 +576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,27 +949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "packed_struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
-dependencies = [
- "bitvec",
- "packed_struct_codegen",
-]
-
-[[package]]
-name = "packed_struct_codegen"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "panic-probe"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,12 +1025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1063,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 name = "rmk"
 version = "0.1.12"
 dependencies = [
+ "bitfield-struct",
  "byteorder",
  "defmt",
  "document-features",
@@ -1115,7 +1082,6 @@ dependencies = [
  "nrf-softdevice",
  "num_enum",
  "once_cell",
- "packed_struct",
  "sequential-storage",
  "ssmarshal",
  "static_cell",
@@ -1277,12 +1243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "thiserror"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,15 +1350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/boards/rp2040/Cargo.lock
+++ b/boards/rp2040/Cargo.lock
@@ -78,6 +78,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitfield-struct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0fe3d90b1534e1b0e92008ad2d9f9a3ddb650965ae0592ed1d1031b9dea94f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,18 +99,6 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bytemuck"
@@ -665,12 +664,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,27 +1022,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "packed_struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
-dependencies = [
- "bitvec",
- "packed_struct_codegen",
-]
-
-[[package]]
-name = "packed_struct_codegen"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "panic-probe"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,12 +1195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,8 +1259,10 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 name = "rmk"
 version = "0.1.12"
 dependencies = [
+ "bitfield-struct",
  "byteorder",
  "defmt",
+ "document-features",
  "embassy-embedded-hal",
  "embassy-executor",
  "embassy-futures",
@@ -1307,7 +1275,6 @@ dependencies = [
  "futures",
  "heapless 0.8.0",
  "num_enum 0.7.2",
- "packed_struct",
  "sequential-storage",
  "ssmarshal",
  "static_cell",
@@ -1316,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "rmk-rp2040"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "const-gen",
  "cortex-m-rt",
@@ -1530,12 +1497,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "term"
@@ -1841,15 +1802,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "xz2"

--- a/boards/stm32f1/Cargo.lock
+++ b/boards/stm32f1/Cargo.lock
@@ -39,22 +39,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitfield-struct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0fe3d90b1534e1b0e92008ad2d9f9a3ddb650965ae0592ed1d1031b9dea94f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bxcan"
@@ -519,12 +518,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,27 +721,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "packed_struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
-dependencies = [
- "bitvec",
- "packed_struct_codegen",
-]
-
-[[package]]
-name = "packed_struct_codegen"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "panic-halt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,12 +793,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,8 +802,10 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 name = "rmk"
 version = "0.1.12"
 dependencies = [
+ "bitfield-struct",
  "byteorder",
  "defmt",
+ "document-features",
  "embassy-embedded-hal",
  "embassy-executor",
  "embassy-futures",
@@ -850,7 +818,6 @@ dependencies = [
  "futures",
  "heapless 0.8.0",
  "num_enum",
- "packed_struct",
  "sequential-storage",
  "ssmarshal",
  "static_cell",
@@ -859,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "rmk-stm32f1"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "const-gen",
  "cortex-m",
@@ -1036,12 +1003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "thiserror"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,15 +1098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/boards/stm32f4/Cargo.lock
+++ b/boards/stm32f4/Cargo.lock
@@ -39,22 +39,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitfield-struct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0fe3d90b1534e1b0e92008ad2d9f9a3ddb650965ae0592ed1d1031b9dea94f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bxcan"
@@ -532,12 +531,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,27 +734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "packed_struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
-dependencies = [
- "bitvec",
- "packed_struct_codegen",
-]
-
-[[package]]
-name = "packed_struct_codegen"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "panic-probe"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,12 +810,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,8 +819,10 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 name = "rmk"
 version = "0.1.12"
 dependencies = [
+ "bitfield-struct",
  "byteorder",
  "defmt",
+ "document-features",
  "embassy-embedded-hal",
  "embassy-executor",
  "embassy-futures",
@@ -867,7 +835,6 @@ dependencies = [
  "futures",
  "heapless 0.8.0",
  "num_enum",
- "packed_struct",
  "sequential-storage",
  "ssmarshal",
  "static_cell",
@@ -876,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "rmk-stm32f4"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "const-gen",
  "cortex-m",
@@ -1055,12 +1022,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "thiserror"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,15 +1117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/boards/stm32h7/Cargo.lock
+++ b/boards/stm32h7/Cargo.lock
@@ -39,22 +39,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitfield-struct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0fe3d90b1534e1b0e92008ad2d9f9a3ddb650965ae0592ed1d1031b9dea94f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bxcan"
@@ -532,12 +531,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,27 +734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "packed_struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
-dependencies = [
- "bitvec",
- "packed_struct_codegen",
-]
-
-[[package]]
-name = "packed_struct_codegen"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "panic-probe"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,12 +810,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,8 +819,10 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 name = "rmk"
 version = "0.1.12"
 dependencies = [
+ "bitfield-struct",
  "byteorder",
  "defmt",
+ "document-features",
  "embassy-embedded-hal",
  "embassy-executor",
  "embassy-futures",
@@ -867,7 +835,6 @@ dependencies = [
  "futures",
  "heapless 0.8.0",
  "num_enum",
- "packed_struct",
  "sequential-storage",
  "ssmarshal",
  "static_cell",
@@ -1055,12 +1022,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "thiserror"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,15 +1117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/check_all.sh
+++ b/check_all.sh
@@ -1,0 +1,8 @@
+cd boards/stm32h7 && cargo build --release && cargo clean && cd ../.. 
+cd boards/stm32f4 && cargo build --release && cargo clean && cd ../..
+cd boards/stm32f1 && cargo build --release && cargo clean && cd ../..
+cd boards/rp2040 && cargo build --release && cargo clean && cd ../..
+cd boards/nrf52840 && cargo build --release && cargo clean && cd ../..
+cd boards/nrf52840_ble && cargo build --release && cargo clean && cd ../..
+cd boards/nrf52832_ble && cargo build --release && cargo clean && cd ../..
+cd boards/esp32c3_ble && cargo build --release && cd ../..

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -32,7 +32,7 @@ ssmarshal = { version = "1.0", default-features = false }
 defmt = "0.3"
 static_cell = "2"
 num_enum = { version = "0.7", default-features = false }
-packed_struct = { version = "0.10", default-features = false }
+bitfield-struct = "0.6"
 byteorder = { version = "1.4", default-features = false }
 futures = { version = "0.3", default-features = false }
 sequential-storage = { version = "2.0", git = "https://github.com/tweedegolf/sequential-storage", rev = "4dedc23", features = [

--- a/rmk/src/action.rs
+++ b/rmk/src/action.rs
@@ -1,7 +1,6 @@
 use crate::keycode::{KeyCode, ModifierCombination};
 use defmt::{error, warn, Format};
 use num_enum::FromPrimitive;
-use packed_struct::PackedStructSlice;
 
 /// A KeyAction is the action at a keyboard position, stored in keymap.
 /// It can be a single action like triggering a key, or a composite keyboard action like tap/hold
@@ -61,17 +60,10 @@ impl KeyAction {
             KeyAction::Tap(a) => 0x0001 | a.to_action_code(),
             KeyAction::OneShot(a) => 0x0010 | a.to_action_code(),
             KeyAction::WithModifier(a, m) => {
-                let mut modifier_bits = [0];
-                // Ignore packing error
-                ModifierCombination::pack_to_slice(&m, &mut modifier_bits).unwrap_or_default();
-                0x4000 | ((modifier_bits[0] as u16) << 8) | a.to_basic_action_code()
+                0x4000 | ((m.into_bits() as u16) << 8) | a.to_basic_action_code()
             }
-            KeyAction::ModifierTapHold(action, modifier) => {
-                let mut modifier_bits = [0];
-                // Ignore packing error
-                ModifierCombination::pack_to_slice(&modifier, &mut modifier_bits)
-                    .unwrap_or_default();
-                0x6000 | ((modifier_bits[0] as u16) << 8) | action.to_basic_action_code()
+            KeyAction::ModifierTapHold(a, m) => {
+                0x6000 | ((m.into_bits() as u16) << 8) | a.to_basic_action_code()
             }
             KeyAction::LayerTapHold(action, layer) => {
                 if layer < 16 {
@@ -153,7 +145,7 @@ impl Action {
     pub(crate) fn to_action_code(self) -> u16 {
         match self {
             Action::Key(k) => k as u16,
-            Action::Modifier(m) => 0xE00 | (m.to_bits() as u16),
+            Action::Modifier(m) => 0xE00 | (m.into_bits() as u16),
             Action::LayerOn(layer) => 0xE20 | (layer as u16),
             Action::LayerOff(layer) => 0xE40 | (layer as u16),
             Action::LayerToggle(layer) => 0xE60 | (layer as u16),

--- a/rmk/src/light.rs
+++ b/rmk/src/light.rs
@@ -183,16 +183,6 @@ impl<P: OutputPin> LightService<P> {
                 let indicator = LedIndicator::from_bits(self.led_indicator_data[0]);
                 debug!("Read keyboard state: {:?}", indicator);
                 self.set_leds(indicator).map_err(|_| ())
-                // match LedIndicator::unpack_from_slice(&self.led_indicator_data) {
-                //     Ok(indicator) => {
-                //         // Ignore the error, which is `Infallible` in most cases
-
-                //     }
-                //     Err(_) => {
-                //         error!("packing error: {:b}", self.led_indicator_data[0]);
-                //         Err(())
-                //     }
-                // }
             }
             Err(e) => {
                 error!("Read keyboard state error: {}", e);

--- a/rmk/src/light.rs
+++ b/rmk/src/light.rs
@@ -1,8 +1,8 @@
 use crate::{config::LightConfig, hid::HidReaderWrapper};
+use bitfield_struct::bitfield;
 use defmt::{debug, error, Format};
 use embassy_time::Timer;
 use embedded_hal::digital::{OutputPin, PinState};
-use packed_struct::prelude::*;
 
 pub(crate) async fn led_task<R: HidReaderWrapper, Out: OutputPin>(
     keyboard_hid_reader: &mut R,
@@ -16,21 +16,23 @@ pub(crate) async fn led_task<R: HidReaderWrapper, Out: OutputPin>(
     }
 }
 
-#[derive(PackedStruct, Clone, Copy, Debug, Default, Format, Eq, PartialEq)]
-#[packed_struct(bit_numbering = "lsb0", size_bytes = "1")]
+#[bitfield(u8)]
+#[derive(Format, Eq, PartialEq)]
 pub struct LedIndicator {
-    #[packed_field(bits = "0")]
+    #[bits(1)]
     numslock: bool,
-    #[packed_field(bits = "1")]
+    #[bits(1)]
     capslock: bool,
-    #[packed_field(bits = "2")]
+    #[bits(1)]
     scrolllock: bool,
-    #[packed_field(bits = "3")]
+    #[bits(1)]
     compose: bool,
-    #[packed_field(bits = "4")]
+    #[bits(1)]
     kana: bool,
-    #[packed_field(bits = "5")]
+    #[bits(1)]
     shift: bool,
+    #[bits(2)]
+    _reserved: u8,
 }
 
 /// A single LED
@@ -158,9 +160,9 @@ impl<P: OutputPin> LightService<P> {
     impl_led_on_off!(numslock, set_numslock);
 
     pub(crate) fn set_leds(&mut self, led_indicator: LedIndicator) -> Result<(), P::Error> {
-        self.set_capslock(led_indicator.capslock)?;
-        self.set_numslock(led_indicator.numslock)?;
-        self.set_scrolllock(led_indicator.scrolllock)?;
+        self.set_capslock(led_indicator.capslock())?;
+        self.set_numslock(led_indicator.numslock())?;
+        self.set_scrolllock(led_indicator.scrolllock())?;
 
         Ok(())
     }
@@ -178,17 +180,19 @@ impl<P: OutputPin> LightService<P> {
         }
         match keyboard_hid_reader.read(&mut self.led_indicator_data).await {
             Ok(_) => {
-                match LedIndicator::unpack_from_slice(&self.led_indicator_data) {
-                    Ok(indicator) => {
-                        debug!("Read keyboard state: {:?}", indicator);
-                        // Ignore the error, which is `Infallible` in most cases
-                        self.set_leds(indicator).map_err(|_| ())
-                    }
-                    Err(_) => {
-                        error!("packing error: {:b}", self.led_indicator_data[0]);
-                        Err(())
-                    }
-                }
+                let indicator = LedIndicator::from_bits(self.led_indicator_data[0]);
+                debug!("Read keyboard state: {:?}", indicator);
+                self.set_leds(indicator).map_err(|_| ())
+                // match LedIndicator::unpack_from_slice(&self.led_indicator_data) {
+                //     Ok(indicator) => {
+                //         // Ignore the error, which is `Infallible` in most cases
+
+                //     }
+                //     Err(_) => {
+                //         error!("packing error: {:b}", self.led_indicator_data[0]);
+                //         Err(())
+                //     }
+                // }
             }
             Err(e) => {
                 error!("Read keyboard state error: {}", e);

--- a/rmk/src/storage/eeconfig.rs
+++ b/rmk/src/storage/eeconfig.rs
@@ -1,4 +1,4 @@
-use packed_struct::prelude::*;
+use bitfield_struct::bitfield;
 
 /// Keyboard configurations which should be saved in eeprom.
 #[derive(Default)]
@@ -12,75 +12,78 @@ pub struct Eeconfig {
     layout_option: u32,
 }
 
-#[derive(PackedStruct, Debug, Clone, Copy, Default)]
-#[packed_struct(bit_numbering = "msb0", bytes = "2")]
+#[bitfield(u16, order = Msb)]
+#[derive(PartialEq, Eq)]
 pub(crate) struct EeKeymapConfig {
-    #[packed_field(bits = "0")]
+    #[bits(1)]
     swap_control_capslock: bool,
-    #[packed_field(bits = "1")]
+    #[bits(1)]
     capslock_to_control: bool,
-    #[packed_field(bits = "2")]
+    #[bits(1)]
     swap_lalt_lgui: bool,
-    #[packed_field(bits = "3")]
+    #[bits(1)]
     swap_ralt_rgui: bool,
-    #[packed_field(bits = "4")]
+    #[bits(1)]
     no_gui: bool,
-    #[packed_field(bits = "5")]
+    #[bits(1)]
     swap_grave_esc: bool,
-    #[packed_field(bits = "6")]
+    #[bits(1)]
     swap_backslash_backspace: bool,
-    #[packed_field(bits = "7")]
+    #[bits(1)]
     nkro: bool,
-    #[packed_field(bits = "8")]
+    #[bits(1)]
     swap_lctl_lgui: bool,
-    #[packed_field(bits = "9")]
+    #[bits(1)]
     swap_rctl_rgui: bool,
-    #[packed_field(bits = "10")]
+    #[bits(1)]
     oneshot_enable: bool,
-    #[packed_field(bits = "11")]
+    #[bits(1)]
     swap_escape_capslock: bool,
-    #[packed_field(bits = "12")]
+    #[bits(1)]
     autocorrect_enable: bool,
-    _reserved: ReservedOne<packed_bits::Bits<3>>,
+    #[bits(3)]
+    _reserved: u8,
 }
 
-#[derive(PackedStruct, Debug, Default)]
-#[packed_struct(bit_numbering = "msb0")]
+#[bitfield(u8, order = Msb)]
+#[derive(PartialEq, Eq)]
 pub(crate) struct EeBacklightConfig {
-    #[packed_field(bits = "0")]
+    #[bits(1)]
     enable: bool,
-    #[packed_field(bits = "1")]
+    #[bits(1)]
     breathing: bool,
-    #[packed_field(bits = "2")]
+    #[bits(1)]
     reserved: bool,
-    #[packed_field(bits = "3..=7")]
+    #[bits(5)]
     level: u8,
 }
 
-#[derive(PackedStruct, Debug, Default)]
-#[packed_struct(bit_numbering = "msb0")]
+#[bitfield(u8, order = Msb)]
+#[derive(PartialEq, Eq)]
 pub(crate) struct EeAudioConfig {
-    #[packed_field(bits = "0")]
+    #[bits(1)]
     enable: bool,
-    #[packed_field(bits = "1")]
+    #[bits(1)]
     clicky_enable: bool,
-    #[packed_field(bits = "2..=7")]
+    #[bits(6)]
     level: u8,
 }
 
-#[derive(PackedStruct, Debug, Default)]
-#[packed_struct(bit_numbering = "msb0")]
+#[bitfield(u64, order = Msb)]
+#[derive(PartialEq, Eq)]
 pub(crate) struct EeRgbLightConfig {
-    #[packed_field(bits = "0")]
+    #[bits(1)]
     enable: bool,
-    #[packed_field(bits = "1..=7")]
+    #[bits(8)]
     mode: u8,
-    #[packed_field(bits = "8..=15")]
+    #[bits(8)]
     hue: u8,
-    #[packed_field(bits = "16..=23")]
+    #[bits(8)]
     sat: u8,
-    #[packed_field(bits = "24..=31")]
+    #[bits(8)]
     val: u8,
-    #[packed_field(bits = "32..=39")]
+    #[bits(8)]
     speed: u8,
+    #[bits(23)]
+    _reserved: u32,
 }

--- a/rmk/src/via/keycode_convert.rs
+++ b/rmk/src/via/keycode_convert.rs
@@ -24,7 +24,7 @@ pub(crate) fn to_via_keycode(key_action: KeyAction) -> u16 {
         KeyAction::OneShot(a) => match a {
             Action::Modifier(m) => {
                 // One-shot modifier
-                let modifier_bits = m.to_bits();
+                let modifier_bits = m.into_bits();
                 0x52A0 | modifier_bits as u16
             }
             Action::LayerOn(l) => {
@@ -42,7 +42,7 @@ pub(crate) fn to_via_keycode(key_action: KeyAction) -> u16 {
                 Action::Key(k) => k as u16,
                 _ => 0,
             };
-            ((m.to_bits() as u16) << 8) | keycode
+            ((m.into_bits() as u16) << 8) | keycode
         }
         KeyAction::LayerTapHold(a, l) => {
             if l > 16 {
@@ -60,7 +60,7 @@ pub(crate) fn to_via_keycode(key_action: KeyAction) -> u16 {
                 Action::Key(k) => k as u16,
                 _ => 0,
             };
-            0x2000 | ((m.to_bits() as u16) << 8) | keycode
+            0x2000 | ((m.into_bits() as u16) << 8) | keycode
         }
         KeyAction::TapHold(_tap, _hold) => todo!(),
     }
@@ -207,7 +207,7 @@ mod test {
         // OSM RCtrl
         let via_keycode = 0x52B1;
         assert_eq!(
-            KeyAction::OneShot(Action::Modifier(ModifierCombination::new(
+            KeyAction::OneShot(Action::Modifier(ModifierCombination::new_from(
                 true, false, false, false, true
             ))),
             from_via_keycode(via_keycode)
@@ -218,7 +218,7 @@ mod test {
         assert_eq!(
             KeyAction::WithModifier(
                 Action::Key(KeyCode::A),
-                ModifierCombination::new(false, false, false, false, true)
+                ModifierCombination::new_from(false, false, false, false, true)
             ),
             from_via_keycode(via_keycode)
         );
@@ -228,7 +228,7 @@ mod test {
         assert_eq!(
             KeyAction::WithModifier(
                 Action::Key(KeyCode::A),
-                ModifierCombination::new(true, false, false, false, true)
+                ModifierCombination::new_from(true, false, false, false, true)
             ),
             from_via_keycode(via_keycode)
         );
@@ -238,7 +238,7 @@ mod test {
         assert_eq!(
             KeyAction::WithModifier(
                 Action::Key(KeyCode::A),
-                ModifierCombination::new(false, false, true, true, true)
+                ModifierCombination::new_from(false, false, true, true, true)
             ),
             from_via_keycode(via_keycode)
         );
@@ -248,7 +248,7 @@ mod test {
         assert_eq!(
             KeyAction::WithModifier(
                 Action::Key(KeyCode::A),
-                ModifierCombination::new(false, true, true, true, true)
+                ModifierCombination::new_from(false, true, true, true, true)
             ),
             from_via_keycode(via_keycode)
         );
@@ -272,7 +272,7 @@ mod test {
         assert_eq!(
             KeyAction::ModifierTapHold(
                 Action::Key(KeyCode::A),
-                ModifierCombination::new(false, false, true, true, false)
+                ModifierCombination::new_from(false, false, true, true, false)
             ),
             from_via_keycode(via_keycode)
         );
@@ -282,7 +282,7 @@ mod test {
         assert_eq!(
             KeyAction::ModifierTapHold(
                 Action::Key(KeyCode::A),
-                ModifierCombination::new(true, true, true, false, true)
+                ModifierCombination::new_from(true, true, true, false, true)
             ),
             from_via_keycode(via_keycode)
         );
@@ -292,7 +292,7 @@ mod test {
         assert_eq!(
             KeyAction::ModifierTapHold(
                 Action::Key(KeyCode::A),
-                ModifierCombination::new(false, true, true, true, true)
+                ModifierCombination::new_from(false, true, true, true, true)
             ),
             from_via_keycode(via_keycode)
         );
@@ -302,7 +302,7 @@ mod test {
         assert_eq!(
             KeyAction::ModifierTapHold(
                 Action::Key(KeyCode::A),
-                ModifierCombination::new(false, false, true, true, true)
+                ModifierCombination::new_from(false, false, true, true, true)
             ),
             from_via_keycode(via_keycode)
         );
@@ -327,7 +327,7 @@ mod test {
         assert_eq!(0x5283, to_via_keycode(a));
 
         // OSM RCtrl
-        let a = KeyAction::OneShot(Action::Modifier(ModifierCombination::new(
+        let a = KeyAction::OneShot(Action::Modifier(ModifierCombination::new_from(
             true, false, false, false, true,
         )));
         assert_eq!(0x52B1, to_via_keycode(a));
@@ -335,28 +335,28 @@ mod test {
         // LCtrl(A) -> WithModifier(A)
         let a = KeyAction::WithModifier(
             Action::Key(KeyCode::A),
-            ModifierCombination::new(false, false, false, false, true),
+            ModifierCombination::new_from(false, false, false, false, true),
         );
         assert_eq!(0x104, to_via_keycode(a));
 
         // RCtrl(A) -> WithModifier(A)
         let a = KeyAction::WithModifier(
             Action::Key(KeyCode::A),
-            ModifierCombination::new(true, false, false, false, true),
+            ModifierCombination::new_from(true, false, false, false, true),
         );
         assert_eq!(0x1104, to_via_keycode(a));
 
         // Meh(A) -> WithModifier(A)
         let a = KeyAction::WithModifier(
             Action::Key(KeyCode::A),
-            ModifierCombination::new(false, false, true, true, true),
+            ModifierCombination::new_from(false, false, true, true, true),
         );
         assert_eq!(0x704, to_via_keycode(a));
 
         // Hypr(A) -> WithModifier(A)
         let a = KeyAction::WithModifier(
             Action::Key(KeyCode::A),
-            ModifierCombination::new(false, true, true, true, true),
+            ModifierCombination::new_from(false, true, true, true, true),
         );
         assert_eq!(0xF04, to_via_keycode(a));
 
@@ -371,28 +371,28 @@ mod test {
         // LSA_T(A) ->
         let a = KeyAction::ModifierTapHold(
             Action::Key(KeyCode::A),
-            ModifierCombination::new(false, false, true, true, false),
+            ModifierCombination::new_from(false, false, true, true, false),
         );
         assert_eq!(0x2604, to_via_keycode(a));
 
         // RCAG_T(A) ->
         let a = KeyAction::ModifierTapHold(
             Action::Key(KeyCode::A),
-            ModifierCombination::new(true, true, true, false, true),
+            ModifierCombination::new_from(true, true, true, false, true),
         );
         assert_eq!(0x3D04, to_via_keycode(a));
 
         // ALL_T(A) ->
         let a = KeyAction::ModifierTapHold(
             Action::Key(KeyCode::A),
-            ModifierCombination::new(false, true, true, true, true),
+            ModifierCombination::new_from(false, true, true, true, true),
         );
         assert_eq!(0x2F04, to_via_keycode(a));
 
         // Meh_T(A) ->
         let a = KeyAction::ModifierTapHold(
             Action::Key(KeyCode::A),
-            ModifierCombination::new(false, false, true, true, true),
+            ModifierCombination::new_from(false, false, true, true, true),
         );
         assert_eq!(0x2704, to_via_keycode(a));
     }


### PR DESCRIPTION
Use `bitfield-struct` to replace`packed_struct`, making it possible to compile for esp32s3