### PR TITLE
Ble vial service for Windows

### DIFF
--- a/.github/workflows/build esp.yml
+++ b/.github/workflows/build esp.yml
@@ -23,19 +23,31 @@ jobs:
         run: espup install
       - name: Build esp32c3_ble
         working-directory: ./examples/use_rust/esp32c3_ble
-        run: cargo +esp build --release
+        run: |
+          cargo +esp build --release 
+          cargo clean
       - name: Build esp32c3_ble with config
         working-directory: ./examples/use_config/esp32c3_ble
-        run: cargo +esp build --release
+        run: |
+          cargo +esp build --release 
+          cargo clean
       - name: Build esp32c6_ble
         working-directory: ./examples/use_rust/esp32c6_ble
-        run: cargo build --release
+        run: |
+          cargo +esp build --release 
+          cargo clean
       - name: Build esp32c6_ble with config
         working-directory: ./examples/use_config/esp32c6_ble
-        run: cargo build --release
+        run: |
+          cargo +esp build --release 
+          cargo clean
       - name: Build esp32s3_ble
         working-directory: ./examples/use_rust/esp32s3_ble
-        run: cargo +esp build --release
+        run: |
+          cargo +esp build --release 
+          cargo clean
       - name: Build esp32s3_ble with config
         working-directory: ./examples/use_config/esp32s3_ble
-        run: cargo +esp build --release
+        run: |
+          cargo +esp build --release 
+          cargo clean

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,14 +16,14 @@
         // "rmk/Cargo.toml",
         // Enable ONE of the following for accurate analyzation of RA
         // "examples/use_rust/esp32c3_ble/Cargo.toml",
-        // "examples/use_rust/esp32c6_ble/Cargo.toml",
+        "examples/use_rust/esp32c6_ble/Cargo.toml",
         // "examples/use_rust/stm32h7/Cargo.toml",
         // "examples/use_rust/stm32f4/Cargo.toml",
         // "examples/use_config/stm32f4/Cargo.toml",
         // "examples/use_rust/stm32f1/Cargo.toml",
         // "examples/use_rust/nrf52840/Cargo.toml",
         // "examples/use_rust/nrf52840_ble_split/Cargo.toml",
-        "examples/use_rust/nrf52832_ble/Cargo.toml",
+        // "examples/use_rust/nrf52832_ble/Cargo.toml",
         // "examples/use_rust/rp2040/Cargo.toml"
         // "examples/use_rust/rp2040_split/Cargo.toml"
         // "examples/use_config/rp2040_split/Cargo.toml"

--- a/rmk/src/ble/descriptor.rs
+++ b/rmk/src/ble/descriptor.rs
@@ -100,3 +100,18 @@ pub(crate) struct BleKeyboardReport {
     pub(crate) vial_input_data: [u8; 32],
     pub(crate) vial_output_data: [u8; 32],
 }
+
+#[gen_hid_descriptor(
+    (collection = APPLICATION, usage_page = 0xFF60, usage = 0x61) = {
+        (usage = 0x62, logical_min = 0x0) = {
+            #[item_settings data,variable,absolute] vial_input_data=input;
+        };
+        (usage = 0x63, logical_min = 0x0) = {
+            #[item_settings data,variable,absolute] vial_output_data=output;
+        };
+    }
+)]
+pub(crate) struct BleVialReport {
+    pub(crate) vial_input_data: [u8; 32],
+    pub(crate) vial_output_data: [u8; 32],
+}

--- a/rmk/src/ble/descriptor.rs
+++ b/rmk/src/ble/descriptor.rs
@@ -72,16 +72,6 @@ pub(crate) enum BleCompositeReportType {
                 #[item_settings data,array,absolute,not_null] system_usage_id=input;
             };
         };
-    },
-    (collection = APPLICATION, usage_page = 0xFF60, usage = 0x61) = {
-        (report_id = 0x05,) = {
-            (usage = 0x62, logical_min = 0x0) = {
-                #[item_settings data,variable,absolute] vial_input_data=input;
-            };
-            (usage = 0x63, logical_min = 0x0) = {
-                #[item_settings data,variable,absolute] vial_output_data=output;
-            };
-        };
     }
 )]
 #[allow(dead_code)]

