### PR TITLE
With modifier support

### DIFF
--- a/docs/src/keyboard_configuration.md
+++ b/docs/src/keyboard_configuration.md
@@ -116,11 +116,12 @@ The key string should follow several rules:
 
     For example, if you set a keycode `"Backspace"`, it will be turned to `KeyCode::Backspace`. So you have to ensure that the keycode string is valid, or RMK wouldn't compile!
 
+    For simple keycodes with modifiers active, you can use `WM(key, modifier)` to create a keypress with modifier action. Modifiers can be chained together like `LShift | RGui` to have multiple modifiers active.
 2. For no-key, use `"__"`
 
 3. RMK supports many advanced layer operations:
     1. Use `"MO(n)"` to create a layer activate action, `n` is the layer number
-    2. Use `"LM(n, modifier)"` to create layer activate with modifier action. The modifier can be like `LShift | RGui`
+    2. Use `"LM(n, modifier)"` to create layer activate with modifier action. The modifier can be chained in the same way as `WM`.
     3. Use `"LT(n, key)"` to create a layer activate action or tap key(tap/hold). The `key` here is the RMK [`KeyCode`](https://docs.rs/rmk/latest/rmk/keycode/enum.KeyCode.html)
     4. Use `"OSL(n)"` to create a one-shot layer action, `n` is the layer number
     5. Use `"TT(n)"` to create a layer activate or tap toggle action, `n` is the layer number

--- a/rmk-macro/CHANGELOG.md
+++ b/rmk-macro/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add default config for chips
-
+- Implemented `keyboard.toml` parsing for the new `WM(key, modifier)` "With Modifier" macro 
 ### Changed
 
 - BREAKING: refactor the whole macro crate, update `keyboard.toml` fields

--- a/rmk-macro/src/layout.rs
+++ b/rmk-macro/src/layout.rs
@@ -98,7 +98,7 @@ fn parse_key(key: String) -> TokenStream2 {
 
                 if (gui || alt || shift || ctrl) == false {
                     return quote! {
-                        compile_error!("keyboard.toml: modifier in LM(layer, modifier) is not valid! Please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
+                        compile_error!("keyboard.toml: modifier in WM(layer, modifier) is not valid! Please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
                     };
                 }
                 quote! {

--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add restart to ESP32
 - Optimize nRF BLE power consumption, now the idle current is decreased to about 20uA
+- Added new `wm` "With Modifier" macro to support basic keycodes with modifiers active
 
 ### Changed
 

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -14,6 +14,14 @@ macro_rules! k {
     };
 }
 
+/// Create a normal key with modifier active
+#[macro_export]
+macro_rules! wm {
+    ($x: ident, $m: expr) => {
+        $crate::action::KeyAction::WithModifier($crate::action::Action::Key($crate::keycode::KeyCode::$x), $m)
+    };
+}
+
 /// Create a normal action: `KeyAction`
 #[macro_export]
 macro_rules! a {

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -14,7 +14,7 @@ macro_rules! k {
     };
 }
 
-/// Create a normal key with modifier active
+/// Create a normal key with modifier action
 #[macro_export]
 macro_rules! wm {
     ($x: ident, $m: expr) => {


### PR DESCRIPTION
This PR implements the feature discussed in [this issue](https://github.com/HaoboGu/rmk/issues/111).
The "With Modifier" (WM) macro is now supported within the `keyboard.toml` file, allowing users to send a standard keycode with modifier options. 
For example `WM(Kc7, LShift)` would send the keycode `Kc7` with the modifier `LShift`.