### PR TITLE
Fix with_modifier action

### DIFF
--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix with_modifier action doesn't trigger the key with modifier
+
 ## [0.2.2] - 2024-07-12
 
 - Add keyboard macro support


### PR DESCRIPTION
Currently, modifier bits and keycodes are sent to the keyboard in one report, which leads to the key trigger without the modifier. This PR fixes this by sending modifier first and then sending the key.

This behavior should be identical with qmk's [Modifier Keys](https://github.com/qmk/qmk_firmware/blob/master/docs/feature_advanced_keycodes.md)