### PR TITLE
Polish public API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
         // "rmk/Cargo.toml",
         // Enable ONE of the following for accurate analyzation of RA
         // "examples/use_rust/esp32c3_ble/Cargo.toml",
-        "examples/use_rust/esp32c6_ble/Cargo.toml",
+        // "examples/use_rust/esp32c6_ble/Cargo.toml",
         // "examples/use_rust/stm32h7/Cargo.toml",
         // "examples/use_rust/stm32f4/Cargo.toml",
         // "examples/use_config/stm32f4/Cargo.toml",
@@ -25,7 +25,7 @@
         // "examples/use_rust/nrf52840_ble/Cargo.toml",
         // "examples/use_rust/nrf52832_ble/Cargo.toml",
         // "examples/use_rust/rp2040/Cargo.toml"
-        "examples/use_rust/rp2040_split/Cargo.toml"
+        // "examples/use_rust/rp2040_split/Cargo.toml"
         // "examples/use_config/rp2040/Cargo.toml"
     ],
     "rust-analyzer.showUnlinkedFileNotification": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,9 +11,9 @@
         // "riscv32imc-esp-espidf",
     ],
     "rust-analyzer.linkedProjects": [
-        // "rmk-config/Cargo.toml",
-        // "rmk-macro/Cargo.toml",
-        // "rmk/Cargo.toml",
+        "rmk-config/Cargo.toml",
+        "rmk-macro/Cargo.toml",
+        "rmk/Cargo.toml",
         // Enable ONE of the following for accurate analyzation of RA
         // "examples/use_rust/esp32c3_ble/Cargo.toml",
         // "examples/use_rust/esp32c6_ble/Cargo.toml",

--- a/docs/src/low_power.md
+++ b/docs/src/low_power.md
@@ -36,21 +36,14 @@ There are a few more things that you have to do:
     // ...Other initialization code
 
     // Run RMK
-    run_rmk::<
-        Flash<'_, Blocking>,
-        Driver<'_, USB_OTG_HS>,
-        ExtiInput<AnyPin>, // Use ExtiInput<AnyPin> !
-        Output<'_, AnyPin>,
-        ROW,
-        COL,
-        NUM_LAYER,
-    >(
-        driver,
+    run_rmk(
         input_pins,
         output_pins,
-        Some(f),
+        driver,
+        f,
         crate::keymap::KEYMAP,
         keyboard_config,
+        spawner,
     )
     .await;
 

--- a/docs/src/low_power.md
+++ b/docs/src/low_power.md
@@ -36,7 +36,7 @@ There are a few more things that you have to do:
     // ...Other initialization code
 
     // Run RMK
-    initialize_keyboard_and_run::<
+    run_rmk::<
         Flash<'_, Blocking>,
         Driver<'_, USB_OTG_HS>,
         ExtiInput<AnyPin>, // Use ExtiInput<AnyPin> !

--- a/examples/use_config/esp32c6_ble/Cargo.lock
+++ b/examples/use_config/esp32c6_ble/Cargo.lock
@@ -63,6 +63,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +82,15 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version 0.2.3",
+]
 
 [[package]]
 name = "bindgen"
@@ -96,6 +114,12 @@ dependencies = [
  "syn 2.0.53",
  "which",
 ]
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "bitfield"
@@ -187,7 +211,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.22",
  "serde",
  "serde_json",
  "thiserror",
@@ -257,6 +281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "const-gen"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +331,18 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "cortex-m"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
+dependencies = [
+ "bare-metal",
+ "bitfield 0.13.2",
+ "embedded-hal 0.2.7",
+ "volatile-register",
+]
 
 [[package]]
 name = "critical-section"
@@ -502,7 +544,7 @@ dependencies = [
  "defmt",
  "embedded-io-async",
  "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -521,7 +563,7 @@ dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -550,7 +592,7 @@ dependencies = [
  "embassy-net-driver-channel",
  "embassy-sync",
  "embassy-usb-driver",
- "heapless",
+ "heapless 0.8.0",
  "ssmarshal",
  "usbd-hid",
 ]
@@ -616,6 +658,9 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+dependencies = [
+ "defmt",
+]
 
 [[package]]
 name = "embedded-io-async"
@@ -623,6 +668,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
+ "defmt",
  "embedded-io",
 ]
 
