### PR TITLE
Sync connection state periodically when using serial

### DIFF
--- a/rmk/src/matrix.rs
+++ b/rmk/src/matrix.rs
@@ -3,7 +3,7 @@ use crate::{
     keyboard::{key_event_channel, KeyEvent},
     CONNECTION_STATE,
 };
-use defmt::{error, info, Format};
+use defmt::{info, Format};
 use embassy_time::{Instant, Timer};
 use embedded_hal::digital::{InputPin, OutputPin};
 #[cfg(feature = "async_matrix")]

--- a/rmk/src/split/serial/mod.rs
+++ b/rmk/src/split/serial/mod.rs
@@ -1,3 +1,5 @@
+use core::sync::atomic::Ordering;
+
 use defmt::{error, info};
 use embedded_io_async::{Read, Write};
 
@@ -8,6 +10,7 @@ use crate::{
         peripheral::SplitPeripheral,
         SplitMessage, SPLIT_MESSAGE_MAX_SIZE,
     },
+    CONNECTION_STATE,
 };
 
 use super::driver::SplitDriverError;


### PR DESCRIPTION
When connecting splits using serial, there's no way to know the connection state. So after the serial disconnect, peripheral may have wrong connection state.

This PR moves the cached connection state to BLE split message writer, makes serial split driver periodically sync the connection state.