--- a/rmk/src/ble/descriptor.rs
+++ b/rmk/src/ble/descriptor.rs
@@ -87,21 +87,4 @@ pub(crate) struct BleKeyboardReport {
     pub(crate) pan: i8,   // Scroll left (negative) or right (positive) this many units
     pub(crate) media_usage_id: u16,
     pub(crate) system_usage_id: u8,
-    pub(crate) vial_input_data: [u8; 32],
-    pub(crate) vial_output_data: [u8; 32],
-}
-
-#[gen_hid_descriptor(
-    (collection = APPLICATION, usage_page = 0xFF60, usage = 0x61) = {
-        (usage = 0x62, logical_min = 0x0) = {
-            #[item_settings data,variable,absolute] vial_input_data=input;
-        };
-        (usage = 0x63, logical_min = 0x0) = {
-            #[item_settings data,variable,absolute] vial_output_data=output;
-        };
-    }
-)]
-pub(crate) struct BleVialReport {
-    pub(crate) vial_input_data: [u8; 32],
-    pub(crate) vial_output_data: [u8; 32],
 }

--- a/rmk/src/ble/esp/server.rs
+++ b/rmk/src/ble/esp/server.rs
@@ -12,7 +12,7 @@ use usbd_hid::descriptor::{AsInputReport, SerializedDescriptor as _};
 
 use crate::{
     ble::{
-        descriptor::{BleCompositeReportType, BleKeyboardReport},
+        descriptor::{BleCompositeReportType, BleKeyboardReport, BleVialReport},
         device_info::VidSource,
     },
     config::KeyboardUsbConfig,
@@ -100,25 +100,6 @@ impl BleServer {
         let input_system_keys = hid.input_report(BleCompositeReportType::System as u8);
         let input_mouse_keys = hid.input_report(BleCompositeReportType::Mouse as u8);
 
-        let vial_hid =  BLEHIDDevice::new(server);
-        vial_hid.manufacturer(usb_config.manufacturer);
-        block_on(server.get_service(BleUuid::from_uuid16(0x180a)))
-            .unwrap()
-            .lock()
-            .create_characteristic(BleUuid::from_uuid16(0x2a50), NimbleProperties::READ)
-            .lock()
-            .set_value(usb_config.serial_number.as_bytes());
-        let input_vial = vial_hid.input_report(BleCompositeReportType::Vial as u8);
-        let output_vial = vial_hid.output_report(BleCompositeReportType::Vial as u8);
-        vial_hid.pnp(
-            VidSource::UsbIF as u8,
-            usb_config.vid,
-            usb_config.pid,
-            0x0000,
-        );
-        vial_hid.hid_info(0x00, 0x03);
-        vial_hid.report_map(BleVialReport::desc());
-
         hid.pnp(
             VidSource::UsbIF as u8,
             usb_config.vid,
@@ -129,12 +110,33 @@ impl BleServer {
         hid.hid_info(0x00, 0x03);
         hid.report_map(BleKeyboardReport::desc());
 
+        let mut vial_hid = BLEHIDDevice::new(server);
+        vial_hid.manufacturer(usb_config.manufacturer);
+        block_on(server.get_service(BleUuid::from_uuid16(0x180a)))
+            .unwrap()
+            .lock()
+            .create_characteristic(BleUuid::from_uuid16(0x2a50), NimbleProperties::READ)
+            .lock()
+            .set_value(usb_config.serial_number.as_bytes());
+        let input_vial = vial_hid.input_report(0);
+        let output_vial = vial_hid.output_report(0);
+
+        vial_hid.pnp(
+            VidSource::UsbIF as u8,
+            usb_config.vid,
+            usb_config.pid,
+            0x0000,
+        );
+        vial_hid.hid_info(0x00, 0x03);
+        vial_hid.report_map(BleVialReport::desc());
+
         let ble_advertising = device.get_advertising();
         if let Err(e) = ble_advertising.lock().scan_response(false).set_data(
             BLEAdvertisementData::new()
                 .name(keyboard_name)
                 .appearance(0x03C1)
-                .add_service_uuid(hid.hid_service().lock().uuid()),
+                .add_service_uuid(hid.hid_service().lock().uuid())
+                .add_service_uuid(vial_hid.hid_service().lock().uuid()),
         ) {
             error!("BLE advertising error, error code: {}", e.code());
         }

--- a/rmk/src/ble/esp/server.rs
+++ b/rmk/src/ble/esp/server.rs
@@ -12,11 +12,12 @@ use usbd_hid::descriptor::{AsInputReport, SerializedDescriptor as _};
 
 use crate::{
     ble::{
-        descriptor::{BleCompositeReportType, BleKeyboardReport, BleVialReport},
+        descriptor::{BleCompositeReportType, BleKeyboardReport},
         device_info::VidSource,
     },
     config::KeyboardUsbConfig,
     hid::{ConnectionType, ConnectionTypeWrapper, HidError, HidReaderWrapper, HidWriterWrapper},
+    usb::descriptor::ViaReport,
 };
 
 type BleHidWriter = Arc<Mutex<BLECharacteristic>>;
@@ -128,7 +129,7 @@ impl BleServer {
             0x0000,
         );
         vial_hid.hid_info(0x00, 0x03);
-        vial_hid.report_map(BleVialReport::desc());
+        vial_hid.report_map(ViaReport::desc());
 
         let ble_advertising = device.get_advertising();
         if let Err(e) = ble_advertising.lock().scan_response(false).set_data(

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -6,7 +6,7 @@ pub mod esp;
 #[cfg(feature = "_nrf_ble")]
 pub mod nrf;
 
-use defmt::error;
+use defmt::{debug, error};
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Receiver};
 use embassy_time::Timer;
 #[cfg(any(feature = "nrf52840_ble", feature = "nrf52833_ble"))]
@@ -38,6 +38,7 @@ pub(crate) async fn ble_communication_task<
     loop {
         match keyboard_report_receiver.receive().await {
             KeyboardReportMessage::KeyboardReport(report) => {
+                debug!("Send keyboard report: {}", report.keycodes);
                 match ble_keyboard_writer.write_serialize(&report).await {
                     Ok(()) => {}
                     Err(e) => error!("Send keyboard report error: {}", e),

--- a/rmk/src/ble/nrf.rs
+++ b/rmk/src/ble/nrf.rs
@@ -3,9 +3,9 @@ mod battery_service;
 pub(crate) mod bonder;
 mod device_information_service;
 mod hid_service;
-mod vial_service;
 pub(crate) mod server;
 pub(crate) mod spec;
+mod vial_service;
 
 use self::server::BleServer;
 #[cfg(not(feature = "rapid_debouncer"))]

--- a/rmk/src/ble/nrf.rs
+++ b/rmk/src/ble/nrf.rs
@@ -3,6 +3,7 @@ mod battery_service;
 pub(crate) mod bonder;
 mod device_information_service;
 mod hid_service;
+mod vial_service;
 pub(crate) mod server;
 pub(crate) mod spec;
 
@@ -146,7 +147,7 @@ pub(crate) fn nrf_ble_config(keyboard_name: &str) -> Config {
         }),
         conn_gatt: Some(raw::ble_gatt_conn_cfg_t { att_mtu: 256 }),
         gatts_attr_tab_size: Some(raw::ble_gatts_cfg_attr_tab_size_t {
-            attr_tab_size: raw::BLE_GATTS_ATTR_TAB_SIZE_DEFAULT,
+            attr_tab_size: 2048,
         }),
         gap_role_count: Some(raw::ble_gap_cfg_role_count_t {
             adv_set_count: 1,

--- a/rmk/src/ble/nrf/hid_service.rs
+++ b/rmk/src/ble/nrf/hid_service.rs
@@ -24,7 +24,6 @@ pub(crate) struct HidService {
     hid_info: u16,
     report_map: u16,
     hid_control: u16,
-    protocol_mode: u16,
     pub(crate) input_keyboard: u16,
     input_keyboard_cccd: u16,
     input_keyboard_descriptor: u16,
@@ -75,22 +74,14 @@ impl HidService {
             .add_characteristic(
                 BleCharacteristics::HidControlPoint.uuid(),
                 Attribute::new([0u8]).security(SecurityMode::JustWorks),
-                Metadata::new(Properties::new().read().write_without_response()),
-            )?
-            .build();
-
-        let protocol_mode_handle = service_builder
-            .add_characteristic(
-                BleCharacteristics::ProtocolMode.uuid(),
-                Attribute::new([1u8]).security(SecurityMode::JustWorks),
-                Metadata::new(Properties::new().read().write_without_response()),
+                Metadata::new(Properties::new().write_without_response()),
             )?
             .build();
 
         let mut input_keyboard = service_builder.add_characteristic(
             BleCharacteristics::HidReport.uuid(),
             Attribute::new([0u8; 8]).security(SecurityMode::JustWorks),
-            Metadata::new(Properties::new().read().write().notify()),
+            Metadata::new(Properties::new().read().notify()),
         )?;
         let input_keyboard_desc = input_keyboard.add_descriptor(
             BleDescriptor::ReportReference.uuid(),
@@ -114,7 +105,7 @@ impl HidService {
         let mut input_media_keys = service_builder.add_characteristic(
             BleCharacteristics::HidReport.uuid(),
             Attribute::new([0u8; 2]).security(SecurityMode::JustWorks),
-            Metadata::new(Properties::new().read().write().notify()),
+            Metadata::new(Properties::new().read().notify()),
         )?;
         let input_media_keys_desc = input_media_keys.add_descriptor(
             BleDescriptor::ReportReference.uuid(),
@@ -126,7 +117,7 @@ impl HidService {
         let mut input_system_keys = service_builder.add_characteristic(
             BleCharacteristics::HidReport.uuid(),
             Attribute::new([0u8; 1]).security(SecurityMode::JustWorks),
-            Metadata::new(Properties::new().read().write().notify()),
+            Metadata::new(Properties::new().read().notify()),
         )?;
         let input_system_keys_desc = input_system_keys.add_descriptor(
             BleDescriptor::ReportReference.uuid(),
@@ -138,7 +129,7 @@ impl HidService {
         let mut input_mouse = service_builder.add_characteristic(
             BleCharacteristics::HidReport.uuid(),
             Attribute::new([0u8; 5]).security(SecurityMode::JustWorks),
-            Metadata::new(Properties::new().read().write().notify()),
+            Metadata::new(Properties::new().read().notify()),
         )?;
         let input_mouse_desc = input_mouse.add_descriptor(
             BleDescriptor::ReportReference.uuid(),
@@ -150,7 +141,7 @@ impl HidService {
         let mut input_vial = service_builder.add_characteristic(
             BleCharacteristics::HidReport.uuid(),
             Attribute::new([0u8; 32]).security(SecurityMode::JustWorks),
-            Metadata::new(Properties::new().read().write().notify()),
+            Metadata::new(Properties::new().read().notify()),
         )?;
         let input_vial_desc = input_vial.add_descriptor(
             BleDescriptor::ReportReference.uuid(),
@@ -177,7 +168,6 @@ impl HidService {
             hid_info: hid_info_handle.value_handle,
             report_map: report_map_handle.value_handle,
             hid_control: hid_control_handle.value_handle,
-            protocol_mode: protocol_mode_handle.value_handle,
             input_keyboard: input_keyboard_handle.value_handle,
             input_keyboard_cccd: input_keyboard_handle.cccd_handle,
             input_keyboard_descriptor: input_keyboard_desc.handle(),

--- a/rmk/src/ble/nrf/server.rs
+++ b/rmk/src/ble/nrf/server.rs
@@ -157,13 +157,11 @@ impl gatt_server::Server for BleServer {
                 HidServiceEvent::InputKeyboardCccdWrite
                 | HidServiceEvent::InputMediaKeyCccdWrite
                 | HidServiceEvent::InputMouseKeyCccdWrite
-                // | HidServiceEvent::InputVialKeyCccdWrite
                 | HidServiceEvent::InputSystemKeyCccdWrite => {
                     info!("{}, handle: {}, data: {}", event, handle, data);
                     self.bonder.save_sys_attrs(conn)
                 }
                 HidServiceEvent::OutputKeyboard => (),
-                // HidServiceEvent::OutputVial => (),
             }
         }
         if let Some(event) = self.bas.on_write(handle, data) {

--- a/rmk/src/ble/nrf/vial_service.rs
+++ b/rmk/src/ble/nrf/vial_service.rs
@@ -1,0 +1,138 @@
+use super::spec::{BleCharacteristics, BleDescriptor, BLE_HID_SERVICE_UUID};
+use crate::ble::descriptor::{BleCompositeReportType, BleVialReport};
+use defmt::{error, info, Format};
+use nrf_softdevice::{
+    ble::{
+        gatt_server::{
+            self,
+            builder::ServiceBuilder,
+            characteristic::{Attribute, Metadata, Properties},
+            RegisterError,
+        },
+        Connection, SecurityMode,
+    },
+    Softdevice,
+};
+use usbd_hid::descriptor::SerializedDescriptor;
+
+#[derive(Debug, defmt::Format)]
+pub(crate) struct BleVialService {
+    pub(crate) input_vial: u16,
+    input_vial_cccd: u16,
+    input_vial_descriptor: u16,
+    pub(crate) output_vial: u16,
+    output_vial_descriptor: u16,
+    hid_info: u16,
+    report_map: u16,
+    hid_control: u16,
+    protocol_mode: u16,
+}
+
+impl BleVialService {
+    pub(crate) fn new(sd: &mut Softdevice) -> Result<Self, RegisterError> {
+        let mut service_builder = ServiceBuilder::new(sd, BLE_HID_SERVICE_UUID)?;
+
+        let hid_info_handle = service_builder
+            .add_characteristic(
+                BleCharacteristics::HidInfo.uuid(),
+                Attribute::new([
+                    0x1u8, 0x1u8,  // HID version: 1.1
+                    0x00u8, // Country Code
+                    0x03u8, // Remote wake + Normally Connectable
+                ])
+                .security(SecurityMode::JustWorks),
+                Metadata::new(Properties::new().read()),
+            )?
+            .build();
+
+        let report_map_handle = service_builder
+            .add_characteristic(
+                BleCharacteristics::ReportMap.uuid(),
+                Attribute::new(BleVialReport::desc()).security(SecurityMode::JustWorks),
+                Metadata::new(Properties::new().read()),
+            )?
+            .build();
+
+        let hid_control_handle = service_builder
+            .add_characteristic(
+                BleCharacteristics::HidControlPoint.uuid(),
+                Attribute::new([0u8]).security(SecurityMode::JustWorks),
+                Metadata::new(Properties::new().write_without_response()),
+            )?
+            .build();
+
+        let protocol_mode_handle = service_builder
+            .add_characteristic(
+                BleCharacteristics::ProtocolMode.uuid(),
+                Attribute::new([0x01u8]).security(SecurityMode::JustWorks),
+                Metadata::new(Properties::new().read().write_without_response()),
+            )?
+            .build();
+
+        // Existing Vial input and output characteristics
+        let mut input_vial = service_builder.add_characteristic(
+            BleCharacteristics::HidReport.uuid(),
+            Attribute::new([0u8; 32]).security(SecurityMode::JustWorks),
+            Metadata::new(Properties::new().read().notify()),
+        )?;
+        let input_vial_desc = input_vial.add_descriptor(
+            BleDescriptor::ReportReference.uuid(),
+            Attribute::new([BleCompositeReportType::Vial as u8, 1u8])
+                .security(SecurityMode::JustWorks),
+        )?;
+        let input_vial_handle = input_vial.build();
+
+        let mut output_vial = service_builder.add_characteristic(
+            BleCharacteristics::HidReport.uuid(),
+            Attribute::new([0u8; 32]).security(SecurityMode::JustWorks),
+            Metadata::new(Properties::new().read().write().write_without_response()),
+        )?;
+        let output_vial_desc = output_vial.add_descriptor(
+            BleDescriptor::ReportReference.uuid(),
+            Attribute::new([BleCompositeReportType::Vial as u8, 2u8])
+                .security(SecurityMode::JustWorks),
+        )?;
+        let output_vial_handle = output_vial.build();
+
+        let _service_handle = service_builder.build();
+
+        Ok(BleVialService {
+            input_vial: input_vial_handle.value_handle,
+            input_vial_cccd: input_vial_handle.cccd_handle,
+            input_vial_descriptor: input_vial_desc.handle(),
+            output_vial: output_vial_handle.value_handle,
+            output_vial_descriptor: output_vial_desc.handle(),
+            hid_info: hid_info_handle.value_handle,
+            report_map: report_map_handle.value_handle,
+            hid_control: hid_control_handle.value_handle,
+            protocol_mode: protocol_mode_handle.value_handle,
+        })
+    }
+
+    pub(crate) fn send_ble_vial_report(&self, conn: &Connection, data: &[u8]) {
+        gatt_server::notify_value(conn, self.input_vial, data)
+            .map_err(|e| error!("send vial report error: {}", e))
+            .ok();
+    }
+}
+
+impl gatt_server::Service for BleVialService {
+    type Event = VialServiceEvent;
+
+    fn on_write(&self, handle: u16, data: &[u8]) -> Option<Self::Event> {
+        if handle == self.input_vial_cccd {
+            Some(VialServiceEvent::InputVialKeyCccdWrite)
+        } else if handle == self.output_vial {
+            info!("Vial output: {:?}", data);
+            Some(VialServiceEvent::OutputVial)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Format)]
+pub(crate) enum VialServiceEvent {
+    InputVialKeyCccdWrite,
+    OutputVial,
+}

--- a/rmk/src/ble/nrf/vial_service.rs
+++ b/rmk/src/ble/nrf/vial_service.rs
@@ -1,5 +1,3 @@
-use super::spec::{BleCharacteristics, BleDescriptor, BLE_HID_SERVICE_UUID};
-use crate::ble::descriptor::{BleCompositeReportType, BleVialReport};
 use defmt::{error, info, Format};
 use nrf_softdevice::{
     ble::{
@@ -14,6 +12,10 @@ use nrf_softdevice::{
     Softdevice,
 };
 use usbd_hid::descriptor::SerializedDescriptor;
+
+use crate::usb::descriptor::ViaReport;
+
+use super::spec::{BleCharacteristics, BleDescriptor, BLE_HID_SERVICE_UUID};
 
 #[derive(Debug, defmt::Format)]
 pub(crate) struct BleVialService {
@@ -48,7 +50,7 @@ impl BleVialService {
         let report_map_handle = service_builder
             .add_characteristic(
                 BleCharacteristics::ReportMap.uuid(),
-                Attribute::new(BleVialReport::desc()).security(SecurityMode::JustWorks),
+                Attribute::new(ViaReport::desc()).security(SecurityMode::JustWorks),
                 Metadata::new(Properties::new().read()),
             )?
             .build();
@@ -77,8 +79,7 @@ impl BleVialService {
         )?;
         let input_vial_desc = input_vial.add_descriptor(
             BleDescriptor::ReportReference.uuid(),
-            Attribute::new([BleCompositeReportType::Vial as u8, 1u8])
-                .security(SecurityMode::JustWorks),
+            Attribute::new([0u8, 1u8]).security(SecurityMode::JustWorks),
         )?;
         let input_vial_handle = input_vial.build();
 
@@ -89,8 +90,7 @@ impl BleVialService {
         )?;
         let output_vial_desc = output_vial.add_descriptor(
             BleDescriptor::ReportReference.uuid(),
-            Attribute::new([BleCompositeReportType::Vial as u8, 2u8])
-                .security(SecurityMode::JustWorks),
+            Attribute::new([0u8, 2u8]).security(SecurityMode::JustWorks),
         )?;
         let output_vial_handle = output_vial.build();
 

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -755,7 +755,6 @@ impl<'a, M: MatrixTrait, const ROW: usize, const COL: usize, const NUM_LAYER: us
 
     /// Register a key, the key can be a basic keycode or a modifier.
     fn register_key(&mut self, key: KeyCode) {
-        self.need_send_key_report = true;
         if key.is_modifier() {
             self.register_modifier(key.as_modifier_bit());
         } else if key.is_basic() {

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -755,6 +755,7 @@ impl<'a, M: MatrixTrait, const ROW: usize, const COL: usize, const NUM_LAYER: us
 
     /// Register a key, the key can be a basic keycode or a modifier.
     fn register_key(&mut self, key: KeyCode) {
+        self.need_send_key_report = true;
         if key.is_modifier() {
             self.register_modifier(key.as_modifier_bit());
         } else if key.is_basic() {


### PR DESCRIPTION
This PR tries to make vial recognize RMK BLE keyboard. This is currently possible only for Windows because Windows regard BLE HID devices as a normal HID device and use BLE driver automatically.

A successful try is https://github.com/HaoboGu/rmk/pull/70. #70 cannot work with vial-web since vial-web uses report_id 0. 

This PR tries to extract BLE vial service to a separate one and makes vial-web recognize RMK keyboard.

Note: This PR is actually a temporary solution only for Windows. To achieve general vial-over-BLE, the BLE vial service should be a customized service(not HID!). This is because Apple devices don't expose BLE-HID services at all. So, a host tool(like a wireless version of via/vial) needs to be implemented finally.