### PR TITLE
Fix capital letters in macro

### DIFF
--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix with_modifier action doesn't trigger the key with modifier
+- Fix capital letter is not send in keyboard macro
+
+### Changed
+
+- Yield everytime after sending a keyboard report to channel
 
 ## [0.2.2] - 2024-07-12
 

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -137,7 +137,11 @@ impl<const ROW: usize, const COL: usize, const NUM_LAYER: usize> KeyMap<ROW, COL
                 } else {
                     (MacroOperation::End, offset + 4)
                 }
-            }
+            },
+            (1, 5) | (1, 6) | (1, 7) => {
+                warn!("VIAL_MACRO_EXT is not supported");
+                (MacroOperation::Delay(0), offset + 4)
+            },
             _ => {
                 // Current byte is the ascii code, convert it to keyboard keycode(with caps state)
                 let (keycode, is_caps) = KeyCode::from_ascii(self.macro_cache[idx]);


### PR DESCRIPTION
Similar with #50, sending a capital letter requires to send a shift first, then send the letter.

Also we want to make sure the shift key is sent to host before sending the following key, so we make keyboard task yield after sending the keyboard report to channel.