### PR TITLE
Combos support

### DIFF
--- a/rmk-macro/src/behavior.rs
+++ b/rmk-macro/src/behavior.rs
@@ -1,7 +1,7 @@
 //! Initialize behavior config boilerplate of RMK
 //!
 
-use crate::config::{OneShotConfig, TapHoldConfig, TriLayerConfig};
+use crate::config::{CombosConfig, OneShotConfig, TapHoldConfig, TriLayerConfig};
 use crate::keyboard_config::KeyboardConfig;
 use quote::quote;
 use crate::layout::parse_key;
@@ -90,7 +90,11 @@ fn expand_combos(combos: &Option<CombosConfig>) -> proc_macro2::TokenStream {
             let combos = combos.combos.iter().map(|combo| {
                 let actions = combo.actions.iter().map(|a| parse_key(a.to_owned()));
                 let output = parse_key(combo.output.to_owned());
-                quote! { ::rmk::combo::Combo::new([#(#actions),*], #output) }
+                let layer = match combo.layer {
+                    Some(layer) => quote! { ::core::option::Option::Some(#layer) },
+                    None => quote! { ::core::option::Option::None },
+                };
+                quote! { ::rmk::combo::Combo::new([#(#actions),*], #output, #layer) }
             });
 
             quote! { ::heapless::Vec::from_iter([#(#combos),*]) }

--- a/rmk-macro/src/config/mod.rs
+++ b/rmk-macro/src/config/mod.rs
@@ -170,6 +170,7 @@ pub struct OneShotConfig {
 #[derive(Clone, Debug, Deserialize)]
 pub struct CombosConfig {
     pub combos: Vec<ComboConfig>,
+    pub timeout: Option<DurationMillis>,
 }
 
 /// Configurations for combo

--- a/rmk-macro/src/config/mod.rs
+++ b/rmk-macro/src/config/mod.rs
@@ -140,6 +140,7 @@ pub struct BehaviorConfig {
     pub tri_layer: Option<TriLayerConfig>,
     pub tap_hold: Option<TapHoldConfig>,
     pub one_shot: Option<OneShotConfig>,
+    pub combo: Option<CombosConfig>,
 }
 
 /// Configurations for tap hold
@@ -163,6 +164,19 @@ pub struct TriLayerConfig {
 #[derive(Clone, Debug, Deserialize)]
 pub struct OneShotConfig {
     pub timeout: Option<DurationMillis>,
+}
+
+/// Configurations for combos
+#[derive(Clone, Debug, Deserialize)]
+pub struct CombosConfig {
+    pub combos: Vec<ComboConfig>,
+}
+
+/// Configurations for combo
+#[derive(Clone, Debug, Deserialize)]
+pub struct ComboConfig {
+    pub actions: Vec<String>,
+    pub output: String,
 }
 
 /// Configurations for split keyboards
@@ -223,7 +237,7 @@ fn parse_duration_millis<'de, D: de::Deserializer<'de>>(deserializer: D) -> Resu
     let unit = &input[num.len()..];
     let num: u64 = num.parse().map_err(|_| {
         de::Error::custom(format!(
-            "Invalid number \"{num}\" in [one_shot.timeout]: number part must be a u64"
+            "Invalid number \"{num}\" in duration: number part must be a u64"
         ))
     })?;
 

--- a/rmk-macro/src/config/mod.rs
+++ b/rmk-macro/src/config/mod.rs
@@ -177,6 +177,7 @@ pub struct CombosConfig {
 pub struct ComboConfig {
     pub actions: Vec<String>,
     pub output: String,
+    pub layer: Option<u8>,
 }
 
 /// Configurations for split keyboards

--- a/rmk-macro/src/keyboard_config.rs
+++ b/rmk-macro/src/keyboard_config.rs
@@ -22,6 +22,11 @@ macro_rules! rmk_compile_error {
     };
 }
 
+// Max number of macros
+pub const COMBO_MAX_NUM: usize = 8;
+// Max size of macros
+pub const COMBO_MAX_LENGTH: usize = 4;
+
 /// Keyboard's basic info
 #[allow(unused)]
 #[derive(Clone, Debug, Deserialize)]
@@ -442,6 +447,19 @@ impl KeyboardConfig {
 
                 behavior.tap_hold = behavior.tap_hold.or(default.tap_hold);
                 behavior.one_shot = behavior.one_shot.or(default.one_shot);
+
+                behavior.combo = behavior.combo.or(default.combo);
+                if let Some(combo) = &behavior.combo {
+                    if combo.combos.len() > COMBO_MAX_NUM {
+                        return rmk_compile_error!(format!("keyboard.toml: number of combos is greater than [behavior.combo.max_num]"));
+                    }
+
+                    for (i, c) in combo.combos.iter().enumerate() {
+                        if c.actions.len() > COMBO_MAX_LENGTH {
+                            return rmk_compile_error!(format!("keyboard.toml: number of keys in combo #{i} is greater than [behavior.combo.max_length]"));
+                        }
+                    }
+                }
 
                 Ok(behavior)
             }

--- a/rmk-macro/src/keyboard_config.rs
+++ b/rmk-macro/src/keyboard_config.rs
@@ -458,6 +458,12 @@ impl KeyboardConfig {
                         if c.actions.len() > COMBO_MAX_LENGTH {
                             return rmk_compile_error!(format!("keyboard.toml: number of keys in combo #{i} is greater than [behavior.combo.max_length]"));
                         }
+
+                        if let Some(layer) = c.layer {
+                            if layer >= layout.layers {
+                                return rmk_compile_error!(format!("keyboard.toml: layer in combo #{i} is greater than [layout.layers]"));
+                            }
+                        }
                     }
                 }
 

--- a/rmk-macro/src/keyboard_config.rs
+++ b/rmk-macro/src/keyboard_config.rs
@@ -22,9 +22,9 @@ macro_rules! rmk_compile_error {
     };
 }
 
-// Max number of macros
+// Max number of combos
 pub const COMBO_MAX_NUM: usize = 8;
-// Max size of macros
+// Max size of combos
 pub const COMBO_MAX_LENGTH: usize = 4;
 
 /// Keyboard's basic info

--- a/rmk-macro/src/layout.rs
+++ b/rmk-macro/src/layout.rs
@@ -107,7 +107,7 @@ fn parse_modifiers(modifiers_str: &str) -> ModifierCombinationMacro {
 }
 
 /// Parse the key string at a single position
-fn parse_key(key: String) -> TokenStream2 {
+pub(crate) fn parse_key(key: String) -> TokenStream2 {
     if key.len() < 5 {
         return if key.len() > 0 && key.trim_start_matches("_").len() == 0 {
             quote! { ::rmk::a!(No) }

--- a/rmk/src/ble/esp/mod.rs
+++ b/rmk/src/ble/esp/mod.rs
@@ -59,16 +59,19 @@ pub async fn initialize_esp_ble_keyboard_with_config_and_run<
     )
     .await;
 
-    let keymap = RefCell::new(KeyMap::new_from_storage(default_keymap, Some(&mut storage)).await);
+    let keymap = RefCell::new(
+        KeyMap::new_from_storage(
+            default_keymap,
+            Some(&mut storage),
+            keyboard_config.behavior_config,
+        )
+        .await,
+    );
 
     let keyboard_report_sender = KEYBOARD_REPORT_CHANNEL.sender();
     let keyboard_report_receiver = KEYBOARD_REPORT_CHANNEL.receiver();
 
-    let mut keyboard = Keyboard::new(
-        &keymap,
-        &keyboard_report_sender,
-        keyboard_config.behavior_config,
-    );
+    let mut keyboard = Keyboard::new(&keymap, &keyboard_report_sender);
     // esp32c3 doesn't have USB device, so there is no usb here
     // TODO: add usb service for other chips of esp32 which have USB device
 

--- a/rmk/src/ble/nrf/mod.rs
+++ b/rmk/src/ble/nrf/mod.rs
@@ -252,7 +252,14 @@ pub async fn initialize_nrf_ble_keyboard_and_run<
     // Flash and keymap configuration
     let flash = Flash::take(sd);
     let mut storage = Storage::new(flash, default_keymap, keyboard_config.storage_config).await;
-    let keymap = RefCell::new(KeyMap::new_from_storage(default_keymap, Some(&mut storage)).await);
+    let keymap = RefCell::new(
+        KeyMap::new_from_storage(
+            default_keymap,
+            Some(&mut storage),
+            keyboard_config.behavior_config,
+        )
+        .await,
+    );
 
     let mut buf: [u8; 128] = [0; 128];
 
@@ -304,11 +311,7 @@ pub async fn initialize_nrf_ble_keyboard_and_run<
     let keyboard_report_receiver = KEYBOARD_REPORT_CHANNEL.receiver();
 
     // Keyboard services
-    let mut keyboard = Keyboard::new(
-        &keymap,
-        &keyboard_report_sender,
-        keyboard_config.behavior_config,
-    );
+    let mut keyboard = Keyboard::new(&keymap, &keyboard_report_sender);
     #[cfg(not(feature = "_no_usb"))]
     let mut usb_device = KeyboardUsbDevice::new(usb_driver, keyboard_config.usb_config);
     let mut vial_service = VialService::new(&keymap, keyboard_config.vial_config);

--- a/rmk/src/combo.rs
+++ b/rmk/src/combo.rs
@@ -62,7 +62,7 @@ impl Combo {
         let action_idx = self.actions.iter().position(|&a| a == key_action);
         if let Some(i) = action_idx {
             self.state |= 1 << i;
-        } else {
+        } else if !self.done() {
             self.reset();
         }
         action_idx.is_some()

--- a/rmk/src/combo.rs
+++ b/rmk/src/combo.rs
@@ -11,6 +11,7 @@ pub(crate) const COMBO_MAX_LENGTH: usize = 4;
 pub struct Combo {
     pub(crate) actions: Vec<KeyAction, COMBO_MAX_LENGTH>,
     pub(crate) output: KeyAction,
+    pub(crate) layer: Option<u8>,
     state: u8,
 }
 
@@ -21,21 +22,41 @@ impl Default for Combo {
 }
 
 impl Combo {
-    pub fn new<I: IntoIterator<Item = KeyAction>>(actions: I, output: KeyAction) -> Self {
+    pub fn new<I: IntoIterator<Item = KeyAction>>(
+        actions: I,
+        output: KeyAction,
+        layer: Option<u8>,
+    ) -> Self {
         Self {
             actions: Vec::from_iter(actions),
             output,
+            layer,
             state: 0,
         }
     }
 
     pub fn empty() -> Self {
-        Self::new(Vec::<KeyAction, COMBO_MAX_LENGTH>::new(), KeyAction::No)
+        Self::new(
+            Vec::<KeyAction, COMBO_MAX_LENGTH>::new(),
+            KeyAction::No,
+            None,
+        )
     }
 
-    pub(crate) fn update(&mut self, key_action: KeyAction, key_event: KeyEvent) -> bool {
+    pub(crate) fn update(
+        &mut self,
+        key_action: KeyAction,
+        key_event: KeyEvent,
+        active_layer: u8,
+    ) -> bool {
         if !key_event.pressed || key_action == KeyAction::No {
             return false;
+        }
+
+        if let Some(layer) = self.layer {
+            if layer != active_layer {
+                return false;
+            }
         }
 
         let action_idx = self.actions.iter().position(|&a| a == key_action);

--- a/rmk/src/combo.rs
+++ b/rmk/src/combo.rs
@@ -1,6 +1,6 @@
 use heapless::Vec;
 
-use crate::{action::KeyAction, keyboard::KeyEvent};
+use crate::{action::KeyAction, event::KeyEvent};
 
 // Default number of macros
 pub(crate) const COMBO_MAX_NUM: usize = 8;

--- a/rmk/src/combo.rs
+++ b/rmk/src/combo.rs
@@ -2,31 +2,38 @@ use heapless::Vec;
 
 use crate::{action::KeyAction, event::KeyEvent};
 
-// Default number of macros
+// Max number of macros
 pub(crate) const COMBO_MAX_NUM: usize = 8;
-// Default size of macros
+// Max size of macros
 pub(crate) const COMBO_MAX_LENGTH: usize = 4;
 
-pub(crate) struct Combo {
+#[derive(Clone)]
+pub struct Combo {
     pub(crate) actions: Vec<KeyAction, COMBO_MAX_LENGTH>,
     pub(crate) output: KeyAction,
     state: u8,
 }
 
+impl Default for Combo {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 impl Combo {
-    pub fn new(actions: Vec<KeyAction, COMBO_MAX_LENGTH>, output: KeyAction) -> Self {
+    pub fn new<I: IntoIterator<Item = KeyAction>>(actions: I, output: KeyAction) -> Self {
         Self {
-            actions,
+            actions: Vec::from_iter(actions),
             output,
             state: 0,
         }
     }
 
     pub fn empty() -> Self {
-        Self::new(Vec::new(), KeyAction::No)
+        Self::new(Vec::<KeyAction, COMBO_MAX_LENGTH>::new(), KeyAction::No)
     }
 
-    pub fn update(&mut self, key_action: KeyAction, key_event: KeyEvent) -> bool {
+    pub(crate) fn update(&mut self, key_action: KeyAction, key_event: KeyEvent) -> bool {
         if !key_event.pressed || key_action == KeyAction::No {
             return false;
         }
@@ -40,19 +47,19 @@ impl Combo {
         action_idx.is_some()
     }
 
-    pub fn done(&self) -> bool {
+    pub(crate) fn done(&self) -> bool {
         self.started() && self.keys_pressed() == self.actions.len() as u32
     }
 
-    pub fn started(&self) -> bool {
+    pub(crate) fn started(&self) -> bool {
         self.state != 0
     }
 
-    pub fn keys_pressed(&self) -> u32 {
+    pub(crate) fn keys_pressed(&self) -> u32 {
         self.state.count_ones()
     }
 
-    pub fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         self.state = 0;
     }
 }

--- a/rmk/src/combo.rs
+++ b/rmk/src/combo.rs
@@ -1,0 +1,55 @@
+use heapless::Vec;
+
+use crate::action::KeyAction;
+
+// Default number of macros
+pub(crate) const COMBO_MAX_NUM: usize = 8;
+// Default size of macros
+pub(crate) const COMBO_MAX_LENGTH: usize = 4;
+
+pub(crate) struct Combo {
+    pub(crate) actions: Vec<KeyAction, COMBO_MAX_LENGTH>,
+    pub(crate) output: KeyAction,
+    state: u8,
+}
+
+impl Combo {
+    pub fn new(actions: Vec<KeyAction, COMBO_MAX_LENGTH>, output: KeyAction) -> Self {
+        Self {
+            actions,
+            output,
+            state: 0,
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self::new(Vec::new(), KeyAction::No)
+    }
+
+    pub fn update(&mut self, key_action: KeyAction) -> bool {
+        let action_idx = self.actions.iter().position(|&a| a == key_action);
+        if let Some(i) = action_idx {
+            self.state |= 1 << i;
+            true
+        } else {
+            self.reset();
+            false
+        }
+    }
+
+    pub fn done(&self) -> bool {
+        self.started() && self.keys_pressed() == self.actions.len() as u32
+    }
+
+    pub fn started(&self) -> bool {
+        self.state != 0
+    }
+
+    pub fn keys_pressed(&self) -> u32 {
+        self.state.count_ones()
+    }
+
+    pub fn reset(&mut self) {
+        self.state = 0;
+    }
+}

--- a/rmk/src/combo.rs
+++ b/rmk/src/combo.rs
@@ -2,9 +2,9 @@ use heapless::Vec;
 
 use crate::{action::KeyAction, event::KeyEvent};
 
-// Max number of macros
+// Max number of combos
 pub(crate) const COMBO_MAX_NUM: usize = 8;
-// Max size of macros
+// Max size of combos
 pub(crate) const COMBO_MAX_LENGTH: usize = 4;
 
 #[derive(Clone)]

--- a/rmk/src/combo.rs
+++ b/rmk/src/combo.rs
@@ -1,6 +1,6 @@
 use heapless::Vec;
 
-use crate::action::KeyAction;
+use crate::{action::KeyAction, keyboard::KeyEvent};
 
 // Default number of macros
 pub(crate) const COMBO_MAX_NUM: usize = 8;
@@ -26,15 +26,18 @@ impl Combo {
         Self::new(Vec::new(), KeyAction::No)
     }
 
-    pub fn update(&mut self, key_action: KeyAction) -> bool {
+    pub fn update(&mut self, key_action: KeyAction, key_event: KeyEvent) -> bool {
+        if !key_event.pressed || key_action == KeyAction::No {
+            return false;
+        }
+
         let action_idx = self.actions.iter().position(|&a| a == key_action);
         if let Some(i) = action_idx {
             self.state |= 1 << i;
-            true
         } else {
             self.reset();
-            false
         }
+        action_idx.is_some()
     }
 
     pub fn done(&self) -> bool {

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -3,6 +3,7 @@ mod esp_config;
 #[cfg(feature = "_nrf_ble")]
 mod nrf_config;
 
+use ::heapless::Vec;
 #[cfg(feature = "_esp_ble")]
 pub use esp_config::BleBatteryConfig;
 #[cfg(feature = "_nrf_ble")]
@@ -10,6 +11,8 @@ pub use nrf_config::BleBatteryConfig;
 
 use embassy_time::Duration;
 use embedded_hal::digital::OutputPin;
+
+use crate::combo::{Combo, COMBO_MAX_NUM};
 
 /// Internal configurations for RMK keyboard.
 pub struct RmkConfig<'a, O: OutputPin> {
@@ -46,6 +49,7 @@ pub struct BehaviorConfig {
     pub tri_layer: Option<[u8; 3]>,
     pub tap_hold: TapHoldConfig,
     pub one_shot: OneShotConfig,
+    pub combos: Vec<Combo, COMBO_MAX_NUM>,
 }
 
 /// Configurations for tap hold behavior

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -49,7 +49,7 @@ pub struct BehaviorConfig {
     pub tri_layer: Option<[u8; 3]>,
     pub tap_hold: TapHoldConfig,
     pub one_shot: OneShotConfig,
-    pub combos: Vec<Combo, COMBO_MAX_NUM>,
+    pub combo: CombosConfig,
 }
 
 /// Configurations for tap hold behavior
@@ -80,6 +80,21 @@ impl Default for OneShotConfig {
     fn default() -> Self {
         Self {
             timeout: Duration::from_secs(1),
+        }
+    }
+}
+
+/// Config for combo behavior
+pub struct CombosConfig {
+    pub combos: Vec<Combo, COMBO_MAX_NUM>,
+    pub timeout: Duration,
+}
+
+impl Default for CombosConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_millis(50),
+            combos: Vec::new(),
         }
     }
 }

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -353,8 +353,9 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
         key_event: KeyEvent,
     ) -> Option<KeyAction> {
         let mut is_combo_action = false;
+        let current_layer = self.keymap.borrow().get_activated_layer();
         for combo in self.keymap.borrow_mut().combos.iter_mut() {
-            is_combo_action |= combo.update(key_action, key_event);
+            is_combo_action |= combo.update(key_action, key_event, current_layer);
         }
 
         if key_event.pressed && is_combo_action {

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1,3 +1,4 @@
+use crate::combo::{Combo, COMBO_MAX_LENGTH};
 use crate::config::BehaviorConfig;
 use crate::event::{Event, KeyEvent};
 use crate::CONNECTION_STATE;
@@ -6,7 +7,7 @@ use crate::{
     hid::{ConnectionType, HidWriterWrapper},
     keyboard_macro::{MacroOperation, NUM_MACRO},
     keycode::{KeyCode, ModifierCombination},
-    keymap::{Combo, KeyMap, COMBO_MAX_LENGTH},
+    keymap::KeyMap,
     usb::descriptor::{CompositeReport, CompositeReportType, ViaReport},
     KEYBOARD_STATE,
 };

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -405,10 +405,12 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
         while let Some((action, event)) = self.combo_actions_buffer.pop_front() {
             self.process_key_action(action, event).await;
         }
+
         self.keymap
             .borrow_mut()
             .combos
             .iter_mut()
+            .filter(|combo| !combo.done())
             .for_each(Combo::reset);
     }
 

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -18,8 +18,6 @@ use embassy_sync::{
 };
 use embassy_time::{Instant, Timer};
 use heapless::{Deque, FnvIndexMap, Vec};
-use postcard::experimental::max_size::MaxSize;
-use serde::{Deserialize, Serialize};
 use usbd_hid::descriptor::KeyboardReport;
 
 pub const EVENT_CHANNEL_SIZE: usize = 32;
@@ -336,7 +334,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
         if !key_event.pressed {
             // Check key release only
             let mut is_mod = false;
-            if let KeyAction::Single(Action::Key(k)) = action {
+            if let KeyAction::Single(Action::Key(k)) = key_action {
                 if k.is_modifier() {
                     is_mod = true;
                 }
@@ -388,7 +386,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
                 self.combo_actions_buffer.clear();
             } else {
                 let timeout = embassy_time::Timer::after_millis(50);
-                match select(timeout, key_event_channel.receive()).await {
+                match select(timeout, KEY_EVENT_CHANNEL.receive()).await {
                     embassy_futures::select::Either::First(_) => self.dispatch_combos().await,
                     embassy_futures::select::Either::Second(event) => {
                         self.unprocessed_events.push(event).unwrap()

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -377,7 +377,8 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
             if next_action.is_some() {
                 self.combo_actions_buffer.clear();
             } else {
-                let timeout = embassy_time::Timer::after_millis(50);
+                let timeout =
+                    embassy_time::Timer::after(self.keymap.borrow().behavior.combo.timeout);
                 match select(timeout, KEY_EVENT_CHANNEL.receive()).await {
                     embassy_futures::select::Either::First(_) => self.dispatch_combos().await,
                     embassy_futures::select::Either::Second(event) => {

--- a/rmk/src/keycode.rs
+++ b/rmk/src/keycode.rs
@@ -995,6 +995,11 @@ impl KeyCode {
         KeyCode::Bootloader <= self && self <= KeyCode::AltRepeatKey
     }
 
+    /// Returns `true` if the keycode is a combo keycode
+    pub(crate) fn is_combo(self) -> bool {
+        KeyCode::ComboOn <= self && self <= KeyCode::ComboToggle
+    }
+
     /// Returns `true` if the keycode is a kb keycode
     pub(crate) fn is_kb(self) -> bool {
         KeyCode::Kb0 <= self && self <= KeyCode::Kb31

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -1,5 +1,6 @@
 use crate::{
     action::KeyAction,
+    combo::{Combo, COMBO_MAX_NUM},
     event::KeyEvent,
     keyboard_macro::{MacroOperation, MACRO_SPACE_SIZE},
     keycode::KeyCode,
@@ -7,58 +8,7 @@ use crate::{
     storage::Storage,
 };
 use embedded_storage_async::nor_flash::NorFlash;
-use heapless::Vec;
 use num_enum::FromPrimitive;
-
-pub(crate) const COMBO_MAX_NUM: usize = 8;
-pub(crate) const COMBO_MAX_LENGTH: usize = 4;
-
-pub(crate) struct Combo {
-    pub(crate) actions: Vec<KeyAction, COMBO_MAX_LENGTH>,
-    pub(crate) output: KeyAction,
-    state: u8,
-}
-
-impl Combo {
-    pub fn new(actions: Vec<KeyAction, COMBO_MAX_LENGTH>, output: KeyAction) -> Self {
-        Self {
-            actions,
-            output,
-            state: 0,
-        }
-    }
-
-    pub fn empty() -> Self {
-        Self::new(Vec::new(), KeyAction::No)
-    }
-
-    pub fn update(&mut self, key_action: KeyAction) -> bool {
-        let action_idx = self.actions.iter().position(|&a| a == key_action);
-        if let Some(i) = action_idx {
-            self.state |= 1 << i;
-            true
-        } else {
-            self.reset();
-            false
-        }
-    }
-
-    pub fn done(&self) -> bool {
-        self.started() && self.keys_pressed() == self.actions.len() as u32
-    }
-
-    pub fn started(&self) -> bool {
-        self.state != 0
-    }
-
-    pub fn keys_pressed(&self) -> u32 {
-        self.state.count_ones()
-    }
-
-    pub fn reset(&mut self) {
-        self.state = 0;
-    }
-}
 
 /// Keymap represents the stack of layers.
 ///

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -44,7 +44,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
         behavior: BehaviorConfig,
     ) -> Self {
         let mut combos: [Combo; COMBO_MAX_NUM] = Default::default();
-        for (i, combo) in behavior.combos.iter().enumerate() {
+        for (i, combo) in behavior.combo.combos.iter().enumerate() {
             combos[i] = combo.clone();
         }
         KeyMap {
@@ -66,7 +66,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
         // If the storage is initialized, read keymap from storage
         let mut macro_cache = [0; MACRO_SPACE_SIZE];
         let mut combos: [Combo; COMBO_MAX_NUM] = Default::default();
-        for (i, combo) in behavior.combos.iter().enumerate() {
+        for (i, combo) in behavior.combo.combos.iter().enumerate() {
             combos[i] = combo.clone();
         }
         if let Some(storage) = storage {

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -246,7 +246,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
         KeyAction::No
     }
 
-    fn get_activated_layer(&self) -> u8 {
+    pub(crate) fn get_activated_layer(&self) -> u8 {
         for (layer_idx, _) in self.layers.iter().enumerate().rev() {
             if self.layer_state[layer_idx] || layer_idx as u8 == self.default_layer {
                 return layer_idx as u8;

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -43,13 +43,17 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
         action_map: &'a mut [[[KeyAction; COL]; ROW]; NUM_LAYER],
         behavior: BehaviorConfig,
     ) -> Self {
+        let mut combos: [Combo; COMBO_MAX_NUM] = Default::default();
+        for (i, combo) in behavior.combos.iter().enumerate() {
+            combos[i] = combo.clone();
+        }
         KeyMap {
             layers: action_map,
             layer_state: [false; NUM_LAYER],
             default_layer: 0,
             layer_cache: [[0; COL]; ROW],
             macro_cache: [0; MACRO_SPACE_SIZE],
-            combos: [(); COMBO_MAX_NUM].map(|_| Combo::empty()),
+            combos,
             behavior,
         }
     }
@@ -61,7 +65,10 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
     ) -> Self {
         // If the storage is initialized, read keymap from storage
         let mut macro_cache = [0; MACRO_SPACE_SIZE];
-        let mut combos = [(); COMBO_MAX_NUM].map(|_| Combo::empty());
+        let mut combos: [Combo; COMBO_MAX_NUM] = Default::default();
+        for (i, combo) in behavior.combos.iter().enumerate() {
+            combos[i] = combo.clone();
+        }
         if let Some(storage) = storage {
             if {
                 Ok(())

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -47,6 +47,7 @@ use embedded_hal_async::digital::Wait;
 use embedded_storage::nor_flash::NorFlash;
 pub use flash::EmptyFlashWrapper;
 use futures::pin_mut;
+pub use heapless;
 use keyboard::{communication_task, Keyboard, KeyboardReportMessage, KEYBOARD_REPORT_CHANNEL};
 pub use keyboard::{EVENT_CHANNEL, EVENT_CHANNEL_SIZE, REPORT_CHANNEL_SIZE};
 use keymap::KeyMap;

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -60,6 +60,7 @@ use {embedded_storage_async::nor_flash::NorFlash as AsyncNorFlash, storage::Stor
 pub mod action;
 #[cfg(feature = "_ble")]
 pub mod ble;
+mod combo;
 pub mod config;
 pub mod debounce;
 pub mod direct_pin;

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -60,7 +60,7 @@ use {embedded_storage_async::nor_flash::NorFlash as AsyncNorFlash, storage::Stor
 pub mod action;
 #[cfg(feature = "_ble")]
 pub mod ble;
-mod combo;
+pub mod combo;
 pub mod config;
 pub mod debounce;
 pub mod direct_pin;

--- a/rmk/src/split/central.rs
+++ b/rmk/src/split/central.rs
@@ -302,6 +302,7 @@ pub async fn initialize_usb_split_central_and_run<
             KeyMap::<TOTAL_ROW, TOTAL_COL, NUM_LAYER>::new_from_storage(
                 default_keymap,
                 Some(&mut s),
+                keyboard_config.behavior_config,
             )
             .await,
         );
@@ -309,18 +310,20 @@ pub async fn initialize_usb_split_central_and_run<
     };
 
     #[cfg(all(not(feature = "_nrf_ble"), feature = "_no_external_storage"))]
-    let keymap = RefCell::new(KeyMap::<TOTAL_ROW, TOTAL_COL, NUM_LAYER>::new(default_keymap).await);
+    let keymap = RefCell::new(
+        KeyMap::<TOTAL_ROW, TOTAL_COL, NUM_LAYER>::new(
+            default_keymap,
+            keyboard_config.behavior_config,
+        )
+        .await,
+    );
 
     let keyboard_report_sender = KEYBOARD_REPORT_CHANNEL.sender();
     let keyboard_report_receiver = KEYBOARD_REPORT_CHANNEL.receiver();
 
     // Create keyboard services and devices
     let (mut keyboard, mut usb_device, mut vial_service, mut light_service) = (
-        Keyboard::new(
-            &keymap,
-            &keyboard_report_sender,
-            keyboard_config.behavior_config,
-        ),
+        Keyboard::new(&keymap, &keyboard_report_sender),
         KeyboardUsbDevice::new(usb_driver, keyboard_config.usb_config),
         VialService::new(&keymap, keyboard_config.vial_config),
         LightService::from_config(keyboard_config.light_config),

--- a/rmk/src/storage/mod.rs
+++ b/rmk/src/storage/mod.rs
@@ -187,7 +187,11 @@ impl Value<'_> for StorageData {
                     );
                 }
                 BigEndian::write_u16(&mut buffer[9..11], to_via_keycode(combo.output));
-                Ok(11)
+                buffer[11] = match combo.layer {
+                    Some(layer) => layer.to_be(),
+                    None => u8::MAX,
+                };
+                Ok(12)
             }
             StorageData::ConnectionType(ty) => {
                 buffer[0] = StorageKeys::ConnectionType as u8;
@@ -273,7 +277,7 @@ impl Value<'_> for StorageData {
                     Ok(StorageData::MacroData(buf))
                 }
                 StorageKeys::ComboData => {
-                    if buffer.len() < 11 {
+                    if buffer.len() < 12 {
                         return Err(SerializationError::InvalidData);
                     }
                     let mut actions = [KeyAction::No; 4];
@@ -282,10 +286,12 @@ impl Value<'_> for StorageData {
                             from_via_keycode(BigEndian::read_u16(&buffer[1 + i * 2..3 + i * 2]));
                     }
                     let output = from_via_keycode(BigEndian::read_u16(&buffer[9..11]));
+                    let layer = u8::from_be(buffer[11]);
                     Ok(StorageData::ComboData(ComboData {
                         idx: 0,
                         actions,
                         output,
+                        layer: (layer != u8::MAX).then_some(layer),
                     }))
                 }
                 StorageKeys::ConnectionType => Ok(StorageData::ConnectionType(buffer[1])),
@@ -356,6 +362,7 @@ pub(crate) struct ComboData {
     pub(crate) idx: usize,
     pub(crate) actions: [KeyAction; COMBO_MAX_LENGTH],
     pub(crate) output: KeyAction,
+    pub(crate) layer: Option<u8>,
 }
 
 pub(crate) struct Storage<
@@ -697,7 +704,7 @@ impl<F: AsyncNorFlash, const ROW: usize, const COL: usize, const NUM_LAYER: usiz
                 for &action in combo.actions.iter().filter(|&&a| a != KeyAction::No) {
                     let _ = actions.push(action);
                 }
-                combos[i] = Combo::new(actions, combo.output);
+                combos[i] = Combo::new(actions, combo.output, combo.layer);
             }
         }
 

--- a/rmk/src/storage/mod.rs
+++ b/rmk/src/storage/mod.rs
@@ -9,6 +9,7 @@ use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;
 use embedded_storage::nor_flash::NorFlash;
 use embedded_storage_async::nor_flash::NorFlash as AsyncNorFlash;
+use heapless::Vec;
 use sequential_storage::{
     cache::NoCache,
     map::{fetch_all_items, fetch_item, store_item, SerializationError, Value},
@@ -17,11 +18,11 @@ use sequential_storage::{
 #[cfg(feature = "_nrf_ble")]
 use {crate::ble::nrf::bonder::BondInfo, core::mem};
 
-use crate::keyboard_macro::MACRO_SPACE_SIZE;
 use crate::{
     action::KeyAction,
     via::keycode_convert::{from_via_keycode, to_via_keycode},
 };
+use crate::{keyboard_macro::MACRO_SPACE_SIZE, keymap::Combo};
 
 use self::eeconfig::EeKeymapConfig;
 
@@ -57,6 +58,8 @@ pub(crate) enum FlashOperationMessage {
     },
     // Current saved connection type
     ConnectionType(u8),
+    // Write combo
+    WriteCombo(ComboData),
 }
 
 #[repr(u32)]
@@ -68,6 +71,7 @@ pub(crate) enum StorageKeys {
     LayoutConfig,
     KeymapKeys,
     MacroData,
+    ComboData,
     ConnectionType,
     #[cfg(feature = "_nrf_ble")]
     ActiveBleProfile = 0xEE,
@@ -85,6 +89,7 @@ impl StorageKeys {
             4 => Some(StorageKeys::LayoutConfig),
             5 => Some(StorageKeys::KeymapKeys),
             6 => Some(StorageKeys::MacroData),
+            7 => Some(StorageKeys::ComboData),
             #[cfg(feature = "_nrf_ble")]
             0xEF => Some(StorageKeys::BleBondInfo),
             _ => None,
@@ -99,6 +104,7 @@ pub(crate) enum StorageData {
     KeymapConfig(EeKeymapConfig),
     KeymapKey(KeymapKey),
     MacroData([u8; MACRO_SPACE_SIZE]),
+    ComboData(ComboData),
     ConnectionType(u8),
     #[cfg(feature = "_nrf_ble")]
     BondInfo(BondInfo),
@@ -161,6 +167,20 @@ impl Value<'_> for StorageData {
                 buffer[0] = StorageKeys::MacroData as u8;
                 buffer[1..MACRO_SPACE_SIZE + 1].copy_from_slice(d);
                 Ok(MACRO_SPACE_SIZE + 1)
+            }
+            StorageData::ComboData(combo) => {
+                if buffer.len() < 11 {
+                    return Err(SerializationError::BufferTooSmall);
+                }
+                buffer[0] = StorageKeys::ComboData as u8;
+                for i in 0..4 {
+                    BigEndian::write_u16(
+                        &mut buffer[1 + i * 2..3 + i * 2],
+                        to_via_keycode(combo.actions[i]),
+                    );
+                }
+                BigEndian::write_u16(&mut buffer[9..11], to_via_keycode(combo.output));
+                Ok(11)
             }
             StorageData::ConnectionType(ty) => {
                 buffer[0] = StorageKeys::ConnectionType as u8;
@@ -245,6 +265,22 @@ impl Value<'_> for StorageData {
                     buf.copy_from_slice(&buffer[1..MACRO_SPACE_SIZE + 1]);
                     Ok(StorageData::MacroData(buf))
                 }
+                StorageKeys::ComboData => {
+                    if buffer.len() < 11 {
+                        return Err(SerializationError::InvalidData);
+                    }
+                    let mut actions = [KeyAction::No; 4];
+                    for i in 0..4 {
+                        actions[i] =
+                            from_via_keycode(BigEndian::read_u16(&buffer[1 + i * 2..3 + i * 2]));
+                    }
+                    let output = from_via_keycode(BigEndian::read_u16(&buffer[9..11]));
+                    Ok(StorageData::ComboData(ComboData {
+                        idx: 0,
+                        actions,
+                        output,
+                    }))
+                }
                 StorageKeys::ConnectionType => Ok(StorageData::ConnectionType(buffer[1])),
                 #[cfg(feature = "_nrf_ble")]
                 StorageKeys::BleBondInfo => {
@@ -274,6 +310,7 @@ impl StorageData {
                 panic!("To get storage key for KeymapKey, use `get_keymap_key` instead");
             }
             StorageData::MacroData(_) => StorageKeys::MacroData as u32,
+            StorageData::ComboData(_) => StorageKeys::ComboData as u32,
             StorageData::ConnectionType(_) => StorageKeys::ConnectionType as u32,
             #[cfg(feature = "_nrf_ble")]
             StorageData::BondInfo(b) => get_bond_info_key(b.slot_num),
@@ -302,6 +339,14 @@ pub(crate) struct KeymapKey {
     col: usize,
     layer: usize,
     action: KeyAction,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub(crate) struct ComboData {
+    pub(crate) idx: u8,
+    pub(crate) actions: [KeyAction; 4],
+    pub(crate) output: KeyAction,
 }
 
 pub(crate) struct Storage<
@@ -497,6 +542,17 @@ impl<F: AsyncNorFlash, const ROW: usize, const COL: usize, const NUM_LAYER: usiz
                     )
                     .await
                 }
+                FlashOperationMessage::WriteCombo(combo) => {
+                    store_item(
+                        &mut self.flash,
+                        self.storage_range.clone(),
+                        &mut storage_cache,
+                        &mut self.buffer,
+                        &(0x2000 + combo.idx as u32),
+                        &StorageData::ComboData(combo),
+                    )
+                    .await
+                }
                 FlashOperationMessage::ConnectionType(ty) => {
                     store_item(
                         &mut self.flash,
@@ -608,6 +664,30 @@ impl<F: AsyncNorFlash, const ROW: usize, const COL: usize, const NUM_LAYER: usiz
         if let Some(StorageData::MacroData(data)) = read_data {
             // Send data back
             macro_cache.copy_from_slice(&data);
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn read_combos(&mut self, combos: &mut [Combo]) -> Result<(), ()> {
+        for i in 0..combos.len() {
+            let read_data = fetch_item::<u32, StorageData, _>(
+                &mut self.flash,
+                self.storage_range.clone(),
+                &mut NoCache::new(),
+                &mut self.buffer,
+                &(0x2000 + i as u32),
+            )
+            .await
+            .map_err(|e| print_storage_error::<F>(e))?;
+
+            if let Some(StorageData::ComboData(combo)) = read_data {
+                let mut actions = Vec::<_, 4>::new();
+                for &action in combo.actions.iter().filter(|&&a| a != KeyAction::No) {
+                    let _ = actions.push(action);
+                }
+                combos[i] = Combo::new(actions, combo.output);
+            }
         }
 
         Ok(())

--- a/rmk/src/storage/mod.rs
+++ b/rmk/src/storage/mod.rs
@@ -1,7 +1,7 @@
 mod eeconfig;
 pub mod nor_flash;
 
-use crate::config::StorageConfig;
+use crate::{combo::Combo, config::StorageConfig};
 use byteorder::{BigEndian, ByteOrder};
 use core::fmt::Debug;
 use core::ops::Range;
@@ -18,11 +18,11 @@ use sequential_storage::{
 #[cfg(feature = "_nrf_ble")]
 use {crate::ble::nrf::bonder::BondInfo, core::mem};
 
+use crate::keyboard_macro::MACRO_SPACE_SIZE;
 use crate::{
     action::KeyAction,
     via::keycode_convert::{from_via_keycode, to_via_keycode},
 };
-use crate::{keyboard_macro::MACRO_SPACE_SIZE, keymap::Combo};
 
 use self::eeconfig::EeKeymapConfig;
 

--- a/rmk/src/via/keycode_convert.rs
+++ b/rmk/src/via/keycode_convert.rs
@@ -15,6 +15,8 @@ pub(crate) fn to_via_keycode(key_action: KeyAction) -> u16 {
                     k as u16 & 0xFF | 0x7700
                 } else if k.is_user() {
                     k as u16 & 0xF | 0x7E00
+                } else if k.is_combo() {
+                    k as u16 & 0xF | 0x7C50
                 } else {
                     k as u16
                 }
@@ -153,6 +155,7 @@ pub(crate) fn from_via_keycode(via_keycode: u16) -> KeyAction {
             KeyAction::No
         }
         0x7700..=0x770F => {
+            // Macro
             let keycode = via_keycode & 0xFF | 0x500;
             KeyAction::Single(Action::Key(KeyCode::from_primitive(keycode)))
         }
@@ -160,6 +163,11 @@ pub(crate) fn from_via_keycode(via_keycode: u16) -> KeyAction {
             // TODO: backlight and rgb configuration
             warn!("Backlight and RGB configuration key not supported");
             KeyAction::No
+        }
+        0x7C50..=0x7C52 => {
+            // Combo
+            let keycode = via_keycode & 0xFF | 0x750;
+            KeyAction::Single(Action::Key(KeyCode::from_primitive(keycode)))
         }
         0x7C00..=0x7C5F => {
             // TODO: Reset/GESC/Space Cadet/Haptic/Auto shift(AS)/Dynamic macro

--- a/rmk/src/via/keycode_convert.rs
+++ b/rmk/src/via/keycode_convert.rs
@@ -327,6 +327,13 @@ mod test {
             ),
             from_via_keycode(via_keycode)
         );
+
+        // ComboOff
+        let via_keycode = 0x7C51;
+        assert_eq!(
+            KeyAction::Single(Action::Key(KeyCode::ComboOff)),
+            from_via_keycode(via_keycode)
+        );
     }
 
     #[test]
@@ -416,5 +423,9 @@ mod test {
             ModifierCombination::new_from(false, false, true, true, true),
         );
         assert_eq!(0x2704, to_via_keycode(a));
+
+        // ComboOff
+        let a = KeyAction::Single(Action::Key(KeyCode::ComboOff));
+        assert_eq!(0x7C51, to_via_keycode(a));
     }
 }

--- a/rmk/src/via/process.rs
+++ b/rmk/src/via/process.rs
@@ -1,6 +1,6 @@
 use super::{protocol::*, vial::process_vial};
-use crate::config::VialConfig;
 use crate::{
+    config::VialConfig,
     hid::{HidError, HidReaderWriterWrapper},
     keyboard_macro::{MACRO_SPACE_SIZE, NUM_MACRO},
     keymap::KeyMap,

--- a/rmk/src/via/process.rs
+++ b/rmk/src/via/process.rs
@@ -313,12 +313,15 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
             ViaCommand::DynamicKeymapSetEncoder => {
                 warn!("Keymap set encoder -- not supported");
             }
-            ViaCommand::Vial => process_vial(
-                report,
-                self.vial_config.vial_keyboard_id,
-                self.vial_config.vial_keyboard_def,
-                keymap,
-            ),
+            ViaCommand::Vial => {
+                process_vial(
+                    report,
+                    self.vial_config.vial_keyboard_id,
+                    self.vial_config.vial_keyboard_def,
+                    keymap,
+                )
+                .await
+            }
             ViaCommand::Unhandled => {
                 info!("Unknown cmd: {}", report.output_data);
                 report.input_data[0] = ViaCommand::Unhandled as u8

--- a/rmk/src/via/vial.rs
+++ b/rmk/src/via/vial.rs
@@ -183,6 +183,7 @@ pub(crate) async fn process_vial<'a, const ROW: usize, const COL: usize, const N
                             idx: real_idx,
                             actions,
                             output,
+                            layer: combos[real_idx].layer,
                         }))
                         .await;
                 }

--- a/rmk/src/via/vial.rs
+++ b/rmk/src/via/vial.rs
@@ -177,7 +177,7 @@ pub(crate) async fn process_vial<'a, const ROW: usize, const COL: usize, const N
                     }
                     FLASH_CHANNEL
                         .send(FlashOperationMessage::WriteCombo(ComboData {
-                            idx: combo_idx as u8,
+                            idx: combo_idx,
                             actions,
                             output,
                         }))

--- a/rmk/src/via/vial.rs
+++ b/rmk/src/via/vial.rs
@@ -183,7 +183,6 @@ pub(crate) async fn process_vial<'a, const ROW: usize, const COL: usize, const N
                             idx: real_idx,
                             actions,
                             output,
-                            layer: combos[real_idx].layer,
                         }))
                         .await;
                 }

--- a/rmk/src/via/vial.rs
+++ b/rmk/src/via/vial.rs
@@ -5,7 +5,8 @@ use num_enum::FromPrimitive;
 
 use crate::{
     action::KeyAction,
-    keymap::{KeyMap, COMBO_MAX_NUM},
+    combo::COMBO_MAX_NUM,
+    keymap::KeyMap,
     storage::{ComboData, FlashOperationMessage, FLASH_CHANNEL},
     usb::descriptor::ViaReport,
     via::keycode_convert::{from_via_keycode, to_via_keycode},


### PR DESCRIPTION
Closes #117

- [x] Implement basic functionality
- [x] Add configuration options
- [x] Add Vial support
- [ ] Move behind a feature flag (maybe)
- [x] Support `COMBO_{ON/OFF/TOGGLE}` keycodes
- [x] Allow limiting a combo to a specific layer
- [ ] [Layer independent combos](https://docs.qmk.fm/features/combo#layer-independent-combos)
- [ ] Update relevant documentation
- [x] Save combos in flash
- [ ] Add `cmb!` macro for easy combo declaration in rust