### PR TITLE
Tri Layer support

### DIFF
--- a/docs/src/keyboard_configuration.md
+++ b/docs/src/keyboard_configuration.md
@@ -147,14 +147,29 @@ The key string should follow several rules:
     
   The definitions of those operations are same with QMK, you can found [here](https://docs.qmk.fm/#/feature_layers). If you want other actions, please [fire an issue](https://github.com/HaoboGu/rmk/issues/new).
 
-#### Tri Layer
-You can enable Tri Layer by specifying the `upper`, `lower` and `adjust` layers in the `tri_layer` sub-table.
+
+### `[behavior]`
+
+`[behavior]` section contains configuration for how different keyboard actions should behave:
 
 ```toml
-[layout]
+[behavior]
 tri_layer = { uppper = 1, lower = 2, adjust = 3 }
 ```
-When both the `upper` and `lower` layers are active, the `adjust` layer will also be enabled.
+
+#### Tri Layer
+
+`Tri Layer` works by enabling a layer (called `adjust`) when other two layers (`upper` and `lower`) are both enabled.
+
+You can enable Tri Layer by specifying the `upper`, `lower` and `adjust` layers in the `tri_layer` sub-table:
+
+```toml
+[behavior.tri_layer]
+uppper = 1
+lower = 2
+adjust = 3
+```
+In this example, when both layers 1 (`upper`) and 2 (`lower`) are active, layer 3 (`adjust`) will also be enabled.
 
 ### `[light]`
 
@@ -298,6 +313,11 @@ keymap = [
         ["_", "_", "_"]
     ],
 ]
+
+# Behavior configuration, if you don't want to customize anything, just ignore this section.
+[behavior]
+# Tri Layer configuration.
+tri_layer = { uppper = 1, lower = 2, adjust = 3 }
 
 # Lighting configuration, if you don't have any light, just ignore this section.
 [light]

--- a/docs/src/keyboard_configuration.md
+++ b/docs/src/keyboard_configuration.md
@@ -147,6 +147,15 @@ The key string should follow several rules:
     
   The definitions of those operations are same with QMK, you can found [here](https://docs.qmk.fm/#/feature_layers). If you want other actions, please [fire an issue](https://github.com/HaoboGu/rmk/issues/new).
 
+#### Tri Layer
+You can enable Tri Layer by specifying the `upper`, `lower` and `adjust` layers in the `tri_layer` sub-table.
+
+```toml
+[layout]
+tri_layer = { uppper = 1, lower = 2, adjust = 3 }
+```
+When both the `upper` and `lower` layers are active, the `adjust` layer will also be enabled.
+
 ### `[light]`
 
 `[light]` section defines lights of the keyboard, aka `capslock`, `scrolllock` and `numslock`. They are actually an input pin, so there are two fields available: `pin` and `low_active`.

--- a/rmk-config/src/keyboard_config.rs
+++ b/rmk-config/src/keyboard_config.rs
@@ -17,6 +17,7 @@ pub struct RmkConfig<'a, O: OutputPin> {
     pub vial_config: VialConfig<'a>,
     pub light_config: LightConfig<O>,
     pub storage_config: StorageConfig,
+    pub keyboard_options_config: KeyboardOptionsConfig,
     #[cfg(feature = "_nrf_ble")]
     pub ble_battery_config: BleBatteryConfig<'a>,
     #[cfg(feature = "_esp_ble")]
@@ -31,9 +32,21 @@ impl<'a, O: OutputPin> Default for RmkConfig<'a, O> {
             vial_config: VialConfig::default(),
             light_config: LightConfig::default(),
             storage_config: StorageConfig::default(),
+            keyboard_options_config: KeyboardOptionsConfig::default(),
             #[cfg(any(feature = "_nrf_ble", feature = "_esp_ble"))]
             ble_battery_config: BleBatteryConfig::default(),
         }
+    }
+}
+
+/// Config for configurable action behavior
+pub struct KeyboardOptionsConfig {
+    pub tri_layer: Option<[u8; 3]>,
+}
+
+impl Default for KeyboardOptionsConfig {
+    fn default() -> Self {
+        Self { tri_layer: None }
     }
 }
 

--- a/rmk-config/src/keyboard_config.rs
+++ b/rmk-config/src/keyboard_config.rs
@@ -17,7 +17,7 @@ pub struct RmkConfig<'a, O: OutputPin> {
     pub vial_config: VialConfig<'a>,
     pub light_config: LightConfig<O>,
     pub storage_config: StorageConfig,
