### PR TITLE
Use async keyboard report sending in matrix scanning

### DIFF
--- a/rmk/src/direct_pin.rs
+++ b/rmk/src/direct_pin.rs
@@ -21,7 +21,7 @@ use crate::ble::nrf::initialize_nrf_ble_keyboard_and_run;
 ))]
 use crate::initialize_usb_keyboard_and_run;
 
-use defmt::{error, info};
+use defmt::info;
 #[cfg(not(feature = "_esp_ble"))]
 use embassy_executor::Spawner;
 use embassy_time::Instant;
@@ -330,15 +330,13 @@ impl<
                                 self.key_states[row_idx][col_idx].toggle_pressed();
                                 let key_state = self.key_states[row_idx][col_idx];
 
-                                // `try_send` is used here because we don't want to block scanning if the channel is full
-                                let send_re = key_event_channel.try_send(KeyEvent {
-                                    row: row_idx as u8,
-                                    col: col_idx as u8,
-                                    pressed: key_state.pressed,
-                                });
-                                if send_re.is_err() {
-                                    error!("Failed to send key event: key event channel full");
-                                }
+                                key_event_channel
+                                    .send(KeyEvent {
+                                        row: row_idx as u8,
+                                        col: col_idx as u8,
+                                        pressed: key_state.pressed,
+                                    })
+                                    .await;
                             }
                             _ => (),
                         }

--- a/rmk/src/matrix.rs
+++ b/rmk/src/matrix.rs
@@ -2,7 +2,7 @@ use crate::{
     debounce::{DebounceState, DebouncerTrait},
     keyboard::{key_event_channel, KeyEvent},
 };
-use defmt::{error, Format};
+use defmt::Format;
 use embassy_time::{Instant, Timer};
 use embedded_hal::digital::{InputPin, OutputPin};
 #[cfg(feature = "async_matrix")]
@@ -193,15 +193,13 @@ impl<
                             let (row, col, key_state) =
                                 (out_idx, in_idx, self.key_states[out_idx][in_idx]);
 
-                            // `try_send` is used here because we don't want to block scanning if the channel is full
-                            let send_re = key_event_channel.try_send(KeyEvent {
-                                row: row as u8,
-                                col: col as u8,
-                                pressed: key_state.pressed,
-                            });
-                            if send_re.is_err() {
-                                error!("Failed to send key event: key event channel full");
-                            }
+                            key_event_channel
+                                .send(KeyEvent {
+                                    row: row as u8,
+                                    col: col as u8,
+                                    pressed: key_state.pressed,
+                                })
+                                .await;
                         }
                         _ => (),
                     }

--- a/rmk/src/split/central.rs
+++ b/rmk/src/split/central.rs
@@ -378,15 +378,13 @@ impl<
                                 self.key_states[out_idx][in_idx],
                             );
 
-                            // `try_send` is used here because we don't want to block scanning if the channel is full
-                            let send_re = key_event_channel.try_send(KeyEvent {
-                                row,
-                                col,
-                                pressed: key_state.pressed,
-                            });
-                            if send_re.is_err() {
-                                error!("Failed to send key event: key event channel full");
-                            }
+                            key_event_channel
+                                .send(KeyEvent {
+                                    row,
+                                    col,
+                                    pressed: key_state.pressed,
+                                })
+                                .await;
                         }
                         _ => (),
                     }
@@ -541,8 +539,8 @@ impl<
 
     #[cfg(feature = "async_matrix")]
     async fn wait_for_key(&mut self) {
-        use heapless::Vec;
         use embassy_futures::select::select_slice;
+        use heapless::Vec;
         if let Some(start_time) = self.scan_start {
             // If no key press over 1ms, stop scanning and wait for interupt
             if start_time.elapsed().as_millis() <= 1 {
@@ -611,15 +609,13 @@ impl<
                                     self.key_states[row_idx][col_idx],
                                 );
 
-                                // `try_send` is used here because we don't want to block scanning if the channel is full
-                                let send_re = key_event_channel.try_send(KeyEvent {
-                                    row,
-                                    col,
-                                    pressed: key_state.pressed,
-                                });
-                                if send_re.is_err() {
-                                    error!("Failed to send key event: key event channel full");
-                                }
+                                key_event_channel
+                                    .send(KeyEvent {
+                                        row,
+                                        col,
+                                        pressed: key_state.pressed,
+                                    })
+                                    .await;
                             }
                             _ => (),
                         }


### PR DESCRIPTION
Now the matrix scanning result is sent key processor using `try_send`, which might result in missing key event when typing fast. Changing to async `send` might slow down the scanning rate when the channel is full, but no more missing key. 