### PR TITLE
Improve nRF power consumption

### DIFF
--- a/rmk/src/matrix.rs
+++ b/rmk/src/matrix.rs
@@ -130,12 +130,12 @@ impl<
     const ROW: usize = OUTPUT_PIN_NUM;
     #[cfg(not(feature = "col2row"))]
     const COL: usize = OUTPUT_PIN_NUM;
-
+    
     #[cfg(feature = "async_matrix")]
     async fn wait_for_key(&mut self) {
         if let Some(start_time) = self.scan_start {
-            // If not key over 2 secs, wait for interupt in next loop
-            if start_time.elapsed().as_secs() < 1 {
+            // If no key press over 1ms, stop scanning and wait for interupt
+            if start_time.elapsed().as_millis() <= 1 {
                 return;
             } else {
                 self.scan_start = None;

--- a/rmk/src/split/nrf/central.rs
+++ b/rmk/src/split/nrf/central.rs
@@ -49,7 +49,7 @@ use crate::{
         SplitMessage, SPLIT_MESSAGE_MAX_SIZE,
     },
     storage::{get_bond_info_key, Storage, StorageData},
-    usb::{wait_for_usb_suspend, KeyboardUsbDevice, USB_DEVICE_ENABLED},
+    usb::{wait_for_usb_enabled, wait_for_usb_suspend, KeyboardUsbDevice, USB_DEVICE_ENABLED},
     via::process::VialService,
 };
 use crate::{debounce::DebouncerTrait, split::central::CentralMatrix};
@@ -327,7 +327,7 @@ pub(crate) async fn initialize_ble_split_central_and_run<
             info!("USB suspended, BLE Advertising");
 
             // Wait for BLE or USB connection
-            match select(adv_fut, usb_device.wait_for_usb_configured()).await {
+            match select(adv_fut, wait_for_usb_enabled()).await {
                 Either::First(re) => match re {
                     Ok(conn) => {
                         info!("Connected to BLE");
@@ -344,7 +344,7 @@ pub(crate) async fn initialize_ble_split_central_and_run<
                                 &mut keyboard_config.ble_battery_config,
                                 &keyboard_report_receiver,
                             ),
-                            usb_device.wait_for_usb_configured(),
+                            wait_for_usb_enabled(),
                         )
                         .await
                         {


### PR DESCRIPTION
In recent changes, the usb task is started when the BLE is working, this draws about 2mA current. This PR disables usb task for nRF when BLE is working, use softdevice's interrupt to enable USB devices.

Some other optimizations are added as well. As a result, for nRF52840 + high-voltage mode, the advertising current is about 45uA, idle current is about 30uA, and the matrix scanning current is about 1.5mA.