### PR TITLE
fix(direct-pins): rust cannot infer the specific type of options for shadowing variables

### DIFF
--- a/examples/use_config/rp2040_direct_pin/keyboard.toml
+++ b/examples/use_config/rp2040_direct_pin/keyboard.toml
@@ -16,7 +16,7 @@ direct_pin_low_active = true
 direct_pins = [
     ["PIN_0", "PIN_1", "PIN_2"],
     ["PIN_3", "PIN_4", "PIN_5"],
-    ["PIN_6", "_", "PIN_8"],
+    ["PIN_6", "_", "_"],
     ["PIN_9", "PIN_10", "_"],
 ]
 
@@ -28,7 +28,7 @@ keymap = [
     [
         ["A", "B", "C"],
         ["Kc1", "Kc2", "Kc3"],
-        ["LCtrl", "_", "LShift"],
+        ["LCtrl", "_", "_"],
         ["OSL(1)", "LT(2, Kc9)", "_"]
     ],
     [

--- a/rmk-macro/src/gpio_config.rs
+++ b/rmk-macro/src/gpio_config.rs
@@ -61,22 +61,15 @@ pub(crate) fn convert_direct_pins_to_initializers(
         let pin_initializers = row_pins
             .into_iter()
             .map(|p| {
-                (
-                    p.clone(),
-                    if p != "_" {
-                        // Convert pin to Some(pin) when it's not "_"
-                        let pin = convert_gpio_str_to_input_pin(chip, p, async_matrix, low_active);
-                        quote! { Some(#pin) }
-                    } else {
-                        // Use None for "_" pins
-                        quote! { None }
-                    },
-                )
-            })
-            .map(|(p, ts)| {
-                let ident_name = format_ident!("{}_{}", p.to_lowercase(), row_idx);
+                let ident_name = format_ident!("{}_{}_{}", p.to_lowercase(), row_idx, col_idents.len());
                 col_idents.push(ident_name.clone());
-                quote! { let #ident_name = #ts; }
+                if p != "_" {
+                    // Convert pin to Some(pin) when it's not "_"
+                    let pin = convert_gpio_str_to_input_pin(chip, p, async_matrix, low_active);
+                    quote! { let #ident_name = Some(#pin); }
+                } else {
+                    quote! { let #ident_name = None; }
+                }
             });
         // Extend initializers with current row's pin initializations
         initializers.extend(pin_initializers);


### PR DESCRIPTION
Support multi "_" GPIO in each row in direct-pins matrix.
Related issue and PR: #140 and #160 