-    pub keyboard_options_config: KeyboardOptionsConfig,
+    pub behavior_config: BehaviorConfig,
     #[cfg(feature = "_nrf_ble")]
     pub ble_battery_config: BleBatteryConfig<'a>,
     #[cfg(feature = "_esp_ble")]
@@ -32,7 +32,7 @@ impl<'a, O: OutputPin> Default for RmkConfig<'a, O> {
             vial_config: VialConfig::default(),
             light_config: LightConfig::default(),
             storage_config: StorageConfig::default(),
-            keyboard_options_config: KeyboardOptionsConfig::default(),
+            behavior_config: BehaviorConfig::default(),
             #[cfg(any(feature = "_nrf_ble", feature = "_esp_ble"))]
             ble_battery_config: BleBatteryConfig::default(),
         }
@@ -40,14 +40,9 @@ impl<'a, O: OutputPin> Default for RmkConfig<'a, O> {
 }
 
 /// Config for configurable action behavior
-pub struct KeyboardOptionsConfig {
+#[derive(Default)]
+pub struct BehaviorConfig {
     pub tri_layer: Option<[u8; 3]>,
-}
-
-impl Default for KeyboardOptionsConfig {
-    fn default() -> Self {
-        Self { tri_layer: None }
-    }
 }
 
 /// Config for storage

--- a/rmk-config/src/toml_config.rs
+++ b/rmk-config/src/toml_config.rs
@@ -10,6 +10,8 @@ pub struct KeyboardTomlConfig {
     /// Layout config.
     /// For split keyboard, the total row/col should be defined in this section
     pub layout: LayoutConfig,
+    /// Behavior config
+    pub behavior: Option<BehaviorConfig>,
     /// Light config
     pub light: Option<LightConfig>,
     /// Storage config
@@ -122,6 +124,11 @@ pub struct LayoutConfig {
     pub cols: u8,
     pub layers: u8,
     pub keymap: Vec<Vec<Vec<String>>>,
+}
+
+/// Configurations for actions behavior
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct BehaviorConfig {
     pub tri_layer: Option<TriLayerConfig>,
 }
 

--- a/rmk-config/src/toml_config.rs
+++ b/rmk-config/src/toml_config.rs
@@ -122,6 +122,15 @@ pub struct LayoutConfig {
     pub cols: u8,
     pub layers: u8,
     pub keymap: Vec<Vec<Vec<String>>>,
+    pub tri_layer: Option<TriLayerConfig>,
+}
+
+/// Configurations for tri layer
+#[derive(Clone, Debug, Deserialize)]
+pub struct TriLayerConfig {
+    pub upper: u8,
+    pub lower: u8,
+    pub adjust: u8,
 }
 
 /// Configurations for split keyboards

--- a/rmk-macro/src/behavior.rs
+++ b/rmk-macro/src/behavior.rs
@@ -1,0 +1,29 @@
+//! Initialize behavior config boilerplate of RMK
+//!
+
+use quote::quote;
+use rmk_config::toml_config::TriLayerConfig;
+
+use crate::keyboard_config::KeyboardConfig;
+
+fn expand_tri_layer(tri_layer: &Option<TriLayerConfig>) -> proc_macro2::TokenStream {
+    match tri_layer {
+        Some(tri_layer) => {
+            let upper = tri_layer.upper;
+            let lower = tri_layer.lower;
+            let adjust = tri_layer.adjust;
+            quote! {::core::option::Option::Some([#upper, #lower, #adjust])}
+        }
+        None => quote! {::core::option::Option::None::<[u8; 3]>},
+    }
+}
+
+pub(crate) fn expand_behavior_config(keyboard_config: &KeyboardConfig) -> proc_macro2::TokenStream {
+    let tri_layer = expand_tri_layer(&keyboard_config.behavior.tri_layer);
+
+    quote! {
+        let behavior_config = ::rmk::config::keyboard_config::BehaviorConfig {
+            tri_layer: #tri_layer,
+        };
+    }
+}

--- a/rmk-macro/src/keyboard.rs
+++ b/rmk-macro/src/keyboard.rs
@@ -13,7 +13,8 @@ use crate::{
     flash::expand_flash_init,
     import::expand_imports,
     keyboard_config::{
-        expand_keyboard_info, expand_vial_config, read_keyboard_toml_config, KeyboardConfig,
+        expand_kb_options_config, expand_keyboard_info, expand_vial_config,
+        read_keyboard_toml_config, KeyboardConfig,
     },
     layout::expand_layout_init,
     light::expand_light_config,
@@ -115,6 +116,7 @@ fn expand_main(
     let usb_init = expand_usb_init(keyboard_config, &item_mod);
     let flash_init = expand_flash_init(keyboard_config);
     let light_config = expand_light_config(keyboard_config);
+    let kb_options_config = expand_kb_options_config(keyboard_config);
     let matrix_config = expand_matrix_config(keyboard_config, async_matrix);
     let run_rmk = expand_rmk_entry(keyboard_config, &item_mod);
     let (ble_config, set_ble_config) = expand_ble_config(keyboard_config);
@@ -151,6 +153,9 @@ fn expand_main(
             // Initialize light config as `light_config`
             #light_config
 
+            // Initialize keyboard options config as `keyboard_options_config`
+            #kb_options_config
+
             // Initialize matrix config as `(input_pins, output_pins)` or `direct_pins`
             #matrix_config
 
@@ -162,6 +167,7 @@ fn expand_main(
                 vial_config: VIAL_CONFIG,
                 light_config,
                 storage_config,
+                keyboard_options_config,
                 #set_ble_config
                 ..Default::default()
             };

--- a/rmk-macro/src/keyboard.rs
+++ b/rmk-macro/src/keyboard.rs
@@ -4,6 +4,7 @@ use quote::quote;
 use syn::ItemMod;
 
 use crate::{
+    behavior::expand_behavior_config,
     bind_interrupt::expand_bind_interrupt,
     ble::expand_ble_config,
     chip_init::expand_chip_init,
@@ -13,8 +14,7 @@ use crate::{
     flash::expand_flash_init,
     import::expand_imports,
     keyboard_config::{
-        expand_kb_options_config, expand_keyboard_info, expand_vial_config,
-        read_keyboard_toml_config, KeyboardConfig,
+        expand_keyboard_info, expand_vial_config, read_keyboard_toml_config, KeyboardConfig,
     },
     layout::expand_layout_init,
     light::expand_light_config,
@@ -116,7 +116,7 @@ fn expand_main(
     let usb_init = expand_usb_init(keyboard_config, &item_mod);
     let flash_init = expand_flash_init(keyboard_config);
     let light_config = expand_light_config(keyboard_config);
-    let kb_options_config = expand_kb_options_config(keyboard_config);
+    let behavior_config = expand_behavior_config(keyboard_config);
     let matrix_config = expand_matrix_config(keyboard_config, async_matrix);
     let run_rmk = expand_rmk_entry(keyboard_config, &item_mod);
     let (ble_config, set_ble_config) = expand_ble_config(keyboard_config);
@@ -153,8 +153,8 @@ fn expand_main(
             // Initialize light config as `light_config`
             #light_config
 
-            // Initialize keyboard options config as `keyboard_options_config`
-            #kb_options_config
+            // Initialize behavior config config as `behavior_config`
+            #behavior_config
 
             // Initialize matrix config as `(input_pins, output_pins)` or `direct_pins`
             #matrix_config
@@ -167,7 +167,7 @@ fn expand_main(
                 vial_config: VIAL_CONFIG,
                 light_config,
                 storage_config,
-                keyboard_options_config,
+                behavior_config,
                 #set_ble_config
                 ..Default::default()
             };

--- a/rmk-macro/src/keyboard_config.rs
+++ b/rmk-macro/src/keyboard_config.rs
@@ -1,8 +1,8 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use rmk_config::toml_config::{
-    BleConfig, DependencyConfig, KeyboardInfo, KeyboardTomlConfig, LayoutConfig, LightConfig,
-    MatrixConfig, MatrixType, SplitConfig, StorageConfig, TriLayerConfig,
+    BehaviorConfig, BleConfig, DependencyConfig, KeyboardInfo, KeyboardTomlConfig, LayoutConfig,
+    LightConfig, MatrixConfig, MatrixType, SplitConfig, StorageConfig,
 };
 use serde::Deserialize;
 use std::fs;
@@ -71,6 +71,8 @@ pub(crate) struct KeyboardConfig {
     pub(crate) board: BoardConfig,
     // Layout config
     pub(crate) layout: LayoutConfig,
+    // Begavior Config
+    pub(crate) behavior: BehaviorConfig,
     // Light config
     pub(crate) light: LightConfig,
     // Storage config
@@ -163,6 +165,10 @@ impl KeyboardConfig {
 
         // Layout config
         config.layout = Self::get_layout_from_toml(toml_config.layout)?;
+
+        // Behavior config
+        config.behavior =
+            Self::get_behavior_from_toml(config.behavior, toml_config.behavior, &config.layout)?;
 
         // Light config
         config.light = Self::get_light_from_toml(config.light, toml_config.light);
@@ -401,23 +407,41 @@ impl KeyboardConfig {
             );
         }
 
-        if let Some(ref tri_layer) = layout.tri_layer {
-            if tri_layer.upper >= layout.layers {
-                return rmk_compile_error!(
-                    "keyboard.toml: Tri layer upper is larger than [layout.layers]"
-                );
-            } else if tri_layer.lower >= layout.layers {
-                return rmk_compile_error!(
-                    "keyboard.toml: Tri layer lower is larger than [layout.layers]"
-                );
-            } else if tri_layer.adjust >= layout.layers {
-                return rmk_compile_error!(
-                    "keyboard.toml: Tri layer adjust is larger than [layout.layers]"
-                );
-            }
-        }
-
         Ok(layout)
+    }
+
+    fn get_behavior_from_toml(
+        default: BehaviorConfig,
+        toml: Option<BehaviorConfig>,
+        layout: &LayoutConfig,
+    ) -> Result<BehaviorConfig, TokenStream2> {
+        match toml {
+            Some(mut behavior) => {
+                // Use default setting if the corresponding field is not set
+                behavior.tri_layer = match behavior.tri_layer {
+                    Some(tri_layer) => {
+                        if tri_layer.upper >= layout.layers {
+                            return rmk_compile_error!(
+                                "keyboard.toml: Tri layer upper is larger than [layout.layers]"
+                            );
+                        } else if tri_layer.lower >= layout.layers {
+                            return rmk_compile_error!(
+                                "keyboard.toml: Tri layer lower is larger than [layout.layers]"
+                            );
+                        } else if tri_layer.adjust >= layout.layers {
+                            return rmk_compile_error!(
+                                "keyboard.toml: Tri layer adjust is larger than [layout.layers]"
+                            );
+                        }
+                        Some(tri_layer)
+                    }
+                    None => default.tri_layer,
+                };
+
+                Ok(behavior)
+            }
+            None => Ok(default),
+        }
     }
 
     fn get_light_from_toml(default: LightConfig, toml: Option<LightConfig>) -> LightConfig {
@@ -462,31 +486,6 @@ pub(crate) fn read_keyboard_toml_config() -> Result<KeyboardTomlConfig, TokenStr
             let msg = format!("Parse `keyboard.toml` error: {}", e.message());
             return rmk_compile_error!(msg);
         }
-    }
-}
-
-fn expand_tri_layer(tri_layer: &Option<TriLayerConfig>) -> proc_macro2::TokenStream {
-    match tri_layer {
-        Some(tri_layer) => {
-            let upper = tri_layer.upper;
-            let lower = tri_layer.lower;
-            let adjust = tri_layer.adjust;
-            quote! {::core::option::Option::Some([#upper, #lower, #adjust])}
-        }
-        None => quote! {::core::option::Option::None},
-    }
-}
-
-pub(crate) fn expand_kb_options_config(
-    keyboard_config: &KeyboardConfig,
-) -> proc_macro2::TokenStream {
-    let tri_layer = expand_tri_layer(&keyboard_config.layout.tri_layer);
-
-    // Generate a macro that does light config
-    quote! {
-        let keyboard_options_config = ::rmk::config::keyboard_config::KeyboardOptionsConfig {
-            tri_layer: #tri_layer,
-        };
     }
 }
 

--- a/rmk-macro/src/lib.rs
+++ b/rmk-macro/src/lib.rs
@@ -1,3 +1,4 @@
+mod behavior;
 mod bind_interrupt;
 mod ble;
 mod chip_init;

--- a/rmk-macro/src/split/central.rs
+++ b/rmk-macro/src/split/central.rs
@@ -14,7 +14,9 @@ use crate::{
     flash::expand_flash_init,
     import::expand_imports,
     keyboard::gen_imports,
-    keyboard_config::{read_keyboard_toml_config, BoardConfig, KeyboardConfig},
+    keyboard_config::{
+        expand_kb_options_config, read_keyboard_toml_config, BoardConfig, KeyboardConfig,
+    },
     light::expand_light_config,
     matrix::expand_matrix_input_output_pins,
     ChipModel, ChipSeries,
@@ -74,6 +76,7 @@ fn expand_split_central(
     let usb_init = expand_usb_init(keyboard_config, &item_mod);
     let flash_init = expand_flash_init(keyboard_config);
     let light_config = expand_light_config(keyboard_config);
+    let kb_options_config = expand_kb_options_config(keyboard_config);
 
     let matrix_config = expand_matrix_input_output_pins(
         &keyboard_config.chip,
@@ -118,6 +121,9 @@ fn expand_split_central(
             // Initialize light config as `light_config`
             #light_config
 
+            // Initialize keyboard options config as `keyboard_options_config`
+            #kb_options_config
+
             // Initialize matrix config as `(input_pins, output_pins)`
             #matrix_config
 
@@ -130,6 +136,7 @@ fn expand_split_central(
                 vial_config: VIAL_CONFIG,
                 light_config,
                 storage_config,
+                keyboard_options_config,
                 #set_ble_config
                 ..Default::default()
             };

--- a/rmk-macro/src/split/central.rs
+++ b/rmk-macro/src/split/central.rs
@@ -6,6 +6,7 @@ use rmk_config::toml_config::{SerialConfig, SplitConfig};
 use syn::ItemMod;
 
 use crate::{
+    behavior::expand_behavior_config,
     bind_interrupt::expand_bind_interrupt,
     ble::expand_ble_config,
     chip_init::expand_chip_init,
@@ -14,9 +15,7 @@ use crate::{
     flash::expand_flash_init,
     import::expand_imports,
     keyboard::gen_imports,
-    keyboard_config::{
-        expand_kb_options_config, read_keyboard_toml_config, BoardConfig, KeyboardConfig,
-    },
+    keyboard_config::{read_keyboard_toml_config, BoardConfig, KeyboardConfig},
     light::expand_light_config,
     matrix::expand_matrix_input_output_pins,
     ChipModel, ChipSeries,
@@ -76,7 +75,7 @@ fn expand_split_central(
     let usb_init = expand_usb_init(keyboard_config, &item_mod);
     let flash_init = expand_flash_init(keyboard_config);
     let light_config = expand_light_config(keyboard_config);
-    let kb_options_config = expand_kb_options_config(keyboard_config);
+    let behavior_config = expand_behavior_config(keyboard_config);
 
     let matrix_config = expand_matrix_input_output_pins(
         &keyboard_config.chip,
@@ -121,8 +120,8 @@ fn expand_split_central(
             // Initialize light config as `light_config`
             #light_config
 
-            // Initialize keyboard options config as `keyboard_options_config`
-            #kb_options_config
+            // Initialize behavior config config as `behavior_config`
+            #behavior_config
 
             // Initialize matrix config as `(input_pins, output_pins)`
             #matrix_config
@@ -136,7 +135,7 @@ fn expand_split_central(
                 vial_config: VIAL_CONFIG,
                 light_config,
                 storage_config,
-                keyboard_options_config,
+                behavior_config,
                 #set_ble_config
                 ..Default::default()
             };

--- a/rmk/src/ble/esp/mod.rs
+++ b/rmk/src/ble/esp/mod.rs
@@ -62,7 +62,11 @@ pub(crate) async fn initialize_esp_ble_keyboard_with_config_and_run<
     let keyboard_report_sender = keyboard_report_channel.sender();
     let keyboard_report_receiver = keyboard_report_channel.receiver();
 
-    let mut keyboard = Keyboard::new(&keymap, &keyboard_report_sender);
+    let mut keyboard = Keyboard::new(
+        &keymap,
+        &keyboard_report_sender,
+        keyboard_config.keyboard_options_config,
+    );
     // esp32c3 doesn't have USB device, so there is no usb here
     // TODO: add usb service for other chips of esp32 which have USB device
 

--- a/rmk/src/ble/esp/mod.rs
+++ b/rmk/src/ble/esp/mod.rs
@@ -65,7 +65,7 @@ pub(crate) async fn initialize_esp_ble_keyboard_with_config_and_run<
     let mut keyboard = Keyboard::new(
         &keymap,
         &keyboard_report_sender,
-        keyboard_config.keyboard_options_config,
+        keyboard_config.behavior_config,
     );
     // esp32c3 doesn't have USB device, so there is no usb here
     // TODO: add usb service for other chips of esp32 which have USB device

--- a/rmk/src/ble/nrf/mod.rs
+++ b/rmk/src/ble/nrf/mod.rs
@@ -295,7 +295,7 @@ pub(crate) async fn initialize_nrf_ble_keyboard_and_run<
     let mut keyboard = Keyboard::new(
         &keymap,
         &keyboard_report_sender,
-        keyboard_config.keyboard_options_config,
+        keyboard_config.behavior_config,
     );
     #[cfg(not(feature = "_no_usb"))]
     let mut usb_device = KeyboardUsbDevice::new(usb_driver, keyboard_config.usb_config);

--- a/rmk/src/ble/nrf/mod.rs
+++ b/rmk/src/ble/nrf/mod.rs
@@ -292,7 +292,11 @@ pub(crate) async fn initialize_nrf_ble_keyboard_and_run<
     let keyboard_report_receiver = keyboard_report_channel.receiver();
 
     // Keyboard services
-    let mut keyboard = Keyboard::new(&keymap, &keyboard_report_sender);
+    let mut keyboard = Keyboard::new(
+        &keymap,
+        &keyboard_report_sender,
+        keyboard_config.keyboard_options_config,
+    );
     #[cfg(not(feature = "_no_usb"))]
     let mut usb_device = KeyboardUsbDevice::new(usb_driver, keyboard_config.usb_config);
     let mut vial_service = VialService::new(&keymap, keyboard_config.vial_config);

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -17,6 +17,7 @@ use embassy_sync::{
 use embassy_time::{Instant, Timer};
 use heapless::{FnvIndexMap, Vec};
 use postcard::experimental::max_size::MaxSize;
+use rmk_config::KeyboardOptionsConfig;
 use serde::{Deserialize, Serialize};
 use usbd_hid::descriptor::KeyboardReport;
 
@@ -131,6 +132,9 @@ pub(crate) struct Keyboard<'a, const ROW: usize, const COL: usize, const NUM_LAY
     /// Timer which records the timestamp of key changes
     pub(crate) timer: [[Option<Instant>; ROW]; COL],
 
+    /// Options for configurable action behavior
+    options: KeyboardOptionsConfig,
+
     /// One shot modifier state
     osm_state: OneShotState<ModifierCombination>,
 
@@ -163,11 +167,13 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
     pub(crate) fn new(
         keymap: &'a RefCell<KeyMap<'a, ROW, COL, NUM_LAYER>>,
         sender: &'a Sender<'a, CriticalSectionRawMutex, KeyboardReportMessage, REPORT_CHANNEL_SIZE>,
+        options: KeyboardOptionsConfig,
     ) -> Self {
         Keyboard {
             keymap,
             sender,
             timer: [[None; ROW]; COL],
+            options,
             osm_state: OneShotState::default(),
             osl_state: OneShotState::default(),
             unprocessed_events: Vec::new(),

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -17,7 +17,7 @@ use embassy_sync::{
 use embassy_time::{Instant, Timer};
 use heapless::{FnvIndexMap, Vec};
 use postcard::experimental::max_size::MaxSize;
-use rmk_config::KeyboardOptionsConfig;
+use rmk_config::BehaviorConfig;
 use serde::{Deserialize, Serialize};
 use usbd_hid::descriptor::KeyboardReport;
 
@@ -133,7 +133,7 @@ pub(crate) struct Keyboard<'a, const ROW: usize, const COL: usize, const NUM_LAY
     pub(crate) timer: [[Option<Instant>; ROW]; COL],
 
     /// Options for configurable action behavior
-    options: KeyboardOptionsConfig,
+    behavior: BehaviorConfig,
 
     /// One shot modifier state
     osm_state: OneShotState<ModifierCombination>,
@@ -167,13 +167,13 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
     pub(crate) fn new(
         keymap: &'a RefCell<KeyMap<'a, ROW, COL, NUM_LAYER>>,
         sender: &'a Sender<'a, CriticalSectionRawMutex, KeyboardReportMessage, REPORT_CHANNEL_SIZE>,
-        options: KeyboardOptionsConfig,
+        behavior: BehaviorConfig,
     ) -> Self {
         Keyboard {
             keymap,
             sender,
             timer: [[None; ROW]; COL],
-            options,
+            behavior,
             osm_state: OneShotState::default(),
             osl_state: OneShotState::default(),
             unprocessed_events: Vec::new(),
@@ -302,7 +302,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
         }
 
         // Tri Layer
-        if let Some(ref tri_layer) = self.options.tri_layer {
+        if let Some(ref tri_layer) = self.behavior.tri_layer {
             self.keymap.borrow_mut().update_tri_layer(tri_layer);
         }
     }

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -300,6 +300,11 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
                     .await;
             }
         }
+
+        // Tri Layer
+        if let Some(ref tri_layer) = self.options.tri_layer {
+            self.keymap.borrow_mut().update_tri_layer(tri_layer);
+        }
     }
 
     async fn update_osm(&mut self, key_event: KeyEvent) {

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -253,6 +253,12 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
         self.layer_cache[row][col] = layer_num;
     }
 
+    /// Update given Tri Layer state
+    pub(crate) fn update_tri_layer(&mut self, tri_layer: &[u8; 3]) {
+        self.layer_state[tri_layer[2] as usize] =
+            self.layer_state[tri_layer[0] as usize] && self.layer_state[tri_layer[0] as usize];
+    }
+
     /// Activate given layer
     pub(crate) fn activate_layer(&mut self, layer_num: u8) {
         if layer_num as usize >= NUM_LAYER {

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -256,7 +256,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
     /// Update given Tri Layer state
     pub(crate) fn update_tri_layer(&mut self, tri_layer: &[u8; 3]) {
         self.layer_state[tri_layer[2] as usize] =
-            self.layer_state[tri_layer[0] as usize] && self.layer_state[tri_layer[0] as usize];
+            self.layer_state[tri_layer[0] as usize] && self.layer_state[tri_layer[1] as usize];
     }
 
     /// Activate given layer

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -251,7 +251,11 @@ pub(crate) async fn initialize_usb_keyboard_and_run<
 
     // Create keyboard services and devices
     let (mut keyboard, mut usb_device, mut vial_service, mut light_service) = (
-        Keyboard::new(&keymap, &keyboard_report_sender),
+        Keyboard::new(
+            &keymap,
+            &keyboard_report_sender,
+            keyboard_config.keyboard_options_config,
+        ),
         KeyboardUsbDevice::new(usb_driver, keyboard_config.usb_config),
         VialService::new(&keymap, keyboard_config.vial_config),
         LightService::from_config(keyboard_config.light_config),

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -254,7 +254,7 @@ pub(crate) async fn initialize_usb_keyboard_and_run<
         Keyboard::new(
             &keymap,
             &keyboard_report_sender,
-            keyboard_config.keyboard_options_config,
+            keyboard_config.behavior_config,
         ),
         KeyboardUsbDevice::new(usb_driver, keyboard_config.usb_config),
         VialService::new(&keymap, keyboard_config.vial_config),

--- a/rmk/src/split/central.rs
+++ b/rmk/src/split/central.rs
@@ -194,7 +194,11 @@ pub(crate) async fn initialize_usb_split_central_and_run<
 
     // Create keyboard services and devices
     let (mut keyboard, mut usb_device, mut vial_service, mut light_service) = (
-        Keyboard::new(&keymap, &keyboard_report_sender),
+        Keyboard::new(
+            &keymap,
+            &keyboard_report_sender,
+            keyboard_config.keyboard_options_config,
+        ),
         KeyboardUsbDevice::new(usb_driver, keyboard_config.usb_config),
         VialService::new(&keymap, keyboard_config.vial_config),
         LightService::from_config(keyboard_config.light_config),

--- a/rmk/src/split/central.rs
+++ b/rmk/src/split/central.rs
@@ -197,7 +197,7 @@ pub(crate) async fn initialize_usb_split_central_and_run<
         Keyboard::new(
             &keymap,
             &keyboard_report_sender,
-            keyboard_config.keyboard_options_config,
+            keyboard_config.behavior_config,
         ),
         KeyboardUsbDevice::new(usb_driver, keyboard_config.usb_config),
         VialService::new(&keymap, keyboard_config.vial_config),


### PR DESCRIPTION
Closes #143

- [x] Find a way to add Tri Layer options
- [x] Add options in toml and macros
- [x] Implement Tri Layer
- [x] Update docs

Implementation will be similar to ZMK, ignore `TriLayerUpper` and `TriLayerLower` key codes and use the layer state instead.
It will be limited to 2 activation layers ("upper" and "lower") and one Tri Layer configuration for now.