### PR TITLE
Add option to customize one shot timeout

### DIFF
--- a/docs/src/keyboard_configuration.md
+++ b/docs/src/keyboard_configuration.md
@@ -155,6 +155,7 @@ The key string should follow several rules:
 ```toml
 [behavior]
 tri_layer = { uppper = 1, lower = 2, adjust = 3 }
+one_shot = { timeout = "1s" }
 ```
 
 #### Tri Layer
@@ -170,6 +171,16 @@ lower = 2
 adjust = 3
 ```
 In this example, when both layers 1 (`upper`) and 2 (`lower`) are active, layer 3 (`adjust`) will also be enabled.
+
+#### One Shot
+
+In the `one_shot` sub-table you can define how long OSM or OSL will wait before releasing the modifier/layer with the `timeout` option, default is one second.
+`timeout` is a string with a suffix of either "s" or "ms".
+
+```toml
+[behavior.one_shot]
+timeout = "5s"
+```
 
 ### `[light]`
 
@@ -314,10 +325,12 @@ keymap = [
     ],
 ]
 
-# Behavior configuration, if you don't want to customize anything, just ignore this section.
+# Behavior configuration, if you don't want to customize anything, just ignore this section
 [behavior]
-# Tri Layer configuration.
+# Tri Layer configuration
 tri_layer = { uppper = 1, lower = 2, adjust = 3 }
+# One Shot configuration
+one_shot = { timeout = "1s" }
 
 # Lighting configuration, if you don't have any light, just ignore this section.
 [light]

--- a/rmk-config/Cargo.toml
+++ b/rmk-config/Cargo.toml
@@ -17,6 +17,7 @@ embassy-nrf = { version = "0.2.0", features = [
     "unstable-pac",
     "time",
 ], optional = true }
+embassy-time = { version = "0.3", features = ["defmt"] }
 
 [features]
 default = []

--- a/rmk-config/src/keyboard_config.rs
+++ b/rmk-config/src/keyboard_config.rs
@@ -3,6 +3,7 @@ mod esp_config;
 #[cfg(feature = "_nrf_ble")]
 mod nrf_config;
 
+use embassy_time::Duration;
 #[cfg(feature = "_esp_ble")]
 pub use esp_config::BleBatteryConfig;
 #[cfg(feature = "_nrf_ble")]
@@ -43,6 +44,20 @@ impl<'a, O: OutputPin> Default for RmkConfig<'a, O> {
 #[derive(Default)]
 pub struct BehaviorConfig {
     pub tri_layer: Option<[u8; 3]>,
+    pub one_shot: OneShotConfig,
+}
+
+/// Config for one shot behavior
+pub struct OneShotConfig {
+    pub timeout: Duration,
+}
+
+impl Default for OneShotConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(1),
+        }
+    }
 }
 
 /// Config for storage

--- a/rmk-config/src/toml_config.rs
+++ b/rmk-config/src/toml_config.rs
@@ -1,3 +1,4 @@
+use serde::de;
 use serde_derive::Deserialize;
 
 /// Configurations for RMK keyboard.
@@ -130,6 +131,7 @@ pub struct LayoutConfig {
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct BehaviorConfig {
     pub tri_layer: Option<TriLayerConfig>,
+    pub one_shot: Option<OneShotConfig>,
 }
 
 /// Configurations for tri layer
@@ -138,6 +140,12 @@ pub struct TriLayerConfig {
     pub upper: u8,
     pub lower: u8,
     pub adjust: u8,
+}
+
+/// Configurations for one shot
+#[derive(Clone, Debug, Deserialize)]
+pub struct OneShotConfig {
+    pub timeout: Option<DurationMillis>,
 }
 
 /// Configurations for split keyboards
@@ -179,6 +187,27 @@ pub struct SerialConfig {
     pub rx_pin: String,
 }
 
+/// Duration in milliseconds
+#[derive(Clone, Debug, Deserialize)]
+pub struct DurationMillis(#[serde(deserialize_with = "parse_duration_millis")] pub u64);
+
 fn default_true() -> bool {
     true
+}
+
+fn parse_duration_millis<'de, D: de::Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
+    let input: String = de::Deserialize::deserialize(deserializer)?;
+    let num = input.trim_end_matches(|c: char| !c.is_numeric());
+    let unit = &input[num.len()..];
+    let num: u64 = num.parse().map_err(|_| {
+        de::Error::custom(format!(
+            "Invalid number \"{num}\" in [one_shot.timeout]: number part must be a u64"
+        ))
+    })?;
+
+    match unit {
+        "s" => Ok(num*1000),
+        "ms" => Ok(num),
+        other => Err(de::Error::custom(format!("Invalid unit \"{other}\" in [one_shot.timeout]: unit part must be either \"s\" or \"ms\""))),
+    }
 }

--- a/rmk-macro/src/behavior.rs
+++ b/rmk-macro/src/behavior.rs
@@ -2,7 +2,7 @@
 //!
 
 use quote::quote;
-use rmk_config::toml_config::TriLayerConfig;
+use rmk_config::toml_config::{OneShotConfig, TriLayerConfig};
 
 use crate::keyboard_config::KeyboardConfig;
 
@@ -18,12 +18,35 @@ fn expand_tri_layer(tri_layer: &Option<TriLayerConfig>) -> proc_macro2::TokenStr
     }
 }
 
+fn expand_one_shot(one_shot: &Option<OneShotConfig>) -> proc_macro2::TokenStream {
+    let default = quote! {::rmk::config::keyboard_config::OneShotConfig::default()};
+    match one_shot {
+        Some(one_shot) => {
+            let millis = match &one_shot.timeout {
+                Some(t) => t.0,
+                None => return default,
+            };
+
+            let timeout = quote! {::embassy_time::Duration::from_millis(#millis)};
+
+            quote! {
+                ::rmk::config::keyboard_config::OneShotConfig {
+                    timeout: #timeout,
+                }
+            }
+        }
+        None => default,
+    }
+}
+
 pub(crate) fn expand_behavior_config(keyboard_config: &KeyboardConfig) -> proc_macro2::TokenStream {
     let tri_layer = expand_tri_layer(&keyboard_config.behavior.tri_layer);
+    let one_shot = expand_one_shot(&keyboard_config.behavior.one_shot);
 
     quote! {
         let behavior_config = ::rmk::config::keyboard_config::BehaviorConfig {
             tri_layer: #tri_layer,
+            one_shot: #one_shot,
         };
     }
 }

--- a/rmk-macro/src/keyboard_config.rs
+++ b/rmk-macro/src/keyboard_config.rs
@@ -438,6 +438,8 @@ impl KeyboardConfig {
                     None => default.tri_layer,
                 };
 
+                behavior.one_shot = behavior.one_shot.or(default.one_shot);
+
                 Ok(behavior)
             }
             None => Ok(default),

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -489,8 +489,6 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
     }
 
     /// Process one shot action.
-    ///     
-    /// TODO: make timeout customizable
     async fn process_key_action_oneshot(&mut self, oneshot_action: Action, key_event: KeyEvent) {
         match oneshot_action {
             Action::Modifier(m) => self.process_action_osm(m, key_event).await,
@@ -521,7 +519,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
                 OneShotState::Initial(m) | OneShotState::Single(m) => {
                     self.osm_state = OneShotState::Single(m);
 
-                    let timeout = embassy_time::Timer::after_secs(1);
+                    let timeout = embassy_time::Timer::after(self.behavior.one_shot.timeout);
                     match select(timeout, key_event_channel.receive()).await {
                         embassy_futures::select::Either::First(_) => {
                             // Timeout, release modifier
@@ -572,7 +570,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
                 OneShotState::Initial(l) | OneShotState::Single(l) => {
                     self.osl_state = OneShotState::Single(l);
 
-                    let timeout = embassy_time::Timer::after_secs(1);
+                    let timeout = embassy_time::Timer::after(self.behavior.one_shot.timeout);
                     match select(timeout, key_event_channel.receive()).await {
                         embassy_futures::select::Either::First(_) => {
                             // Timeout, deactivate layer


### PR DESCRIPTION
Add config under `[behavior]` to customize OSM and OSL timeout.

I believe tap/hold and HRM timeout should wait for #125 