### PR TITLE
Feat/joystick

### DIFF
--- a/rmk-macro/src/analog.rs
+++ b/rmk-macro/src/analog.rs
@@ -1,0 +1,74 @@
+use proc_macro2::TokenStream;
+use quote::{ quote, format_ident };
+use crate::keyboard_config::{ KeyboardConfig, CommunicationConfig };
+
+pub fn expand_analog(keyboard_config: &KeyboardConfig) -> (TokenStream, TokenStream) {
+    let mut config = TokenStream::new();
+    let mut task = TokenStream::new();
+    let mut pins = vec!();
+    let mut channels = vec!();
+    let mut channel_sep = vec!(0usize);
+    let mut pin_channels = vec!();
+    match &keyboard_config.communication {
+        CommunicationConfig::Ble(ble) | CommunicationConfig::Both(_, ble) => {
+            if ble.enabled {
+                if let Some(adc_pin) = ble.battery_adc_pin.clone() {
+                    let adc_pin_def = if adc_pin == "vddh" {
+                        quote! { ::embassy_nrf::saadc::VddhDiv5Input }
+                    } else {
+                        let adc_pin_ident = format_ident!("{}", adc_pin);
+                        quote! { p.#adc_pin_ident.degrade_saadc() }
+                    };
+                    let channel_cfg = format_ident!("channel_cfg_{}", channel_sep.len());
+                    pins.push(quote! {
+                        // use ::embassy_nrf::saadc::Input as _;
+                        // Then we initialize the ADC. We are only using one channel in this example.
+                        let #channel_cfg = ::embassy_nrf::saadc::ChannelConfig::single_ended(#adc_pin_def);
+                    });
+                    pin_channels.push(channel_cfg);
+                    channels.push(quote!{ ::rmk::ble::nrf::BLE_BATTERY_CHANNEL.try_send });
+                    channel_sep.push(channel_sep.last().unwrap() + 1);
+                }
+            }
+        }
+        _ => {}
+    };
+    let rev_side = channel_sep.iter().rev().collect::<Vec<_>>();
+    let range = rev_side[1..].into_iter().rev().zip(channel_sep[1..].into_iter());
+    let send_expr = range.zip(channels).map(|((l, r), c)| {
+        let idx = **l..*r;
+        quote!{
+            match #c([#(buf[#idx]), *]) {
+                Ok(_) => break,
+                Err(e) => warn!("failed to send analog info between {}, {}", #l, #r),
+            }
+        }
+    });
+    
+    let buf_size = channel_sep.last();
+    
+    config.extend(quote! {
+        let run_analog_monitor = {
+           #(#pins) *
+            let config = ::embassy_nrf::saadc::Config::default();
+            ::embassy_nrf::interrupt::SAADC.set_priority(::embassy_nrf::interrupt::Priority::P3);
+            let mut saadc = ::embassy_nrf::saadc::Saadc::new(p.SAADC, Irqs, config, [#(#pin_channels), *]);
+            // Wait for ADC calibration.
+            saadc.calibrate().await;
+            
+            || async move {
+                let mut buf = [0i16; #buf_size];
+                loop {
+                    saadc.sample(&mut buf).await;
+                    info!("saadc sample: {}", buf);
+                    #(#send_expr)*
+                }
+            }
+        };
+    });
+
+    task.extend(quote!{
+        run_analog_monitor()
+    });
+    (config, task)
+}

--- a/rmk-macro/src/analog.rs
+++ b/rmk-macro/src/analog.rs
@@ -1,11 +1,10 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{TokenStream, Ident};
 use quote::{ quote, format_ident };
 use crate::keyboard_config::{ KeyboardConfig, CommunicationConfig };
 
-pub fn expand_analog(keyboard_config: &KeyboardConfig) -> (TokenStream, TokenStream) {
+pub fn expand_analog(keyboard_config: &KeyboardConfig, channel_config:Vec<(Vec<TokenStream>, Ident)>) -> (TokenStream, TokenStream) {
     let mut config = TokenStream::new();
     let mut task = TokenStream::new();
-    let mut pins = vec!();
     let mut channels = vec!();
     let mut channel_sep = vec!(0usize);
     let mut pin_channels = vec!();
@@ -20,27 +19,30 @@ pub fn expand_analog(keyboard_config: &KeyboardConfig) -> (TokenStream, TokenStr
                         quote! { p.#adc_pin_ident.degrade_saadc() }
                     };
                     let channel_cfg = format_ident!("channel_cfg_{}", channel_sep.len());
-                    pins.push(quote! {
-                        // use ::embassy_nrf::saadc::Input as _;
-                        // Then we initialize the ADC. We are only using one channel in this example.
-                        let #channel_cfg = ::embassy_nrf::saadc::ChannelConfig::single_ended(#adc_pin_def);
-                    });
-                    pin_channels.push(channel_cfg);
-                    channels.push(quote!{ ::rmk::ble::nrf::BLE_BATTERY_CHANNEL.try_send });
+                    pin_channels.push(quote!{ ::embassy_nrf::saadc::ChannelConfig::single_ended(#adc_pin_def) });
+                    channels.push(quote!{ ::rmk::ble::nrf::BLE_BATTERY_CHANNEL });
                     channel_sep.push(channel_sep.last().unwrap() + 1);
                 }
             }
         }
         _ => {}
     };
+
+    channel_config.into_iter().for_each(|(mut channel_config, channel_ident)| {
+        channel_sep.push(channel_sep.last().unwrap() + channel_config.len());
+        pin_channels.append(&mut channel_config);
+        channels.push(quote!{ #channel_ident });
+    });
+    
     let rev_side = channel_sep.iter().rev().collect::<Vec<_>>();
     let range = rev_side[1..].into_iter().rev().zip(channel_sep[1..].into_iter());
     let send_expr = range.zip(channels).map(|((l, r), c)| {
         let idx = **l..*r;
         quote!{
-            match #c([#(buf[#idx]), *]) {
-                Ok(_) => break,
-                Err(e) => warn!("failed to send analog info between {}, {}", #l, #r),
+            if !#c.is_full() {
+                if let Err(e) = #c.try_send([#(buf[#idx]), *]) {
+                    warn!("failed to send analog info between {}, {}, because {}", #l, #r, e);
+                }
             }
         }
     });
@@ -49,7 +51,6 @@ pub fn expand_analog(keyboard_config: &KeyboardConfig) -> (TokenStream, TokenStr
     
     config.extend(quote! {
         let run_analog_monitor = {
-           #(#pins) *
             let config = ::embassy_nrf::saadc::Config::default();
             ::embassy_nrf::interrupt::SAADC.set_priority(::embassy_nrf::interrupt::Priority::P3);
             let mut saadc = ::embassy_nrf::saadc::Saadc::new(p.SAADC, Irqs, config, [#(#pin_channels), *]);
@@ -59,8 +60,10 @@ pub fn expand_analog(keyboard_config: &KeyboardConfig) -> (TokenStream, TokenStr
             || async move {
                 let mut buf = [0i16; #buf_size];
                 loop {
+                    //info!("start to sample!");
                     saadc.sample(&mut buf).await;
-                    info!("saadc sample: {}", buf);
+                    
+                    //info!("saadc sample: {}", buf);
                     #(#send_expr)*
                 }
             }

--- a/rmk-macro/src/ble.rs
+++ b/rmk-macro/src/ble.rs
@@ -35,12 +35,12 @@ pub(crate) fn expand_ble_config(keyboard_config: &KeyboardConfig) -> (TokenStrea
                 // Adc config
                 if let Some(adc_pin) = ble.battery_adc_pin.clone() {
                     // Tokens for adc pin
-                    let adc_pin_def = if adc_pin == "vddh" {
+                    /*let adc_pin_def = if adc_pin == "vddh" {
                         quote! { ::embassy_nrf::saadc::VddhDiv5Input }
                     } else {
                         let adc_pin_ident = format_ident!("{}", adc_pin);
                         quote! {p.#adc_pin_ident.degrade_saadc()}
-                    };
+                    };*/
 
                     // Adc divider
                     if adc_pin == "vddh" {
@@ -65,8 +65,7 @@ pub(crate) fn expand_ble_config(keyboard_config: &KeyboardConfig) -> (TokenStrea
                             }
                         }
                     };
-
-                    ble_config_tokens.extend(quote! {
+                    /*ble_config_tokens.extend(quote! {
                         use ::embassy_nrf::saadc::Input as _;
                         // Then we initialize the ADC. We are only using one channel in this example.
                         let config = ::embassy_nrf::saadc::Config::default();
@@ -76,7 +75,7 @@ pub(crate) fn expand_ble_config(keyboard_config: &KeyboardConfig) -> (TokenStrea
                         // Wait for ADC calibration.
                         saadc.calibrate().await;
                         let saadc_option = Some(saadc);
-                    });
+                    });*/
                 } else {
                     ble_config_tokens.extend(quote! {
                         let saadc_option: ::core::option::Option<::embassy_nrf::saadc::Saadc<'_, 1>> = None;
@@ -84,7 +83,7 @@ pub(crate) fn expand_ble_config(keyboard_config: &KeyboardConfig) -> (TokenStrea
                         let adc_divider_total = 1;
                     });
                 };
-
+                
                 if let Some(charging_state_config) = ble.charge_state.clone() {
                     let charging_state_pin = format_ident!("{}", charging_state_config.pin);
                     let low_active = charging_state_config.low_active;
@@ -129,7 +128,8 @@ pub(crate) fn expand_ble_config(keyboard_config: &KeyboardConfig) -> (TokenStrea
 
                 ble_config_tokens.extend(
                     quote! {
-                        let ble_battery_config = ::rmk::config::BleBatteryConfig::new(is_charging_pin, charging_state_low_active, charge_led_pin, charge_led_low_active, saadc_option, adc_divider_measured, adc_divider_total);
+                        // let ble_battery_config = ::rmk::config::BleBatteryConfig::new(is_charging_pin, charging_state_low_active, charge_led_pin, charge_led_low_active, saadc_option, adc_divider_measured, adc_divider_total);
+                        let ble_battery_config = ::rmk::config::BleBatteryConfig::new(is_charging_pin, charging_state_low_active, charge_led_pin, charge_led_low_active, adc_divider_measured, adc_divider_total);
                     }
                 );
 

--- a/rmk-macro/src/chip_init.rs
+++ b/rmk-macro/src/chip_init.rs
@@ -21,20 +21,24 @@ pub(crate) fn chip_init_default(chip: &ChipModel) -> TokenStream2 {
                 quote! {}
             };
             quote! {
-                    use embassy_nrf::interrupt::InterruptExt;
-                    let mut config = ::embassy_nrf::config::Config::default();
-                    // config.hfclk_source = ::embassy_nrf::config::HfclkSource::ExternalXtal;
-                    // config.lfclk_source = ::embassy_nrf::config::LfclkSource::ExternalXtal;
-                    config.gpiote_interrupt_priority = ::embassy_nrf::interrupt::Priority::P3;
-                    config.time_interrupt_priority = ::embassy_nrf::interrupt::Priority::P3;
-                    #usb_related_config
-                    ::embassy_nrf::interrupt::POWER_CLOCK.set_priority(::embassy_nrf::interrupt::Priority::P2);
-                    let p = ::embassy_nrf::init(config);
-                    // Disable external HF clock by default, reduce power consumption
-                    // let clock: ::embassy_nrf::pac::CLOCK = unsafe { ::core::mem::transmute(()) };
-                    // info!("Enabling ext hfosc...");
-                    // clock.tasks_hfclkstart.write(|w| unsafe { w.bits(1) });
-                    // while clock.events_hfclkstarted.read().bits() != 1 {}
+                use embassy_nrf::{ interrupt::InterruptExt, config::Reg0Voltage};
+                let mut config = ::embassy_nrf::config::Config::default();
+                
+                // https://github.com/embassy-rs/embassy/issues/3134
+                config.dcdc.reg0 = true;
+                config.dcdc.reg0_voltage = Some(Reg0Voltage::_3v3);
+                // config.hfclk_source = ::embassy_nrf::config::HfclkSource::ExternalXtal;
+                // config.lfclk_source = ::embassy_nrf::config::LfclkSource::ExternalXtal;
+                config.gpiote_interrupt_priority = ::embassy_nrf::interrupt::Priority::P3;
+                config.time_interrupt_priority = ::embassy_nrf::interrupt::Priority::P3;
+                #usb_related_config
+                ::embassy_nrf::interrupt::POWER_CLOCK.set_priority(::embassy_nrf::interrupt::Priority::P2);
+                let p = ::embassy_nrf::init(config);
+                // Disable external HF clock by default, reduce power consumption
+                // let clock: ::embassy_nrf::pac::CLOCK = unsafe { ::core::mem::transmute(()) };
+                // info!("Enabling ext hfosc...");
+                // clock.tasks_hfclkstart.write(|w| unsafe { w.bits(1) });
+                // while clock.events_hfclkstarted.read().bits() != 1 {}
             }
         }
         ChipSeries::Rp2040 => {

--- a/rmk-macro/src/config/mod.rs
+++ b/rmk-macro/src/config/mod.rs
@@ -186,6 +186,8 @@ pub struct SplitBoardConfig {
     /// Serial config, the vector length should be 1 for peripheral
     pub serial: Option<Vec<SerialConfig>>,
     pub matrix: MatrixConfig,
+    /// Joystick
+    pub joystick: Option<Vec<JoystickConfig>>,
 }
 
 /// Serial port config
@@ -194,6 +196,14 @@ pub struct SerialConfig {
     pub instance: String,
     pub tx_pin: String,
     pub rx_pin: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct JoystickConfig {
+    pub instance: String,
+    pub axis: [String; 2],
+    pub dead: Option<[u8; 2]>,
+    pub transform: Option<[[i8; 2]; 2]>
 }
 
 /// Duration in milliseconds

--- a/rmk-macro/src/joystick.rs
+++ b/rmk-macro/src/joystick.rs
@@ -1,0 +1,78 @@
+//! Joystick
+//!
+
+use quote::{format_ident, quote};
+use crate::{config::JoystickConfig, ChipModel, ChipSeries};
+
+pub(crate) fn expand_joystick(
+    chip: &ChipModel,
+    joystick_config: Vec<JoystickConfig>
+) -> Vec<(proc_macro2::TokenStream, (Vec<proc_macro2::TokenStream>, proc_macro2::Ident), proc_macro2::TokenStream)> {
+    let mut ret = vec!();
+    if chip.series == ChipSeries::Nrf52 {
+        for conf in joystick_config.into_iter() {
+            let mut task = proc_macro2::TokenStream::new();
+            let mut channel_config = vec!();
+            let joystick_ident = format_ident!("joystick_{}", conf.instance);
+            let mut num = 2usize;
+            for (idx, axis_pin) in conf.axis.iter().enumerate() {
+                if axis_pin != "_" {
+                    let pin = convert_gpio_str_to_adc_pin(chip, axis_pin.to_string());
+                    channel_config.push(quote!{ {
+                        use ::embassy_nrf::saadc::{Reference, Gain, Time};
+                        let mut p = ::embassy_nrf::saadc::ChannelConfig::single_ended(#pin);
+                        p.reference = Reference::VDD1_4;
+                        p.gain = Gain::GAIN1_4;
+                        p
+                    } });
+                } else {
+                    num = 1;
+                }
+            }
+            let trans_config = conf.transform.unwrap_or([[1i8, 1i8], [1i8, 1i8]]);
+            let trans = trans_config.map(|n| {
+                quote!{ [#(#n), *] }
+            });
+            let channel_name = format_ident!("joystick_channel_{}", conf.instance);
+            let channel_sender_name = format_ident!("joystick_channel_send_{}", conf.instance);
+            let channel_receiver_name = format_ident!("joystick_channel_recv_{}", conf.instance);
+
+            let joystick_run_ident = format_ident!("joystick_run_{}", conf.instance);
+            let initializer = quote!{
+                    let #channel_name = Channel::<CriticalSectionRawMutex, [i16; #num], 4>::new();
+                    use ::embassy_sync::{
+                        channel::Channel,
+                        blocking_mutex::raw::CriticalSectionRawMutex
+                    };
+                let #channel_sender_name = #channel_name.sender();
+                let #channel_receiver_name = #channel_name.receiver();
+                
+                let #joystick_run_ident = || async move {
+                    use ::embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+                    ::rmk::joystick::run_joystick::<#num, 1600, 4, CriticalSectionRawMutex>([#(#trans), *], #channel_receiver_name).await;
+                };
+            };
+
+            task.extend(quote!{
+                #joystick_run_ident()
+            });
+
+            ret.push((initializer, (channel_config, channel_sender_name), task))
+        };
+        ret
+    } else {
+        vec!((quote!{ compile_error!("\"Joystick\" only support Nrf52 now"); },
+            (vec!(), proc_macro2::Ident::new("Useless", proc_macro2::Span::call_site())),
+            proc_macro2::TokenStream::new()))
+    }
+
+}
+
+pub(crate) fn convert_gpio_str_to_adc_pin(chip: &ChipModel, axis_pin: String) -> proc_macro2::TokenStream {
+    if chip.series == ChipSeries::Nrf52 {
+        let axis_ident = format_ident!("{}", axis_pin);
+        quote!{ p.#axis_ident }
+    } else {
+        quote!{ compile_error!("\"Joystick\" only support for Nrf52 now"); }
+    }
+}

--- a/rmk-macro/src/lib.rs
+++ b/rmk-macro/src/lib.rs
@@ -16,6 +16,7 @@ mod layout;
 mod light;
 mod matrix;
 mod split;
+mod joystick;
 mod analog;
 #[rustfmt::skip]
 mod usb_interrupt_map;

--- a/rmk-macro/src/lib.rs
+++ b/rmk-macro/src/lib.rs
@@ -16,6 +16,7 @@ mod layout;
 mod light;
 mod matrix;
 mod split;
+mod analog;
 #[rustfmt::skip]
 mod usb_interrupt_map;
 

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -92,6 +92,9 @@ rapid_debouncer = []
 ## Feature for split keyboard
 split = []
 
+## Feature for analog joystick
+joystick = []
+
 ## Internal feature that indicates no USB is used, this feature will be auto-activated for some chips
 _no_usb = []
 

--- a/rmk/src/ble/nrf/mod.rs
+++ b/rmk/src/ble/nrf/mod.rs
@@ -63,6 +63,9 @@ use {
     once_cell::sync::OnceCell,
 };
 
+use embassy_sync::channel::Channel;
+pub static BLE_BATTERY_CHANNEL: Channel<CriticalSectionRawMutex, [i16; 1], 4> = Channel::new();
+
 /// Maximum number of bonded devices
 pub const BONDED_DEVICE_NUM: usize = 8;
 pub static ACTIVE_PROFILE: AtomicU8 = AtomicU8::new(0);

--- a/rmk/src/ble/nrf/server.rs
+++ b/rmk/src/ble/nrf/server.rs
@@ -47,7 +47,7 @@ impl<'a, const N: usize> HidWriterWrapper for BleHidWriter<'a, N> {
             error!("Send ble report error: {}", e);
             match e {
                 gatt_server::NotifyValueError::Disconnected => HidError::BleDisconnected,
-                gatt_server::NotifyValueError::Raw(_) => HidError::BleRawError,
+                gatt_server::NotifyValueError::Raw(_) => {HidError::BleRawError},
             }
         })
     }

--- a/rmk/src/config/nrf_config.rs
+++ b/rmk/src/config/nrf_config.rs
@@ -1,14 +1,10 @@
-use embassy_nrf::{
-    gpio::{Input, Output},
-    saadc::Saadc,
-};
+use embassy_nrf::gpio::{Input, Output};
 
 pub struct BleBatteryConfig<'a> {
     pub charge_state_pin: Option<Input<'a>>,
     pub charge_led_pin: Option<Output<'a>>,
     pub charge_state_low_active: bool,
     pub charge_led_low_active: bool,
-    pub saadc: Option<Saadc<'a, 1>>,
     pub adc_divider_measured: u32,
     pub adc_divider_total: u32,
 }
@@ -20,7 +16,6 @@ impl<'a> Default for BleBatteryConfig<'a> {
             charge_led_pin: None,
             charge_state_low_active: false,
             charge_led_low_active: false,
-            saadc: None,
             adc_divider_measured: 1,
             adc_divider_total: 1,
         }
@@ -33,7 +28,6 @@ impl<'a> BleBatteryConfig<'a> {
         charge_state_low_active: bool,
         charge_led_pin: Option<Output<'a>>,
         charge_led_low_active: bool,
-        saadc: Option<Saadc<'a, 1>>,
         adc_divider_measured: u32,
         adc_divider_total: u32,
     ) -> Self {
@@ -42,7 +36,6 @@ impl<'a> BleBatteryConfig<'a> {
             charge_state_low_active,
             charge_led_pin,
             charge_led_low_active,
-            saadc,
             adc_divider_measured,
             adc_divider_total,
         }

--- a/rmk/src/joystick.rs
+++ b/rmk/src/joystick.rs
@@ -1,0 +1,70 @@
+use embassy_futures::yield_now;
+
+use embassy_sync::{
+    blocking_mutex::raw::RawMutex, channel::Receiver };
+use crate::{
+    usb::descriptor::{CompositeReport, CompositeReportType},
+    keyboard::{ keyboard_report_channel, KeyboardReportMessage}
+};
+use defmt::info;
+
+/// Run Joystick
+/// It process the input of 2(or 1) channels analog input device.
+/// Sampling the analog input device
+/// `TRANS` perform transformation on the input channels,
+/// `NUM` number of channels,
+/// the sampler rate is 16MHz / `RATE_DIVISOR`.
+pub async fn run_joystick<
+    const NUM: usize,
+    const RATE_DIVISOR: u32,
+    const N: usize,
+    M: RawMutex
+    > (trans: [[i8; 2]; 2], recv: Receiver<'_, M, [i16; 2], N>) {
+        assert!(NUM <= 2);
+        let mut report = CompositeReport::default();
+        let sender = keyboard_report_channel.sender();
+        let divider = 5;
+        let center = [125, 113];
+        let dead = 5;
+
+        loop {
+            let buf = recv.receive().await;
+            let ch1 = get_adc(buf[0]);
+            let ch2 = get_adc(buf[1]);
+            report.x = if ch1 > center[0] - dead && ch1 < center[0] + dead {
+                0
+            } else {
+                (ch1 as i16 - (u8::MAX as i16 / 2)).try_into().unwrap()
+            };
+            
+            report.y = if ch2 > center[1] - dead && ch2 < center[1] + dead {
+                0
+            } else {
+                (ch2 as i16 - (u8::MAX as i16 / 2)).try_into().unwrap()
+            };
+            report.x = report.x / divider;
+            report.y = report.y / divider;
+
+            // high report rate cause error
+            if report.x == 0 && report.y == 0 {
+                yield_now().await;
+                continue;
+            }
+            
+            //info!("joystick: {} {}", ch1, ch2);
+            sender.send(KeyboardReportMessage::CompositeReport(report, CompositeReportType::Mouse)).await;
+            ::embassy_time::Timer::after_millis(20).await;
+        }
+    }
+
+fn get_adc(val: i16) -> u8 {
+    // Avoid overflow
+    let val = val as i32;
+
+    // According to nRF52840's datasheet, for single_ended saadc:
+    // val = v_adc * (gain / reference) * 2^(resolution)
+    //
+    // setting, gain = 1/4, reference = VDD, resolution = 12bits, so:
+    // val = v_adc / VDD * 4096
+    (val * 255 / 4096).try_into().unwrap()
+}

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -74,6 +74,8 @@ mod light;
 mod matrix;
 #[cfg(feature = "split")]
 pub mod split;
+#[cfg(feature = "joystick")]
+pub mod joystick;
 mod storage;
 mod usb;
 mod via;


### PR DESCRIPTION
use Hall-Effect joystick to simulate mouse moving behavior

todo:
- [ ] more functions besides moving the mouse
- [ ] untested except split direct matrix
- [ ] migrate to rmk’s official feature `input device`
- [ ] lag in BLE mode