### PR TITLE
refactor(core): create matrix and debouncer in advance

### DIFF
--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decouple the matrix(input device) and keyboard implementation
 - Stop scanning matrix after releasing all keys
 - Use divider to estimate battery voltage
+- Create Debouncer and Matrix in `run_rmk_*` function ahead of time instead of in the `initialize_*_and_run` function.
 
 ### Fixed
 

--- a/rmk/src/ble/esp/mod.rs
+++ b/rmk/src/ble/esp/mod.rs
@@ -1,12 +1,8 @@
 pub(crate) mod server;
 
 use self::server::{BleServer, VialReaderWriter};
-#[cfg(not(feature = "rapid_debouncer"))]
-use crate::debounce::default_bouncer::DefaultDebouncer;
-#[cfg(feature = "rapid_debouncer")]
-use crate::debounce::fast_debouncer::RapidDebouncer;
 use crate::keyboard::keyboard_report_channel;
-use crate::matrix::{Matrix, MatrixTrait};
+use crate::matrix::MatrixTrait;
 use crate::storage::nor_flash::esp_partition::{Partition, PartitionType};
 use crate::storage::Storage;
 use crate::via::process::VialService;
@@ -20,9 +16,7 @@ use core::cell::RefCell;
 use defmt::{debug, info, warn};
 use embassy_futures::select::{select, select4};
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel};
-use embedded_hal::digital::{InputPin, OutputPin};
-#[cfg(feature = "async_matrix")]
-use embedded_hal_async::digital::Wait;
+use embedded_hal::digital::OutputPin;
 use embedded_storage_async::nor_flash::ReadNorFlash;
 use esp_idf_svc::hal::task::block_on;
 use futures::pin_mut;
@@ -41,17 +35,13 @@ use rmk_config::StorageConfig;
 /// * `keyboard_config` - other configurations of the keyboard, check [RmkConfig] struct for details
 /// * `spwaner` - embassy task spwaner, used to spawn nrf_softdevice background task
 pub(crate) async fn initialize_esp_ble_keyboard_with_config_and_run<