@@ -651,7 +697,7 @@ dependencies = [
  "embedded-io",
  "embedded-io-async",
  "enumset",
- "heapless",
+ "heapless 0.8.0",
  "num_enum",
  "serde",
  "strum 0.25.0",
@@ -764,7 +810,7 @@ dependencies = [
  "embuild",
  "enumset",
  "esp-idf-sys",
- "heapless",
+ "heapless 0.8.0",
  "log",
  "nb 1.1.0",
  "num_enum",
@@ -783,7 +829,7 @@ dependencies = [
  "embuild",
  "enumset",
  "esp-idf-hal",
- "heapless",
+ "heapless 0.8.0",
  "log",
  "num_enum",
  "uncased",
@@ -833,7 +879,7 @@ dependencies = [
  "embassy-sync",
  "embuild",
  "esp-idf-svc",
- "heapless",
+ "heapless 0.8.0",
  "log",
  "num_enum",
  "once_cell",
@@ -971,6 +1017,15 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -995,11 +1050,25 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version 0.4.1",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -1144,6 +1213,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,6 +1357,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
+name = "postcard"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
+dependencies = [
+ "cobs",
+ "defmt",
+ "heapless 0.7.17",
+ "postcard-derive",
+ "serde",
+]
+
+[[package]]
+name = "postcard-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0239fa9c1d225d4b7eb69925c25c5e082307a141e470573fbbe3a817ce6a7a37"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1501,7 @@ version = "0.2.4"
 dependencies = [
  "bitfield-struct",
  "byteorder",
+ "cortex-m",
  "defmt",
  "document-features",
  "embassy-embedded-hal",
@@ -1407,16 +1511,19 @@ dependencies = [
  "embassy-time",
  "embassy-usb",
  "embedded-hal 1.0.0",
+ "embedded-io-async",
  "embedded-storage",
  "embedded-storage-async",
  "esp-idf-svc",
  "esp32-nimble",
  "futures",
- "heapless",
+ "heapless 0.8.0",
  "num_enum",
+ "postcard",
  "rmk-config",
  "rmk-macro",
  "sequential-storage",
+ "serde",
  "ssmarshal",
  "static_cell",
  "usbd-hid",
@@ -1432,7 +1539,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmk-esp32c3"
+name = "rmk-esp32c6"
 version = "0.2.0"
 dependencies = [
  "const-gen",
@@ -1471,6 +1578,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.22",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1630,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +1652,12 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sequential-storage"
@@ -1568,6 +1714,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "ssmarshal"
@@ -1780,7 +1935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
 dependencies = [
  "defmt",
- "heapless",
+ "heapless 0.8.0",
  "portable-atomic",
 ]
 
@@ -1803,7 +1958,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee54712c5d778d2fb2da43b1ce5a7b5060886ef7b09891baeb4bf36910a3ed"
 dependencies = [
- "bitfield",
+ "bitfield 0.14.0",
 ]
 
 [[package]]
@@ -1843,6 +1998,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,6 +2014,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
+dependencies = [
+ "vcell",
+]
 
 [[package]]
 name = "walkdir"

--- a/examples/use_config/stm32h7/src/main.rs
+++ b/examples/use_config/stm32h7/src/main.rs
@@ -11,15 +11,7 @@ use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
 /// There is an example of full customization of the keyboard with `rmk_keyboard` macro
 #[rmk_keyboard]
 mod my_keyboard {
-    use embassy_stm32::{
-        exti::ExtiInput,
-        flash::{Blocking, Flash},
-        gpio::{AnyPin, Output},
-        peripherals::USB_OTG_HS,
-        time::Hertz,
-        usb_otg::Driver,
-        Config,
-    };
+    use embassy_stm32::{time::Hertz, usb_otg::Driver, Config};
     use rmk::run_rmk;
     use static_cell::StaticCell;
 
@@ -88,21 +80,14 @@ mod my_keyboard {
     #[Override(entry)]
     fn run() {
         // Start serving
-        run_rmk::<
-            Flash<'_, Blocking>,
-            Driver<'_, USB_OTG_HS>,
-            ExtiInput<AnyPin>,
-            Output<'_, AnyPin>,
-            ROW,
-            COL,
-            NUM_LAYER,
-        >(
-            driver,
+        run_rmk(
             input_pins,
             output_pins,
-            Some(f),
+            driver,
+            f,
             KEYMAP,
             keyboard_config,
+            spawner,
         )
         .await;
     }

--- a/examples/use_config/stm32h7/src/main.rs
+++ b/examples/use_config/stm32h7/src/main.rs
@@ -20,7 +20,7 @@ mod my_keyboard {
         usb_otg::Driver,
         Config,
     };
-    use rmk::initialize_keyboard_and_run;
+    use rmk::run_rmk;
     use static_cell::StaticCell;
 
     // If you want customize interrupte binding , use `#[Override(bind_interrupt)]` to override default interrupt binding
@@ -88,7 +88,7 @@ mod my_keyboard {
     #[Override(entry)]
     fn run() {
         // Start serving
-        initialize_keyboard_and_run::<
+        run_rmk::<
             Flash<'_, Blocking>,
             Driver<'_, USB_OTG_HS>,
             ExtiInput<AnyPin>,

--- a/examples/use_rust/esp32c3_ble/src/main.rs
+++ b/examples/use_rust/esp32c3_ble/src/main.rs
@@ -5,16 +5,13 @@ mod macros;
 mod keymap;
 mod vial;
 
-use crate::{
-    keymap::{COL, NUM_LAYER, ROW},
-    vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID},
-};
+use crate::vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
 use defmt::*;
 use esp_idf_svc::hal::{gpio::*, peripherals::Peripherals, task::block_on};
 use esp_println as _;
 use rmk::{
     config::{RmkConfig, VialConfig},
-    initialize_esp_ble_keyboard_with_config_and_run,
+    run_rmk,
 };
 
 fn main() {
@@ -39,16 +36,10 @@ fn main() {
     };
 
     // Start serving
-    block_on(initialize_esp_ble_keyboard_with_config_and_run::<
-        PinDriver<'_, AnyInputPin, Input>,
-        PinDriver<'_, AnyOutputPin, Output>,
-        ROW,
-        COL,
-        NUM_LAYER,
-    >(
-        crate::keymap::KEYMAP,
+    block_on(run_rmk(
         input_pins,
         output_pins,
+        crate::keymap::KEYMAP,
         keyboard_config,
     ));
 }

--- a/examples/use_rust/esp32c6_ble/src/main.rs
+++ b/examples/use_rust/esp32c6_ble/src/main.rs
@@ -14,7 +14,7 @@ use esp_idf_svc::hal::{gpio::*, peripherals::Peripherals, task::block_on};
 use esp_println as _;
 use rmk::{
     config::{RmkConfig, VialConfig},
-    initialize_esp_ble_keyboard_with_config_and_run,
+    run_rmk,
 };
 
 fn main() {
@@ -39,16 +39,10 @@ fn main() {
     };
 
     // Start serving
-    block_on(initialize_esp_ble_keyboard_with_config_and_run::<
-        PinDriver<'_, AnyInputPin, Input>,
-        PinDriver<'_, AnyOutputPin, Output>,
-        ROW,
-        COL,
-        NUM_LAYER,
-    >(
-        crate::keymap::KEYMAP,
+    block_on(run_rmk(
         input_pins,
         output_pins,
+        crate::keymap::KEYMAP,
         keyboard_config,
     ));
 }

--- a/examples/use_rust/esp32c6_ble/src/main.rs
+++ b/examples/use_rust/esp32c6_ble/src/main.rs
@@ -5,10 +5,7 @@ mod macros;
 mod keymap;
 mod vial;
 
-use crate::{
-    keymap::{COL, NUM_LAYER, ROW},
-    vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID},
-};
+use crate::vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
 use defmt::*;
 use esp_idf_svc::hal::{gpio::*, peripherals::Peripherals, task::block_on};
 use esp_println as _;

--- a/examples/use_rust/esp32s3_ble/src/main.rs
+++ b/examples/use_rust/esp32s3_ble/src/main.rs
@@ -5,16 +5,13 @@ mod macros;
 mod keymap;
 mod vial;
 
-use crate::{
-    keymap::{COL, NUM_LAYER, ROW},
-    vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID},
-};
+use crate::vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
 use defmt::*;
 use esp_idf_svc::hal::{gpio::*, peripherals::Peripherals, task::block_on};
 use esp_println as _;
 use rmk::{
     config::{RmkConfig, VialConfig},
-    initialize_esp_ble_keyboard_with_config_and_run,
+    run_rmk,
 };
 
 fn main() {
@@ -39,16 +36,10 @@ fn main() {
     };
 
     // Start serving
-    block_on(initialize_esp_ble_keyboard_with_config_and_run::<
-        PinDriver<'_, AnyInputPin, Input>,
-        PinDriver<'_, AnyOutputPin, Output>,
-        ROW,
-        COL,
-        NUM_LAYER,
-    >(
-        crate::keymap::KEYMAP,
+    block_on(run_rmk(
         input_pins,
         output_pins,
+        crate::keymap::KEYMAP,
         keyboard_config,
     ));
 }

--- a/examples/use_rust/hpm5300/src/main.rs
+++ b/examples/use_rust/hpm5300/src/main.rs
@@ -13,18 +13,15 @@ mod vial;
 
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use hpm_hal::gpio::{Input, Output};
-use hpm_hal::usb::UsbDriver;
 use hpm_hal::flash::Flash;
 use hpm_hal::{bind_interrupts, peripherals};
 use riscv_rt as _;
 use rmk::{
     config::{KeyboardUsbConfig, RmkConfig, VialConfig},
-    initialize_keyboard_and_run,
+    run_rmk,
 };
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
 
-use crate::keymap::{COL, NUM_LAYER, ROW};
 
 bind_interrupts!(struct Irqs {
     USB0 => hpm_hal::usb::InterruptHandler<peripherals::USB0>;
@@ -33,7 +30,7 @@ bind_interrupts!(struct Irqs {
 const FLASH_SIZE: usize = 1 * 1024 * 1024;
 
 #[embassy_executor::main(entry = "hpm_hal::entry")]
-async fn main(_spawner: Spawner) {
+async fn main(spawner: Spawner) {
     let mut p = hpm_hal::init(Default::default());
 
     let usb_driver = hpm_hal::usb::UsbDriver::new(p.USB0, p.PA24, p.PA25);
@@ -61,21 +58,14 @@ async fn main(_spawner: Spawner) {
     };
 
     // Start serving
-    initialize_keyboard_and_run::<
-        Flash<_, FLASH_SIZE>,
-        UsbDriver<'_, peripherals::USB0>,
-        Input<'_>,
-        Output<'_>,
-        ROW,
-        COL,
-        NUM_LAYER,
-    >(
-        usb_driver,
+    run_rmk(
         input_pins,
         output_pins,
-        Some(flash),
+        usb_driver,
+        flash,
         crate::keymap::KEYMAP,
         keyboard_config,
+        spawner,
     )
     .await;
 }

--- a/examples/use_rust/nrf52832_ble/src/main.rs
+++ b/examples/use_rust/nrf52832_ble/src/main.rs
@@ -6,7 +6,6 @@ mod macros;
 mod keymap;
 mod vial;
 
-use crate::keymap::{COL, NUM_LAYER, ROW};
 use defmt::*;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
@@ -18,7 +17,7 @@ use embassy_nrf::{
 use panic_probe as _;
 use rmk::{
     config::{KeyboardUsbConfig, RmkConfig, StorageConfig, VialConfig},
-    initialize_nrf_ble_keyboard_with_config_and_run,
+    run_rmk,
 };
 
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
@@ -56,16 +55,10 @@ async fn main(spawner: Spawner) {
         ..Default::default()
     };
 
-    initialize_nrf_ble_keyboard_with_config_and_run::<
-        Input<'_>,
-        Output<'_>,
-        ROW,
-        COL,
-        NUM_LAYER,
-    >(
-        crate::keymap::KEYMAP,
+    run_rmk(
         input_pins,
         output_pins,
+        crate::keymap::KEYMAP,
         keyboard_config,
         spawner,
     )

--- a/examples/use_rust/nrf52840_ble/src/main.rs
+++ b/examples/use_rust/nrf52840_ble/src/main.rs
@@ -6,7 +6,6 @@ mod macros;
 mod keymap;
 mod vial;
 
-use crate::keymap::{COL, NUM_LAYER, ROW};
 use defmt::*;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
@@ -14,7 +13,7 @@ use embassy_nrf::{
     self as _, bind_interrupts,
     gpio::{AnyPin, Input, Output},
     interrupt::{self, InterruptExt, Priority},
-    peripherals::{self, SAADC, USBD},
+    peripherals::{self, SAADC},
     saadc::{self, AnyInput, Input as _, Saadc},
     usb::{self, vbus_detect::SoftwareVbusDetect, Driver},
 };
@@ -22,7 +21,7 @@ use panic_probe as _;
 use rmk::{
     ble::SOFTWARE_VBUS,
     config::{BleBatteryConfig, KeyboardUsbConfig, RmkConfig, StorageConfig, VialConfig},
-    initialize_nrf_ble_keyboard_with_config_and_run,
+    run_rmk,
 };
 
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
@@ -104,18 +103,11 @@ async fn main(spawner: Spawner) {
         ..Default::default()
     };
 
-    initialize_nrf_ble_keyboard_with_config_and_run::<
-        Driver<'_, USBD, &SoftwareVbusDetect>,
-        Input<'_>,
-        Output<'_>,
-        ROW,
-        COL,
-        NUM_LAYER,
-    >(
-        crate::keymap::KEYMAP,
+    run_rmk(
         input_pins,
         output_pins,
-        Some(driver),
+        driver,
+        crate::keymap::KEYMAP,
         keyboard_config,
         spawner,
     )

--- a/examples/use_rust/stm32f1/src/main.rs
+++ b/examples/use_rust/stm32f1/src/main.rs
@@ -6,19 +6,18 @@ mod macros;
 mod keymap;
 mod vial;
 
-use crate::keymap::{COL, NUM_LAYER, ROW};
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_stm32::{
     bind_interrupts,
-    flash::{Blocking, Flash},
-    gpio::{AnyPin, Input, Output},
+    flash::Flash,
+    gpio::{Input, Output},
     peripherals::USB,
     usb::{Driver, InterruptHandler},
     Config,
 };
 use panic_halt as _;
-use rmk::{initialize_keyboard_and_run, config::{RmkConfig, VialConfig}};
+use rmk::{run_rmk, config::{RmkConfig, VialConfig}};
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
 
 #[defmt::global_logger]
@@ -36,7 +35,7 @@ bind_interrupts!(struct Irqs {
 });
 
 #[embassy_executor::main]
-async fn main(_spawner: Spawner) {
+async fn main(spawner: Spawner) {
     info!("RMK start!");
     // RCC config
     let config = Config::default();
@@ -60,21 +59,14 @@ async fn main(_spawner: Spawner) {
     };
 
     // Start serving
-    initialize_keyboard_and_run::<
-        Flash<'_, Blocking>,
-        Driver<'_, USB>,
-        Input<'_, AnyPin>,
-        Output<'_, AnyPin>,
-        ROW,
-        COL,
-        NUM_LAYER,
-    >(
-        driver,
+    run_rmk(
         input_pins,
         output_pins,
-        Some(f),
+        driver,
+        f,
         crate::keymap::KEYMAP,
         keyboard_config,
+        spawner,
     )
     .await;
 }

--- a/examples/use_rust/stm32f4/src/main.rs
+++ b/examples/use_rust/stm32f4/src/main.rs
@@ -6,20 +6,19 @@ mod macros;
 mod keymap;
 mod vial;
 
-use crate::keymap::{COL, NUM_LAYER, ROW};
 use defmt::*;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::{
     bind_interrupts,
-    flash::{Blocking, Flash},
-    gpio::{AnyPin, Input, Output},
+    flash::Flash,
+    gpio::{Input, Output},
     peripherals::USB_OTG_FS,
     usb_otg::{Driver, InterruptHandler},
     Config,
 };
 use panic_probe as _;
-use rmk::{initialize_keyboard_and_run, config::{RmkConfig, VialConfig}};
+use rmk::{run_rmk, config::{RmkConfig, VialConfig}};
 use static_cell::StaticCell;
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
 
@@ -28,7 +27,7 @@ bind_interrupts!(struct Irqs {
 });
 
 #[embassy_executor::main]
-async fn main(_spawner: Spawner) {
+async fn main(spawner: Spawner) {
     info!("RMK start!");
     // RCC config
     let config = Config::default();
@@ -62,21 +61,14 @@ async fn main(_spawner: Spawner) {
     };
 
     // Start serving
-    initialize_keyboard_and_run::<
-        Flash<'_, Blocking>,
-        Driver<'_, USB_OTG_FS>,
-        Input<'_, AnyPin>,
-        Output<'_, AnyPin>,
-        ROW,
-        COL,
-        NUM_LAYER,
-    >(
-        driver,
+    run_rmk(
         input_pins,
         output_pins,
-        Some(f),
+        driver,
+        f,
         crate::keymap::KEYMAP,
         keyboard_config,
+        spawner,
     )
     .await;
 }

--- a/examples/use_rust/stm32h7/src/main.rs
+++ b/examples/use_rust/stm32h7/src/main.rs
@@ -8,14 +8,13 @@ mod macros;
 mod keymap;
 mod vial;
 
-use crate::keymap::{COL, NUM_LAYER, ROW};
 use defmt::*;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::{
     bind_interrupts,
-    flash::{Blocking, Flash},
-    gpio::{AnyPin, Input, Output},
+    flash::Flash,
+    gpio::{Input, Output},
     peripherals::USB_OTG_HS,
     time::Hertz,
     usb_otg::{Driver, InterruptHandler},
@@ -24,7 +23,7 @@ use embassy_stm32::{
 use panic_probe as _;
 use rmk::{
     config::{RmkConfig, VialConfig},
-    initialize_keyboard_and_run,
+    run_rmk,
 };
 use static_cell::StaticCell;
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
@@ -34,7 +33,7 @@ bind_interrupts!(struct Irqs {
 });
 
 #[embassy_executor::main]
-async fn main(_spawner: Spawner) {
+async fn main(spawner: Spawner) {
     info!("RMK start!");
     // RCC config
     let mut config = Config::default();
@@ -98,21 +97,14 @@ async fn main(_spawner: Spawner) {
     };
 
     // Start serving
-    initialize_keyboard_and_run::<
-        Flash<'_, Blocking>,
-        Driver<'_, USB_OTG_HS>,
-        Input<'_, AnyPin>,
-        Output<'_, AnyPin>,
-        ROW,
-        COL,
-        NUM_LAYER,
-    >(
-        driver,
+    run_rmk(
         input_pins,
         output_pins,
-        Some(f),
+        driver,
+        f,
         crate::keymap::KEYMAP,
         keyboard_config,
+        spawner,
     )
     .await;
 }

--- a/examples/use_rust/stm32h7_async/Cargo.lock
+++ b/examples/use_rust/stm32h7_async/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,10 +51,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
-name = "bitfield-struct"
-version = "0.6.0"
+name = "bitfield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0fe3d90b1534e1b0e92008ad2d9f9a3ddb650965ae0592ed1d1031b9dea94f"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+
+[[package]]
+name = "bitfield-struct"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de05f8756f1c68937349406d4632ae96ae35901019b5e59c508d9c38c64715fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -70,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cargo_toml"
@@ -98,6 +116,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "const-gen"
@@ -126,7 +150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
 dependencies = [
  "bare-metal",
- "bitfield",
+ "bitfield 0.13.2",
  "critical-section",
  "embedded-hal 0.2.7",
  "volatile-register",
@@ -263,10 +287,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "embassy-executor"
-version = "0.5.0"
+name = "embassy-embedded-hal"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec648daedd2143466eff4b3e8002024f9f6c1de4ab7666bb679688752624c925"
+checksum = "5794414bc20e0d750f145bc0e82366b19dd078e9e075e8331fb8dd069a1cb6a2"
+dependencies = [
+ "embassy-futures",
+ "embassy-sync 0.6.0",
+ "embassy-time",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-storage",
+ "embedded-storage-async",
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "embassy-executor"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ed0e24bdd4a5f4ff1b72ee4f264b1d23e179ea71a77d984b5fd24877a2bbe1"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -279,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor-macros"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad454accf80050e9cf7a51e994132ba0e56286b31f9317b68703897c328c59b5"
+checksum = "d4d4c0c34b32c2c653c9eecce1cefaf8539dd9a54e61deb5499254f01e2fcac2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -321,13 +362,13 @@ dependencies = [
 
 [[package]]
 name = "embassy-net-driver-channel"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584ab4da7e5612efaa7d55ee76161d9549adf788eab48d49362eddbf322f9933"
+checksum = "4818c32afec43e3cae234f324bad9a976c9aa7501022d26ff60a4017a1a006b7"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver",
- "embassy-sync 0.3.0",
+ "embassy-sync 0.6.0",
 ]
 
 [[package]]
@@ -344,7 +385,7 @@ dependencies = [
  "critical-section",
  "defmt",
  "document-features",
- "embassy-embedded-hal",
+ "embassy-embedded-hal 0.1.0",
  "embassy-futures",
  "embassy-hal-internal",
  "embassy-net-driver",
@@ -369,18 +410,6 @@ dependencies = [
  "stm32-fmc",
  "stm32-metapac",
  "vcell",
-]
-
-[[package]]
-name = "embassy-sync"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0525b466ca3ace30b57f2db868a35215dfaecd038d8668cb2db03feb7c069a0"
-dependencies = [
- "cfg-if",
- "critical-section",
- "futures-util",
- "heapless 0.7.17",
 ]
 
 [[package]]
@@ -413,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-time"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c844070d9f80dc66ee739299183312baee2e1cdeb6e90b4ea2af44f4676da5"
+checksum = "158080d48f824fad101d7b2fae2d83ac39e3f7a6fa01811034f7ab8ffc6e7309"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -447,14 +476,14 @@ checksum = "f1177859559ebf42cd24ae7ba8fe6ee707489b01d0bf471f8827b7b12dcb0bc0"
 
 [[package]]
 name = "embassy-usb"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66444f442f4efc155138a996e250821a6d83a0c40e28ce3de8f0d9033617838b"
+checksum = "8d0b882133fa684b9d4652351cd7aac5afe8a2c2bf4a7da59f442ff61087cda2"
 dependencies = [
  "defmt",
  "embassy-futures",
  "embassy-net-driver-channel",
- "embassy-sync 0.5.0",
+ "embassy-sync 0.6.0",
  "embassy-usb-driver",
  "heapless 0.8.0",
  "ssmarshal",
@@ -654,6 +683,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -667,6 +705,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32 0.2.1",
  "rustc_version 0.4.0",
+ "serde",
  "spin",
  "stable_deref_trait",
 ]
@@ -694,7 +733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -724,6 +763,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lzma-sys"
@@ -827,6 +872,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
+name = "postcard"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
+dependencies = [
+ "cobs",
+ "defmt",
+ "heapless 0.7.17",
+ "postcard-derive",
+ "serde",
+]
+
+[[package]]
+name = "postcard-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0239fa9c1d225d4b7eb69925c25c5e082307a141e470573fbbe3a817ce6a7a37"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,13 +955,14 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rmk"
-version = "0.1.20"
+version = "0.2.4"
 dependencies = [
  "bitfield-struct",
  "byteorder",
+ "cortex-m",
  "defmt",
  "document-features",
- "embassy-embedded-hal",
+ "embassy-embedded-hal 0.2.0",
  "embassy-executor",
  "embassy-futures",
  "embassy-sync 0.6.0",
@@ -900,14 +970,17 @@ dependencies = [
  "embassy-usb",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
+ "embedded-io-async",
  "embedded-storage",
  "embedded-storage-async",
  "futures",
  "heapless 0.8.0",
  "num_enum",
+ "postcard",
  "rmk-config",
  "rmk-macro",
  "sequential-storage",
+ "serde",
  "ssmarshal",
  "static_cell",
  "usbd-hid",
@@ -915,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "rmk-config"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "embedded-hal 1.0.0",
  "serde",
@@ -924,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "rmk-macro"
-version = "0.1.4"
+version = "0.1.8"
 dependencies = [
  "cargo_toml",
  "darling",
@@ -941,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "rmk-stm32h7"
-version = "0.1.16"
+version = "0.2.0"
 dependencies = [
  "const-gen",
  "cortex-m",
@@ -1011,9 +1084,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sequential-storage"
-version = "2.0.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d25123e754473ed08bcc4e0ef61f0a733662872885e533ffdf03771119712fc"
+checksum = "b80693b2169b3fe0f9c68d5fae804490cc437113c0526dbabb75c01e758db597"
 dependencies = [
  "defmt",
  "embedded-storage-async",
@@ -1202,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "usbd-hid"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a2d4546ca3e6a5c6a85584e5caf29feabf3ec35d6cd6b772eb35bd3cff7256"
+checksum = "e6f291ab53d428685cc780f08a2eb9d5d6ff58622db2b36e239a4f715f1e184c"
 dependencies = [
  "defmt",
  "serde",
@@ -1215,20 +1288,22 @@ dependencies = [
 
 [[package]]
 name = "usbd-hid-descriptors"
-version = "0.1.2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbee8c6735e90894fba04770bc41e11fd3c5256018856e15dc4dd1e6c8a3dd1"
+checksum = "0eee54712c5d778d2fb2da43b1ce5a7b5060886ef7b09891baeb4bf36910a3ed"
 dependencies = [
- "bitfield",
+ "bitfield 0.14.0",
 ]
 
 [[package]]
 name = "usbd-hid-macros"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261079a9ada015fa1acac7cc73c98559f3a92585e15f508034beccf6a2ab75a2"
+checksum = "bb573c76e7884035ac5e1ab4a81234c187a82b6100140af0ab45757650ccda38"
 dependencies = [
  "byteorder",
+ "hashbrown 0.13.2",
+ "log",
  "proc-macro2",
  "quote",
  "serde",
@@ -1279,4 +1354,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
 ]

--- a/examples/use_rust/stm32h7_async/src/main.rs
+++ b/examples/use_rust/stm32h7_async/src/main.rs
@@ -8,15 +8,14 @@ mod macros;
 mod keymap;
 mod vial;
 
-use crate::keymap::{COL, NUM_LAYER, ROW};
 use defmt::*;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::{
     bind_interrupts,
     exti::{Channel, ExtiInput},
-    flash::{Blocking, Flash},
-    gpio::{AnyPin, Input, Output, Pull},
+    flash::Flash,
+    gpio::{Input, Output, Pull},
     peripherals::USB_OTG_HS,
     time::Hertz,
     usb_otg::{Driver, InterruptHandler},
@@ -25,7 +24,7 @@ use embassy_stm32::{
 use panic_probe as _;
 use rmk::{
     config::{RmkConfig, VialConfig},
-    initialize_keyboard_and_run,
+    run_rmk,
 };
 use static_cell::StaticCell;
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
@@ -35,7 +34,7 @@ bind_interrupts!(struct Irqs {
 });
 
 #[embassy_executor::main]
-async fn main(_spawner: Spawner) {
+async fn main(spawner: Spawner) {
     info!("RMK start!");
     // RCC config
     let mut config = Config::default();
@@ -105,21 +104,14 @@ async fn main(_spawner: Spawner) {
     };
 
     // Start serving
-    initialize_keyboard_and_run::<
-        Flash<'_, Blocking>,
-        Driver<'_, USB_OTG_HS>,
-        ExtiInput<AnyPin>,
-        Output<'_, AnyPin>,
-        ROW,
-        COL,
-        NUM_LAYER,
-    >(
-        driver,
+    run_rmk(
         input_pins,
         output_pins,
-        Some(f),
+        driver,
+        f,
         crate::keymap::KEYMAP,
         keyboard_config,
+        spawner,
     )
     .await;
 }

--- a/rmk-macro/CHANGELOG.md
+++ b/rmk-macro/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ### Changed
+
+- BREAKING: generate new public APIs
 - Add support for overriding chip initialization for nrf/rp/esp32
 - Fix broken link in error message
 

--- a/rmk-macro/CHANGELOG.md
+++ b/rmk-macro/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- ### Changed
+### Changed
 
 - BREAKING: generate new public APIs
 - Add support for overriding chip initialization for nrf/rp/esp32

--- a/rmk-macro/src/entry.rs
+++ b/rmk-macro/src/entry.rs
@@ -1,20 +1,17 @@
 use darling::FromMeta;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{ItemFn, ItemMod};
 
 use crate::{
     keyboard::{CommunicationType, Overwritten},
-    usb_interrupt_map::UsbInfo,
     ChipModel, ChipSeries,
 };
 
 pub(crate) fn expand_rmk_entry(
     chip: &ChipModel,
-    usb_info: &UsbInfo,
     communication_type: CommunicationType,
     item_mod: &ItemMod,
-    async_matrix: bool,
 ) -> TokenStream2 {
     // If there is a function with `#[Overwritten(usb)]`, override the chip initialization
     if let Some((_, items)) = &item_mod.content {
@@ -32,14 +29,9 @@ pub(crate) fn expand_rmk_entry(
                 }
                 None
             })
-            .unwrap_or(rmk_entry_default(
-                chip,
-                usb_info,
-                communication_type,
-                async_matrix,
-            ))
+            .unwrap_or(rmk_entry_default(chip, communication_type))
     } else {
-        rmk_entry_default(chip, usb_info, communication_type, async_matrix)
+        rmk_entry_default(chip, communication_type)
     }
 }
 
@@ -52,40 +44,19 @@ fn override_rmk_entry(item_fn: &ItemFn) -> TokenStream2 {
 
 pub(crate) fn rmk_entry_default(
     chip: &ChipModel,
-    usb_info: &UsbInfo,
     communication_type: CommunicationType,
-    async_matrix: bool,
 ) -> TokenStream2 {
-    let peripheral_name = format_ident!("{}", usb_info.peripheral_name);
-    let usb_mod_path = if usb_info.peripheral_name.contains("OTG") {
-        format_ident!("{}", "usb_otg")
-    } else {
-        format_ident!("{}", "usb")
-    };
     match chip.series {
         ChipSeries::Stm32 => {
-            // If async_matrix is enabled, use `ExtiInput` as input pin type in RMK entry
-            let input_pin_generics = if async_matrix {
-                quote! {::embassy_stm32::exti::ExtiInput<::embassy_stm32::gpio::AnyPin>}
-            } else {
-                quote! {::embassy_stm32::gpio::Input<'_, ::embassy_stm32::gpio::AnyPin>}
-            };
             quote! {
-                ::rmk::initialize_keyboard_and_run::<
-                    ::embassy_stm32::flash::Flash<'_, ::embassy_stm32::flash::Blocking>,
-                    ::embassy_stm32::#usb_mod_path::Driver<'_, ::embassy_stm32::peripherals::#peripheral_name>,
-                    #input_pin_generics,
-                    ::embassy_stm32::gpio::Output<'_, ::embassy_stm32::gpio::AnyPin>,
-                    ROW,
-                    COL,
-                    NUM_LAYER,
-                >(
-                    driver,
+                ::rmk::run_rmk(
                     input_pins,
                     output_pins,
-                    Some(f),
+                    driver,
+                    f,
                     KEYMAP,
                     keyboard_config,
+                    spawner,
                 )
                 .await;
             }
@@ -93,54 +64,34 @@ pub(crate) fn rmk_entry_default(
         ChipSeries::Nrf52 => match communication_type {
             CommunicationType::Usb => {
                 quote! {
-                    ::rmk::initialize_keyboard_and_run::<
-                        ::embassy_nrf::nvmc::Nvmc,
-                        ::embassy_nrf::usb::Driver<'_, ::embassy_nrf::peripherals::#peripheral_name, ::embassy_nrf::usb::vbus_detect::HardwareVbusDetect>,
-                        ::embassy_nrf::gpio::Input<'_>,
-                        ::embassy_nrf::gpio::Output<'_>,
-                        ROW,
-                        COL,
-                        NUM_LAYER,
-                    >(
-                        driver,
+                    ::rmk::run_rmk(
                         input_pins,
                         output_pins,
-                        Some(f),
+                        driver,
+                        f,
                         KEYMAP,
                         keyboard_config,
+                        spawner
                     )
                     .await;
                 }
             }
             CommunicationType::Both => quote! {
-                ::rmk::initialize_nrf_ble_keyboard_with_config_and_run::<
-                    ::embassy_nrf::usb::Driver<'_, ::embassy_nrf::peripherals::#peripheral_name, &::embassy_nrf::usb::vbus_detect::SoftwareVbusDetect>,
-                    ::embassy_nrf::gpio::Input<'_>,
-                    ::embassy_nrf::gpio::Output<'_>,
-                    ROW,
-                    COL,
-                    NUM_LAYER,
-                >(
-                    KEYMAP,
+                ::rmk::run_rmk(
                     input_pins,
                     output_pins,
-                    Some(driver),
+                    driver,
+                    KEYMAP,
                     keyboard_config,
                     spawner,
                 )
                 .await;
             },
             CommunicationType::Ble => quote! {
-                ::rmk::initialize_nrf_ble_keyboard_with_config_and_run::<
-                    ::embassy_nrf::gpio::Input<'_>,
-                    ::embassy_nrf::gpio::Output<'_>,
-                    ROW,
-                    COL,
-                    NUM_LAYER,
-                >(
-                    KEYMAP,
+                ::rmk::run_rmk(
                     input_pins,
                     output_pins,
+                    KEYMAP,
                     keyboard_config,
                     spawner,
                 )
@@ -149,35 +100,22 @@ pub(crate) fn rmk_entry_default(
             CommunicationType::None => quote! {},
         },
         ChipSeries::Rp2040 => quote! {
-            ::rmk::initialize_keyboard_and_run_async_flash::<
-                ::embassy_rp::flash::Flash<::embassy_rp::peripherals::FLASH, ::embassy_rp::flash::Async, FLASH_SIZE>,
-                ::embassy_rp::usb::Driver<'_, ::embassy_rp::peripherals::USB>,
-                ::embassy_rp::gpio::Input<'_>,
-                ::embassy_rp::gpio::Output<'_>,
-                ROW,
-                COL,
-                NUM_LAYER,
-            >(
-                driver,
+            ::rmk::run_rmk_with_async_flash(
                 input_pins,
                 output_pins,
-                Some(flash),
+                driver,
+                flash,
                 KEYMAP,
                 keyboard_config,
+                spawner,
             )
             .await;
         },
         ChipSeries::Esp32 => quote! {
-            ::esp_idf_svc::hal::task::block_on(::rmk::initialize_esp_ble_keyboard_with_config_and_run::<
-                ::esp_idf_svc::hal::gpio::PinDriver<'_, ::esp_idf_svc::hal::gpio::AnyInputPin, ::esp_idf_svc::hal::gpio::Input>,
-                ::esp_idf_svc::hal::gpio::PinDriver<'_, ::esp_idf_svc::hal::gpio::AnyOutputPin, ::esp_idf_svc::hal::gpio::Output>,
-                ROW,
-                COL,
-                NUM_LAYER,
-            >(
-                KEYMAP,
+            ::esp_idf_svc::hal::task::block_on(::rmk::run_rmk(
                 input_pins,
                 output_pins,
+                KEYMAP,
                 keyboard_config,
             ));
         },

--- a/rmk-macro/src/keyboard.rs
+++ b/rmk-macro/src/keyboard.rs
@@ -219,7 +219,7 @@ fn expand_main(
     let flash_init = expand_flash_init(&chip, comm_type, toml_config.storage);
     let light_config = expand_light_config(&chip, toml_config.light);
     let matrix_config = expand_matrix_config(&chip, toml_config.matrix, async_matrix);
-    let run_rmk = expand_rmk_entry(&chip, &usb_info, comm_type, &item_mod, async_matrix);
+    let run_rmk = expand_rmk_entry(&chip, comm_type, &item_mod);
     let (ble_config, set_ble_config) = expand_ble_config(&chip, comm_type, toml_config.ble);
 
     let main_function_sig = if chip.series == ChipSeries::Esp32 {

--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- BREAKING: all public keyboard APIs are merged into `run_rmk` and `run_rmk_with_async_flash`. Compared with many different APIs for different chips before, the new API is more self-consistent. Different arguments are enabled by feature gates.
+
 ### Added
 
 - Add basic split keyboard support via serial

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -76,7 +76,7 @@ document-features = "0.2"
 cortex-m = { version = "0.7" }
 
 [features]
-default = ["col2row", "rapid_debouncer"]
+default = ["col2row"]
 ## If your PCB diode's direction is col2row, enable this feature. If it's row2col, disable this feature.
 col2row = []
 
@@ -86,6 +86,9 @@ async_matrix = ["dep:embedded-hal-async"]
 ## Use rapid debouncer
 rapid_debouncer = []
 
+### Split keyboard
+split = []
+
 #! ### BLE feature flags
 #! 
 #! ⚠️ Due to the limitation of docs.rs, functions gated by BLE features won't show in docs.rs. You have to head to [`examples`](https://github.com/HaoboGu/rmk/tree/main/examples) folder of RMK repo for their usages.
@@ -94,11 +97,26 @@ nrf52840_ble = ["_nrf_ble", "nrf-softdevice/nrf52840", "nrf-softdevice/s140"]
 ## Enable feature if you want to use nRF52833 with BLE.
 nrf52833_ble = ["_nrf_ble", "nrf-softdevice/nrf52833", "nrf-softdevice/s140"]
 ## Enable feature if you want to use nRF52832 with BLE.
-nrf52832_ble = ["_nrf_ble", "nrf-softdevice/nrf52832", "nrf-softdevice/s132"]
+nrf52832_ble = [
+    "_nrf_ble",
+    "_no_usb",
+    "nrf-softdevice/nrf52832",
+    "nrf-softdevice/s132",
+]
 ## Enable feature if you want to use nRF52811 with BLE.
-nrf52811_ble = ["_nrf_ble", "nrf-softdevice/nrf52811", "nrf-softdevice/s140"]
+nrf52811_ble = [
+    "_nrf_ble",
+    "_no_usb",
+    "nrf-softdevice/nrf52811",
+    "nrf-softdevice/s140",
+]
 ## Enable feature if you want to use nRF52810 with BLE.
-nrf52810_ble = ["_nrf_ble", "nrf-softdevice/nrf52810", "nrf-softdevice/s132"]
+nrf52810_ble = [
+    "_nrf_ble",
+    "_no_usb",
+    "nrf-softdevice/nrf52810",
+    "nrf-softdevice/s132",
+]
 
 ## Enable feature if you want to use ESP32C3 with BLE.
 esp32c3_ble = ["_esp_ble"]
@@ -107,6 +125,7 @@ esp32c6_ble = ["_esp_ble"]
 esp32s3_ble = ["_esp_ble"]
 _esp_ble = [
     "_ble",
+    "_no_usb",             # ESP doesn't have USB support right now
     "rmk-config/_esp_ble",
     "ssmarshal/std",
     "dep:esp32-nimble",
@@ -119,4 +138,10 @@ _nrf_ble = [
     "dep:embassy-nrf",
     "dep:once_cell",
 ]
-_ble = []
+_ble = ["_no_external_storage"]
+
+## Feature that indicates no USB is used, this feature will be auto-activated for some chips
+_no_usb = []
+
+## No storage available, or it's unnecessary to pass storage to the main RMK API
+_no_external_storage = []

--- a/rmk/src/ble/esp.rs
+++ b/rmk/src/ble/esp.rs
@@ -32,7 +32,6 @@ use futures::pin_mut;
 /// * `keyboard_config` - other configurations of the keyboard, check [RmkConfig] struct for details
 /// * `spwaner` - embassy task spwaner, used to spawn nrf_softdevice background task
 pub async fn initialize_esp_ble_keyboard_with_config_and_run<
-    // F: NorFlash,
     #[cfg(feature = "async_matrix")] In: Wait + InputPin,
     #[cfg(not(feature = "async_matrix"))] In: InputPin,
     Out: OutputPin,
@@ -40,11 +39,11 @@ pub async fn initialize_esp_ble_keyboard_with_config_and_run<
     const COL: usize,
     const NUM_LAYER: usize,
 >(
-    keymap: [[[KeyAction; COL]; ROW]; NUM_LAYER],
     #[cfg(feature = "col2row")] input_pins: [In; ROW],
     #[cfg(not(feature = "col2row"))] input_pins: [In; COL],
     #[cfg(feature = "col2row")] output_pins: [Out; COL],
     #[cfg(not(feature = "col2row"))] output_pins: [Out; ROW],
+    default_keymap: [[[KeyAction; COL]; ROW]; NUM_LAYER],
     keyboard_config: RmkConfig<'static, Out>,
 ) -> ! {
     // TODO: Use esp nvs as the storage
@@ -52,7 +51,7 @@ pub async fn initialize_esp_ble_keyboard_with_config_and_run<
     let (mut _storage, keymap) = (
         None::<EmptyFlashWrapper>,
         RefCell::new(
-            KeyMap::<ROW, COL, NUM_LAYER>::new_from_storage::<EmptyFlashWrapper>(keymap, None)
+            KeyMap::<ROW, COL, NUM_LAYER>::new_from_storage::<EmptyFlashWrapper>(default_keymap, None)
                 .await,
         ),
     );

--- a/rmk/src/ble/esp.rs
+++ b/rmk/src/ble/esp.rs
@@ -51,8 +51,11 @@ pub async fn initialize_esp_ble_keyboard_with_config_and_run<
     let (mut _storage, keymap) = (
         None::<EmptyFlashWrapper>,
         RefCell::new(
-            KeyMap::<ROW, COL, NUM_LAYER>::new_from_storage::<EmptyFlashWrapper>(default_keymap, None)
-                .await,
+            KeyMap::<ROW, COL, NUM_LAYER>::new_from_storage::<EmptyFlashWrapper>(
+                default_keymap,
+                None,
+            )
+            .await,
         ),
     );
 

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -23,7 +23,9 @@ use crate::{
 use action::KeyAction;
 use core::cell::RefCell;
 use defmt::*;
-use embassy_futures::select::{select, select4, Either, Either4};
+#[cfg(not(feature = "_esp_ble"))]
+use embassy_executor::Spawner;
+use embassy_futures::select::{select, select4, Either4};
 use embassy_sync::{
     blocking_mutex::raw::CriticalSectionRawMutex,
     channel::{Channel, Receiver, Sender},
@@ -34,8 +36,6 @@ pub use embedded_hal;
 use embedded_hal::digital::{InputPin, OutputPin};
 #[cfg(feature = "async_matrix")]
 use embedded_hal_async::digital::Wait;
-use embedded_storage::nor_flash::NorFlash;
-use embedded_storage_async::nor_flash::NorFlash as AsyncNorFlash;
 use futures::pin_mut;
 use keyboard::{communication_task, Keyboard, KeyboardReportMessage};
 use keymap::KeyMap;
@@ -43,9 +43,13 @@ use matrix::{Matrix, MatrixTrait};
 pub use rmk_config as config;
 use rmk_config::RmkConfig;
 pub use rmk_macro as macros;
-use storage::Storage;
 use usb::KeyboardUsbDevice;
 use via::process::VialService;
+#[cfg(not(feature = "_no_external_storage"))]
+use {
+    embedded_storage::nor_flash::NorFlash,
+    embedded_storage_async::nor_flash::NorFlash as AsyncNorFlash, storage::Storage,
+};
 
 pub mod action;
 #[cfg(feature = "_ble")]
@@ -60,6 +64,7 @@ pub mod keymap;
 pub mod layout_macro;
 mod light;
 mod matrix;
+#[cfg(feature = "split")]
 pub mod split;
 mod storage;
 mod usb;
@@ -75,35 +80,41 @@ mod via;
 /// * `flash` - optional flash storage, which is used for storing keymap and keyboard configs
 /// * `keymap` - default keymap definition
 /// * `keyboard_config` - other configurations of the keyboard, check [RmkConfig] struct for details
-pub async fn initialize_keyboard_and_run<
-    F: NorFlash,
-    D: Driver<'static>,
+pub async fn run_rmk<
     #[cfg(feature = "async_matrix")] In: Wait + InputPin,
     #[cfg(not(feature = "async_matrix"))] In: InputPin,
     Out: OutputPin,
+    #[cfg(not(feature = "_no_usb"))] D: Driver<'static>,
+    #[cfg(not(feature = "_no_external_storage"))] F: NorFlash,
     const ROW: usize,
     const COL: usize,
     const NUM_LAYER: usize,
 >(
-    driver: D,
     #[cfg(feature = "col2row")] input_pins: [In; ROW],
     #[cfg(not(feature = "col2row"))] input_pins: [In; COL],
     #[cfg(feature = "col2row")] output_pins: [Out; COL],
     #[cfg(not(feature = "col2row"))] output_pins: [Out; ROW],
-    flash: Option<F>,
-    keymap: [[[KeyAction; COL]; ROW]; NUM_LAYER],
+    #[cfg(not(feature = "_no_usb"))] usb_driver: D,
+    #[cfg(not(feature = "_no_external_storage"))] flash: F,
+    default_keymap: [[[KeyAction; COL]; ROW]; NUM_LAYER],
     keyboard_config: RmkConfig<'static, Out>,
+    #[cfg(not(feature = "_esp_ble"))] spawner: Spawner,
 ) -> ! {
     // Wrap `embedded-storage` to `embedded-storage-async`
-    let async_flash = flash.map(|f| embassy_embedded_hal::adapter::BlockingAsync::new(f));
+    #[cfg(not(feature = "_no_external_storage"))]
+    let async_flash = embassy_embedded_hal::adapter::BlockingAsync::new(flash);
 
-    initialize_keyboard_and_run_async_flash(
-        driver,
+    run_rmk_with_async_flash(
         input_pins,
         output_pins,
+        #[cfg(not(feature = "_no_usb"))]
+        usb_driver,
+        #[cfg(not(feature = "_no_external_storage"))]
         async_flash,
-        keymap,
+        default_keymap,
         keyboard_config,
+        #[cfg(not(feature = "_esp_ble"))]
+        spawner,
     )
     .await
 }
@@ -118,48 +129,101 @@ pub async fn initialize_keyboard_and_run<
 /// * `flash` - optional **async** flash storage, which is used for storing keymap and keyboard configs
 /// * `keymap` - default keymap definition
 /// * `keyboard_config` - other configurations of the keyboard, check [RmkConfig] struct for details
-pub async fn initialize_keyboard_and_run_async_flash<
-    F: AsyncNorFlash,
-    D: Driver<'static>,
+#[allow(unused_variables)]
+#[allow(unreachable_code)]
+pub async fn run_rmk_with_async_flash<
     #[cfg(feature = "async_matrix")] In: Wait + InputPin,
     #[cfg(not(feature = "async_matrix"))] In: InputPin,
     Out: OutputPin,
+    #[cfg(not(feature = "_no_usb"))] D: Driver<'static>,
+    #[cfg(not(feature = "_no_external_storage"))] F: AsyncNorFlash,
     const ROW: usize,
     const COL: usize,
     const NUM_LAYER: usize,
 >(
-    driver: D,
     #[cfg(feature = "col2row")] input_pins: [In; ROW],
     #[cfg(not(feature = "col2row"))] input_pins: [In; COL],
     #[cfg(feature = "col2row")] output_pins: [Out; COL],
     #[cfg(not(feature = "col2row"))] output_pins: [Out; ROW],
-    flash: Option<F>,
+    #[cfg(not(feature = "_no_usb"))] usb_driver: D,
+    #[cfg(not(feature = "_no_external_storage"))] flash: F,
+    default_keymap: [[[KeyAction; COL]; ROW]; NUM_LAYER],
+    keyboard_config: RmkConfig<'static, Out>,
+    #[cfg(not(feature = "_esp_ble"))] spawner: Spawner,
+) -> ! {
+    // Dispatch according to chip and communication type
+    #[cfg(feature = "_nrf_ble")]
+    let fut = initialize_nrf_ble_keyboard_with_config_and_run(
+        input_pins,
+        output_pins,
+        #[cfg(not(feature = "_no_usb"))]
+        usb_driver,
+        default_keymap,
+        keyboard_config,
+        spawner,
+    )
+    .await;
+
+    #[cfg(feature = "_esp_ble")]
+    let fut = initialize_esp_ble_keyboard_with_config_and_run(
+        input_pins,
+        output_pins,
+        default_keymap,
+        keyboard_config,
+    )
+    .await;
+
+    #[cfg(all(
+        not(feature = "_no_usb"),
+        not(any(feature = "_nrf_ble", feature = "_esp_ble"))
+    ))]
+    let fut = initialize_usb_keyboard_and_run(
+        input_pins,
+        output_pins,
+        usb_driver,
+        #[cfg(not(feature = "_no_external_storage"))]
+        flash,
+        default_keymap,
+        keyboard_config,
+    )
+    .await;
+
+    // The fut should never return.
+    // If there's no fut, the feature flags must not be correct.
+    fut
+}
+
+pub async fn initialize_usb_keyboard_and_run<
+    #[cfg(feature = "async_matrix")] In: Wait + InputPin,
+    #[cfg(not(feature = "async_matrix"))] In: InputPin,
+    Out: OutputPin,
+    D: Driver<'static>,
+    #[cfg(not(feature = "_no_external_storage"))] F: AsyncNorFlash,
+    const ROW: usize,
+    const COL: usize,
+    const NUM_LAYER: usize,
+>(
+    #[cfg(feature = "col2row")] input_pins: [In; ROW],
+    #[cfg(not(feature = "col2row"))] input_pins: [In; COL],
+    #[cfg(feature = "col2row")] output_pins: [Out; COL],
+    #[cfg(not(feature = "col2row"))] output_pins: [Out; ROW],
+    usb_driver: D,
+    #[cfg(not(feature = "_no_external_storage"))] flash: F,
     default_keymap: [[[KeyAction; COL]; ROW]; NUM_LAYER],
     keyboard_config: RmkConfig<'static, Out>,
 ) -> ! {
     // Initialize storage and keymap
-    let (mut storage, keymap) = match flash {
-        Some(f) => {
-            let mut s = Storage::new(f, &default_keymap, keyboard_config.storage_config).await;
-            let keymap = RefCell::new(
-                KeyMap::<ROW, COL, NUM_LAYER>::new_from_storage(default_keymap, Some(&mut s)).await,
-            );
-            (Some(s), keymap)
-        }
-        None => {
-            let keymap = RefCell::new(
-                KeyMap::<ROW, COL, NUM_LAYER>::new_from_storage::<F>(default_keymap, None).await,
-            );
-            (None, keymap)
-        }
+    // For USB keyboard, the "external" storage means the storage initialized by the user.
+    #[cfg(not(feature = "_no_external_storage"))]
+    let (mut storage, keymap) = {
+        let mut s = Storage::new(flash, &default_keymap, keyboard_config.storage_config).await;
+        let keymap = RefCell::new(
+            KeyMap::<ROW, COL, NUM_LAYER>::new_from_storage(default_keymap, Some(&mut s)).await,
+        );
+        (s, keymap)
     };
-
-    static keyboard_channel: Channel<CriticalSectionRawMutex, KeyboardReportMessage, 8> =
-        Channel::new();
-    let mut keyboard_report_sender = keyboard_channel.sender();
-    let mut keyboard_report_receiver = keyboard_channel.receiver();
-
-    // Create keyboard services and devices
+    #[cfg(feature = "_no_external_storage")]
+    let keymap = RefCell::new(KeyMap::<ROW, COL, NUM_LAYER>::new(default_keymap).await);
 
     // Keyboard matrix, use COL2ROW by default
     #[cfg(all(feature = "col2row", feature = "rapid_debouncer"))]
@@ -171,58 +235,32 @@ pub async fn initialize_keyboard_and_run_async_flash<
     #[cfg(all(not(feature = "col2row"), not(feature = "rapid_debouncer")))]
     let matrix = Matrix::<_, _, DefaultDebouncer<COL, ROW>, COL, ROW>::new(input_pins, output_pins);
 
+    // Create keyboard services and devices
     let (mut keyboard, mut usb_device, mut vial_service, mut light_service) = (
         Keyboard::new(matrix, &keymap),
-        KeyboardUsbDevice::new(driver, keyboard_config.usb_config),
+        KeyboardUsbDevice::new(usb_driver, keyboard_config.usb_config),
         VialService::new(&keymap, keyboard_config.vial_config),
         LightService::from_config(keyboard_config.light_config),
     );
 
+    static keyboard_channel: Channel<CriticalSectionRawMutex, KeyboardReportMessage, 8> =
+        Channel::new();
+    let mut keyboard_report_sender = keyboard_channel.sender();
+    let mut keyboard_report_receiver = keyboard_channel.receiver();
+
     loop {
         // Run all tasks, if one of them fails, wait 1 second and then restart
-        if let Some(ref mut s) = storage {
-            run_usb_keyboard(
-                &mut usb_device,
-                &mut keyboard,
-                s,
-                &mut light_service,
-                &mut vial_service,
-                &mut keyboard_report_receiver,
-                &mut keyboard_report_sender,
-            )
-            .await;
-        } else {
-            // Run 5 tasks: usb, keyboard, led, vial, communication
-            let usb_fut = usb_device.device.run();
-            let keyboard_fut = keyboard_task(&mut keyboard, &mut keyboard_report_sender);
-            let communication_fut = communication_task(
-                &mut keyboard_report_receiver,
-                &mut usb_device.keyboard_hid_writer,
-                &mut usb_device.other_hid_writer,
-            );
-            let led_fut = led_hid_task(&mut usb_device.keyboard_hid_reader, &mut light_service);
-            let via_fut = vial_task(&mut usb_device.via_hid, &mut vial_service);
-            pin_mut!(usb_fut);
-            pin_mut!(keyboard_fut);
-            pin_mut!(led_fut);
-            pin_mut!(via_fut);
-            pin_mut!(communication_fut);
-            match select4(
-                usb_fut,
-                select(keyboard_fut, communication_fut),
-                led_fut,
-                via_fut,
-            )
-            .await
-            {
-                Either4::First(_) => {
-                    error!("Usb task is died");
-                }
-                Either4::Second(_) => error!("Keyboard task is died"),
-                Either4::Third(_) => error!("Led task is died"),
-                Either4::Fourth(_) => error!("Via task is died"),
-            }
-        }
+        run_usb_keyboard(
+            &mut usb_device,
+            &mut keyboard,
+            #[cfg(not(feature = "_no_external_storage"))]
+            &mut storage,
+            &mut light_service,
+            &mut vial_service,
+            &mut keyboard_report_receiver,
+            &mut keyboard_report_sender,
+        )
+        .await;
 
         warn!("Detected failure, restarting keyboard sevice after 1 second");
         Timer::after_secs(1).await;
@@ -234,7 +272,7 @@ pub(crate) async fn run_usb_keyboard<
     'a,
     'b,
     D: Driver<'a>,
-    F: AsyncNorFlash,
+    #[cfg(not(feature = "_no_external_storage"))] F: AsyncNorFlash,
     M: MatrixTrait,
     Out: OutputPin,
     const ROW: usize,
@@ -243,7 +281,7 @@ pub(crate) async fn run_usb_keyboard<
 >(
     usb_device: &mut KeyboardUsbDevice<'a, D>,
     keyboard: &mut Keyboard<'b, M, ROW, COL, NUM_LAYER>,
-    storage: &mut Storage<F>,
+    #[cfg(not(feature = "_no_external_storage"))] storage: &mut Storage<F>,
     light_service: &mut LightService<Out>,
     vial_service: &mut VialService<'b, ROW, COL, NUM_LAYER>,
     keyboard_report_receiver: &mut Receiver<'b, CriticalSectionRawMutex, KeyboardReportMessage, 8>,
@@ -258,28 +296,32 @@ pub(crate) async fn run_usb_keyboard<
     );
     let led_fut = led_hid_task(&mut usb_device.keyboard_hid_reader, light_service);
     let via_fut = vial_task(&mut usb_device.via_hid, vial_service);
-    let storage_fut = storage.run::<ROW, COL, NUM_LAYER>();
     pin_mut!(usb_fut);
     pin_mut!(keyboard_fut);
     pin_mut!(led_fut);
     pin_mut!(via_fut);
-    pin_mut!(storage_fut);
     pin_mut!(communication_fut);
+
+    #[cfg(not(feature = "_no_external_storage"))]
+    let storage_fut = storage.run::<ROW, COL, NUM_LAYER>();
+    #[cfg(not(feature = "_no_external_storage"))]
+    pin_mut!(storage_fut);
+
     match select4(
         select(usb_fut, keyboard_fut),
-        storage_fut,
+        #[cfg(not(feature = "_no_external_storage"))]
+        select(storage_fut, via_fut),
+        #[cfg(feature = "_no_external_storage")]
+        via_fut,
         led_fut,
-        select(via_fut, communication_fut),
+        communication_fut,
     )
     .await
     {
-        Either4::First(e) => match e {
-            Either::First(_) => error!("Usb task is died"),
-            Either::Second(_) => error!("Keyboard task is died"),
-        },
-        Either4::Second(_) => error!("Storage task is died"),
+        Either4::First(_) => error!("Usb or keyboard task is died"),
+        Either4::Second(_) => error!("Storage or vial task is died"),
         Either4::Third(_) => error!("Led task is died"),
-        Either4::Fourth(_) => error!("Via task is died"),
+        Either4::Fourth(_) => error!("Communication task is died"),
     }
 }
 

--- a/rmk/src/split/master.rs
+++ b/rmk/src/split/master.rs
@@ -162,7 +162,8 @@ pub async fn initialize_split_master_and_run<
             run_usb_keyboard(
                 &mut usb_device,
                 &mut keyboard,
-                s,
+                // FIXME
+                // s,
                 &mut light_service,
                 &mut vial_service,
                 &mut keyboard_report_receiver,

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -3,18 +3,36 @@ cd examples/use_rust/esp32s3_ble && cargo build --release && cd ../../..
 cd examples/use_config/esp32c3_ble && cargo build --release && cd ../../..
 cd examples/use_config/esp32s3_ble && cargo build --release && cd ../../..
 
-cd examples/use_rust/nrf52832_ble && cargo build --release && cargo clean && cd ../../..
-cd examples/use_rust/nrf52840 && cargo build --release && cargo clean && cd ../../..
-cd examples/use_rust/nrf52840_ble && cargo build --release && cargo clean && cd ../../..
-cd examples/use_rust/rp2040 && cargo build --release && cargo clean && cd ../../..
-cd examples/use_rust/stm32f1 && cargo build --release && cargo clean && cd ../../..
-cd examples/use_rust/stm32f4 && cargo build --release && cargo clean && cd ../../..
-cd examples/use_rust/stm32h7 && cargo build --release && cargo clean && cd ../../.. 
+# Compile examples
+cd examples/use_rust/nrf52832_ble && cargo build --release && cd ../../..
+cd examples/use_rust/nrf52840 && cargo build --release && cd ../../..
+cd examples/use_rust/nrf52840_ble && cargo build --release && cd ../../..
+cd examples/use_rust/rp2040 && cargo build --release && cd ../../..
+cd examples/use_rust/stm32f1 && cargo build --release && cd ../../..
+cd examples/use_rust/stm32f4 && cargo build --release && cd ../../..
+cd examples/use_rust/stm32h7 && cargo build --release && cd ../../.. 
 
-cd examples/use_config/nrf52832_ble && cargo build --release && cargo clean && cd ../../.. 
-cd examples/use_config/nrf52840_ble && cargo build --release && cargo clean && cd ../../.. 
-cd examples/use_config/nrf52840_usb && cargo build --release && cargo clean && cd ../../.. 
-cd examples/use_config/rp2040 && cargo build --release && cargo clean && cd ../../.. 
-cd examples/use_config/stm32f1 && cargo build --release && cargo clean && cd ../../..
-cd examples/use_config/stm32f4 && cargo build --release && cargo clean && cd ../../..
-cd examples/use_config/stm32h7 && cargo build --release && cargo clean && cd ../../.. 
+cd examples/use_config/nrf52832_ble && cargo build --release && cd ../../.. 
+cd examples/use_config/nrf52840_ble && cargo build --release && cd ../../.. 
+cd examples/use_config/nrf52840_usb && cargo build --release && cd ../../.. 
+cd examples/use_config/rp2040 && cargo build --release && cd ../../.. 
+cd examples/use_config/stm32f1 && cargo build --release && cd ../../..
+cd examples/use_config/stm32f4 && cargo build --release && cd ../../..
+cd examples/use_config/stm32h7 && cargo build --release && cd ../../.. 
+
+# Clean examples
+cd examples/use_rust/nrf52832_ble && cargo clean && cd ../../..
+cd examples/use_rust/nrf52840 && cargo clean && cd ../../..
+cd examples/use_rust/nrf52840_ble && cargo clean && cd ../../..
+cd examples/use_rust/rp2040 && cargo clean && cd ../../..
+cd examples/use_rust/stm32f1 && cargo clean && cd ../../..
+cd examples/use_rust/stm32f4 && cargo clean && cd ../../..
+cd examples/use_rust/stm32h7 && cargo clean && cd ../../..  
+
+cd examples/use_config/nrf52832_ble && cargo clean && cd ../../.. 
+cd examples/use_config/nrf52840_ble && cargo clean && cd ../../.. 
+cd examples/use_config/nrf52840_usb && cargo clean && cd ../../.. 
+cd examples/use_config/rp2040 && cargo clean && cd ../../.. 
+cd examples/use_config/stm32f1 && cargo clean && cd ../../..
+cd examples/use_config/stm32f4 && cargo clean && cd ../../..
+cd examples/use_config/stm32h7 && cargo clean && cd ../../..

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -1,6 +1,8 @@
 cd examples/use_rust/esp32c3_ble && cargo build --release && cd ../../..
+cd examples/use_rust/esp32c6_ble && cargo build --release && cd ../../..
 cd examples/use_rust/esp32s3_ble && cargo build --release && cd ../../..
 cd examples/use_config/esp32c3_ble && cargo build --release && cd ../../..
+cd examples/use_config/esp32c6_ble && cargo build --release && cd ../../..
 cd examples/use_config/esp32s3_ble && cargo build --release && cd ../../..
 
 # Compile examples
@@ -11,6 +13,8 @@ cd examples/use_rust/rp2040 && cargo build --release && cd ../../..
 cd examples/use_rust/stm32f1 && cargo build --release && cd ../../..
 cd examples/use_rust/stm32f4 && cargo build --release && cd ../../..
 cd examples/use_rust/stm32h7 && cargo build --release && cd ../../.. 
+cd examples/use_rust/stm32h7_async && cargo build --release && cd ../../.. 
+cd examples/use_rust/hpm5300 && cargo +nightly build --release && cd ../../.. 
 
 cd examples/use_config/nrf52832_ble && cargo build --release && cd ../../.. 
 cd examples/use_config/nrf52840_ble && cargo build --release && cd ../../.. 


### PR DESCRIPTION
Legacy public APIs of RMK are quite complex: `initialize_keyboard_and_run`, `initialize_keyboard_and_run_async_flash`, `initialize_esp_ble_keyboard_with_config_and_run`, `initialize_nrf_ble_keyboard_with_config_and_run`, etc. 

This PR merges them to an unified API `run_rmk` and `run_rmk_with_async_flash`. Different arguments for different chips are enabled by feature gates. This improves the consistency of exposed API, makes APIs easier to use