### PR TITLE
ci: github token ref moved from secrets to vars

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           primary-runner: "self-hosted"
           fallback-runner: "ubuntu-latest"
-          github-token: ${{ secrets.RMK_GITHUB_TOKEN }}
+          github-token: ${{ vars.RMK_GITHUB_TOKEN }}
 
   build_rmk:
     needs: determine-runner


### PR DESCRIPTION
- forked branches can't access secrets

need to add the token to the location shown in the figure below
![image](https://github.com/user-attachments/assets/c6c4ac6f-00b0-432e-bdfb-396746736694)