-    #[cfg(feature = "async_matrix")] In: Wait + InputPin,
-    #[cfg(not(feature = "async_matrix"))] In: InputPin,
+    M: MatrixTrait,
     Out: OutputPin,
     const ROW: usize,
     const COL: usize,
     const NUM_LAYER: usize,
 >(
-    #[cfg(feature = "col2row")] input_pins: [In; ROW],
-    #[cfg(not(feature = "col2row"))] input_pins: [In; COL],
-    #[cfg(feature = "col2row")] output_pins: [Out; COL],
-    #[cfg(not(feature = "col2row"))] output_pins: [Out; ROW],
+    mut matrix: M,
     default_keymap: &mut [[[KeyAction; COL]; ROW]; NUM_LAYER],
     keyboard_config: RmkConfig<'static, Out>,
 ) -> ! {
@@ -73,20 +63,6 @@ pub(crate) async fn initialize_esp_ble_keyboard_with_config_and_run<
 
     let keyboard_report_sender = keyboard_report_channel.sender();
     let keyboard_report_receiver = keyboard_report_channel.receiver();
-
-    // Keyboard matrix
-    #[cfg(all(feature = "col2row", feature = "rapid_debouncer"))]
-    let mut matrix =
-        Matrix::<_, _, RapidDebouncer<ROW, COL>, ROW, COL>::new(input_pins, output_pins);
-    #[cfg(all(feature = "col2row", not(feature = "rapid_debouncer")))]
-    let mut matrix =
-        Matrix::<_, _, DefaultDebouncer<ROW, COL>, ROW, COL>::new(input_pins, output_pins);
-    #[cfg(all(not(feature = "col2row"), feature = "rapid_debouncer"))]
-    let mut matrix =
-        Matrix::<_, _, RapidDebouncer<COL, ROW>, COL, ROW>::new(input_pins, output_pins);
-    #[cfg(all(not(feature = "col2row"), not(feature = "rapid_debouncer")))]
-    let mut matrix =
-        Matrix::<_, _, DefaultDebouncer<COL, ROW>, COL, ROW>::new(input_pins, output_pins);
 
     let mut keyboard = Keyboard::new(&keymap, &keyboard_report_sender);
     // esp32c3 doesn't have USB device, so there is no usb here

--- a/rmk/src/ble/nrf/mod.rs
+++ b/rmk/src/ble/nrf/mod.rs
@@ -8,12 +8,8 @@ pub(crate) mod spec;
 mod vial_service;
 
 use self::server::BleServer;
-#[cfg(not(feature = "rapid_debouncer"))]
-use crate::debounce::default_bouncer::DefaultDebouncer;
-#[cfg(feature = "rapid_debouncer")]
-use crate::debounce::fast_debouncer::RapidDebouncer;
 use crate::keyboard::keyboard_report_channel;
-use crate::matrix::{Matrix, MatrixTrait};
+use crate::matrix::MatrixTrait;
 use crate::KEYBOARD_STATE;
 use crate::{
     ble::{
@@ -36,9 +32,7 @@ use embassy_futures::join::join;
 use embassy_futures::select::{select, select4, Either4};
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Receiver};
 use embassy_time::Timer;
-use embedded_hal::digital::{InputPin, OutputPin};
-#[cfg(feature = "async_matrix")]
-use embedded_hal_async::digital::Wait;
+use embedded_hal::digital::OutputPin;
 use embedded_storage_async::nor_flash::NorFlash as AsyncNorFlash;
 use heapless::FnvIndexMap;
 use nrf_softdevice::raw::sd_ble_gap_conn_param_update;
@@ -187,18 +181,14 @@ pub(crate) fn nrf_ble_config(keyboard_name: &str) -> Config {
 /// * `spwaner` - embassy task spwaner, used to spawn nrf_softdevice background task
 /// * `saadc` - nRF's [saadc](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52832.ps.v1.1%2Fsaadc.html) instance for battery level detection, if you don't need it, pass `None`
 pub(crate) async fn initialize_nrf_ble_keyboard_with_config_and_run<
-    #[cfg(feature = "async_matrix")] In: Wait + InputPin,
-    #[cfg(not(feature = "async_matrix"))] In: InputPin,
-    #[cfg(not(feature = "_no_usb"))] D: Driver<'static>,
+    M: MatrixTrait,
     Out: OutputPin,
+    #[cfg(not(feature = "_no_usb"))] D: Driver<'static>,
     const ROW: usize,
     const COL: usize,
     const NUM_LAYER: usize,
 >(
-    #[cfg(feature = "col2row")] input_pins: [In; ROW],
-    #[cfg(not(feature = "col2row"))] input_pins: [In; COL],
-    #[cfg(feature = "col2row")] output_pins: [Out; COL],
-    #[cfg(not(feature = "col2row"))] output_pins: [Out; ROW],
+    mut matrix: M,
     #[cfg(not(feature = "_no_usb"))] usb_driver: D,
     default_keymap: &mut [[[KeyAction; COL]; ROW]; NUM_LAYER],
     mut keyboard_config: RmkConfig<'static, Out>,
@@ -245,20 +235,6 @@ pub(crate) async fn initialize_nrf_ble_keyboard_with_config_and_run<
     let bonder = BONDER.init(Bonder::new(RefCell::new(bond_info)));
 
     let ble_server = unwrap!(BleServer::new(sd, keyboard_config.usb_config, bonder));
-
-    // Keyboard matrix
-    #[cfg(all(feature = "col2row", feature = "rapid_debouncer"))]
-    let mut matrix =
-        Matrix::<_, _, RapidDebouncer<ROW, COL>, ROW, COL>::new(input_pins, output_pins);
-    #[cfg(all(feature = "col2row", not(feature = "rapid_debouncer")))]
-    let mut matrix =
-        Matrix::<_, _, DefaultDebouncer<ROW, COL>, ROW, COL>::new(input_pins, output_pins);
-    #[cfg(all(not(feature = "col2row"), feature = "rapid_debouncer"))]
-    let mut matrix =
-        Matrix::<_, _, RapidDebouncer<COL, ROW>, COL, ROW>::new(input_pins, output_pins);
-    #[cfg(all(not(feature = "col2row"), not(feature = "rapid_debouncer")))]
-    let mut matrix =
-        Matrix::<_, _, DefaultDebouncer<COL, ROW>, COL, ROW>::new(input_pins, output_pins);
 
     let keyboard_report_sender = keyboard_report_channel.sender();
     let keyboard_report_receiver = keyboard_report_channel.receiver();

--- a/rmk/src/matrix.rs
+++ b/rmk/src/matrix.rs
@@ -102,11 +102,15 @@ impl<
     > Matrix<In, Out, D, INPUT_PIN_NUM, OUTPUT_PIN_NUM>
 {
     /// Create a matrix from input and output pins.
-    pub(crate) fn new(input_pins: [In; INPUT_PIN_NUM], output_pins: [Out; OUTPUT_PIN_NUM]) -> Self {
+    pub(crate) fn new(
+        input_pins: [In; INPUT_PIN_NUM],
+        output_pins: [Out; OUTPUT_PIN_NUM],
+        debouncer: D,
+    ) -> Self {
         Matrix {
             input_pins,
             output_pins,
-            debouncer: D::new(),
+            debouncer,
             key_states: [[KeyState::new(); INPUT_PIN_NUM]; OUTPUT_PIN_NUM],
             scan_start: None,
         }


### PR DESCRIPTION
Create Debouncer and Matrix in `run_rmk_*` function ahead of time instead of in the `initialize_*_and_run` function.