### PR TITLE
update(README.md): add dactyl-lynx-rmk to real world examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@
 
 <img src="https://github.com/HaoboGu/rmk/blob/main/docs/src/images/rmk_ble_keyboard.jpg?raw=true" width="60%">
 
+### [dactyl-lynx-rmk](https://github.com/whitelynx/dactyl-lynx-rmk)
+
+<img src="https://raw.githubusercontent.com/whitelynx/dactyl-lynx-keyboard/refs/heads/main/resources/skeleton-prototype.jpg" width="60%">
+
 ## Usage
 
 ### Option 1: Initialize from template


### PR DESCRIPTION
It only took me a little over a day from first discovering RMK to flashing [a usable firmware](https://github.com/whitelynx/dactyl-lynx-rmk) complete with a 6-layer keymap created in Vial! I'd like to add my project as a real-world example of RMK being used.

---

I did have to do some hacking to get there, though. First, Vial defaults to only 4 layers, so I had to clone and run it locally, and edit the `DummyKeyboard` class to add more layers. Second, I built [a nice little script](https://github.com/whitelynx/dactyl-lynx-rmk/blob/59afa8307b6e49f315e96898d21b4805bcb55610/scripts/via2rmk.py) to convert from a Vial layout to the `layout.keymap` setting in RMK's `keyboard.toml`. (I'll probably open a PR to upstream that script into RMK itself, since I think others would find it useful)