### PR TITLE
ci: Optimize GitHub Actions workflow to use self-hosted runners.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,24 +18,47 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # By default, RUSTFLAGS with “-D warnings” turns warnings into errors.
+  RUSTFLAGS:
 
 jobs:
-  build_rmk:
+  determine-runner:
     runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.set-runner.outputs.use-runner }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - name: Determine which runner to use
+        id: set-runner
+        uses: jimmygchen/runner-fallback-action@v1
+        with:
+          primary-runner: "self-hosted"
+          fallback-runner: "ubuntu-latest"
+          github-token: ${{ secrets.RMK_GITHUB_TOKEN }}
+
+  build_rmk:
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Build rmk
         working-directory: ./rmk
         run: cargo build --release 
   build_rp2040:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv6m-none-eabi
@@ -43,11 +66,15 @@ jobs:
         working-directory: ./examples/use_rust/rp2040
         run: cargo make uf2 --release
   build_rp2040_with_config:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv6m-none-eabi
@@ -55,11 +82,15 @@ jobs:
         working-directory: ./examples/use_config/rp2040
         run: cargo make uf2 --release
   build_stm32h7:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv7em-none-eabihf
@@ -67,11 +98,15 @@ jobs:
         working-directory: ./examples/use_rust/stm32h7
         run: cargo make uf2 --release
   build_stm32h7_with_config:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv7em-none-eabihf
@@ -79,35 +114,47 @@ jobs:
         working-directory: ./examples/use_config/stm32h7
         run: cargo make uf2 --release
   build_stm32f1:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
-        run: rustup target add thumbv7em-none-eabi      
+        run: rustup target add thumbv7m-none-eabi      
       - name: Build stm32f1
         working-directory: ./examples/use_rust/stm32f1
-        run: cargo make uf2 --release
+        run: cargo build --release
   build_stm32f1_with_config:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
-        run: rustup target add thumbv7em-none-eabi     
+        run: rustup target add thumbv7m-none-eabi     
       - name: Build stm32f1 with config
         working-directory: ./examples/use_config/stm32f1
         run: cargo make uf2 --release
   build_stm32f4:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv7em-none-eabihf
@@ -115,11 +162,15 @@ jobs:
         working-directory: ./examples/use_rust/stm32f4
         run: cargo make uf2 --release
   build_stm32f4_with_config:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv7em-none-eabihf
@@ -127,11 +178,15 @@ jobs:
         working-directory: ./examples/use_config/stm32f4
         run: cargo make uf2 --release
   build_nrf52840_ble:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv7em-none-eabihf
@@ -139,11 +194,15 @@ jobs:
         working-directory: ./examples/use_rust/nrf52840_ble
         run: cargo make uf2 --release
   build_nrf52832_ble:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv7em-none-eabihf
@@ -151,11 +210,15 @@ jobs:
         working-directory: ./examples/use_rust/nrf52832_ble
         run: cargo make uf2 --release
   build_nrf52832_ble_with_config:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv7em-none-eabihf
@@ -163,11 +226,15 @@ jobs:
         working-directory: ./examples/use_config/nrf52832_ble
         run: cargo make uf2 --release
   build_rp2040_split:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv6m-none-eabi
@@ -175,11 +242,15 @@ jobs:
         working-directory: ./examples/use_rust/rp2040_split
         run: cargo make uf2 --release
   build_rp2040_split_with_config:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv6m-none-eabi
@@ -187,11 +258,15 @@ jobs:
         working-directory: ./examples/use_config/rp2040_split
         run: cargo make uf2 --release
   build_nrf52840:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv7em-none-eabihf
@@ -199,11 +274,15 @@ jobs:
         working-directory: ./examples/use_rust/nrf52840_ble_split
         run: cargo make uf2 --release
   build_nrf52840_split_with_config:
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-make
-        run: cargo binstall cargo-make -y
+        run: cargo install cargo-make
       - uses: actions/checkout@v3
       - name: Install target
         run: rustup target add thumbv7em-none-eabihf
@@ -212,12 +291,13 @@ jobs:
         run: cargo make uf2 --release
   binary-size:
     # Copied from sequential-storage: https://github.com/tweedegolf/sequential-storage/blob/master/.github/workflows/ci.yaml
-    runs-on: ubuntu-latest
+    needs: determine-runner
+    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     permissions:
       actions: read
       pull-requests: write
     steps:
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: actions/cache@v3
         id: cache-cargo
         with:
@@ -229,7 +309,7 @@ jobs:
             ./example/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install flip-link
-        run: cargo binstall flip-link -y
+        run: cargo install flip-link
       - run: rustup target add thumbv7em-none-eabihf
       - run: rustup component add rust-src llvm-tools
       - if: steps.cache-cargo.outputs.cache-hit != 'true'


### PR DESCRIPTION
- Add determine-runner step, use self-hosted runner or fallback to latest Ubuntu version.
- Remove cargo-bins/cargo-binstall, use cargo install instead.
- Add Python setup step for Python 3.11.
- Add Rust toolchain setup step.