### PR TITLE
Modifier tap hold in keyboard toml

### DIFF
--- a/docs/src/keyboard_configuration.md
+++ b/docs/src/keyboard_configuration.md
@@ -154,7 +154,7 @@ The key string should follow several rules:
 
   The definitions of those operations are same with QMK, you can found [here](https://docs.qmk.fm/#/feature_layers). If you want other actions, please [fire an issue](https://github.com/HaoboGu/rmk/issues/new).
 
-4. For modifier-tap-hold, use `MTH(key, modifier)` where the modifier can be a chain like explained on point 1
+4. For modifier-tap-hold, use `MTH(key, modifier)` where the modifier can be a chain like explained on point 1. For example for a Home row modifier config you can use `MTH(F,LShift)`
 
 5. For generic key tap-hold, use `TH(key-tap, key-hold)`.
 

--- a/docs/src/keyboard_configuration.md
+++ b/docs/src/keyboard_configuration.md
@@ -154,7 +154,7 @@ The key string should follow several rules:
 
   The definitions of those operations are same with QMK, you can found [here](https://docs.qmk.fm/#/feature_layers). If you want other actions, please [fire an issue](https://github.com/HaoboGu/rmk/issues/new).
 
-4. For modifier-tap-hold, use `MTH(key, modifier)` where the modifier can be a chain like explained on point 1. For example for a Home row modifier config you can use `MTH(F,LShift)`
+4. For modifier-tap-hold, use `MT(key, modifier)` where the modifier can be a chain like explained on point 1. For example for a Home row modifier config you can use `MT(F,LShift)`
 
 5. For generic key tap-hold, use `TH(key-tap, key-hold)`.
 

--- a/docs/src/keyboard_configuration.md
+++ b/docs/src/keyboard_configuration.md
@@ -151,9 +151,12 @@ The key string should follow several rules:
     7. Use `"TT(n)"` to create a layer activate or tap toggle action, `n` is the layer number
     8. Use `"TG(n)"` to create a layer toggle action, `n` is the layer number
     9. Use `"TO(n)"` to create a layer toggle only action (activate layer `n` and deactivate all other layers), `n` is the layer number
-    
+
   The definitions of those operations are same with QMK, you can found [here](https://docs.qmk.fm/#/feature_layers). If you want other actions, please [fire an issue](https://github.com/HaoboGu/rmk/issues/new).
 
+4. For modifier-tap-hold, use `MTH(key, modifier)` where the modifier can be a chain like explained on point 1
+
+5. For generic key tap-hold, use `TH(key-tap, key-hold)`.
 
 ### `[behavior]`
 

--- a/rmk-macro/src/layout.rs
+++ b/rmk-macro/src/layout.rs
@@ -219,8 +219,8 @@ fn parse_key(key: String) -> TokenStream2 {
                 ::rmk::df!(#layer)
             }
         }
-        "MTH" => {
-            if let Some(internal) = key.trim_start_matches("MTH(").strip_suffix(")") {
+        "MT(" => {
+            if let Some(internal) = key.trim_start_matches("MT(").strip_suffix(")") {
                 let keys: Vec<&str> = internal
                     .split_terminator(",")
                     .map(|w| w.trim())
@@ -228,7 +228,7 @@ fn parse_key(key: String) -> TokenStream2 {
                     .collect();
                 if keys.len() != 2 {
                     return quote! {
-                        compile_error!("keyboard.toml: MTH(key, modifier) invalid, please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
+                        compile_error!("keyboard.toml: MT(key, modifier) invalid, please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
                     };
                 }
                 let ident = format_ident!("{}", keys[0].to_string());
@@ -236,7 +236,7 @@ fn parse_key(key: String) -> TokenStream2 {
 
                 if (gui || alt || shift || ctrl) == false {
                     return quote! {
-                        compile_error!("keyboard.toml: modifier in MTH(key, modifier) is not valid! Please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
+                        compile_error!("keyboard.toml: modifier in MT(key, modifier) is not valid! Please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
                     };
                 }
                 quote! {
@@ -244,7 +244,7 @@ fn parse_key(key: String) -> TokenStream2 {
                 }
             } else {
                 return quote! {
-                    compile_error!("keyboard.toml: MTH(key, modifier) invalid, please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
+                    compile_error!("keyboard.toml: MT(key, modifier) invalid, please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
                 };
             }
         }

--- a/rmk-macro/src/layout.rs
+++ b/rmk-macro/src/layout.rs
@@ -37,6 +37,43 @@ fn expand_row(row: Vec<String>) -> TokenStream2 {
     quote! { [#(#keys), *] }
 }
 
+/// Get modifier combination, in types of mod1 | mod2 | ...
+fn parse_modifiers(modifiers_str: &str) -> (bool, bool, bool, bool, bool){
+    let mut right = false;
+    let mut gui = false;
+    let mut alt = false;
+    let mut shift = false;
+    let mut ctrl = false;
+    let tokens = modifiers_str.split_terminator("|");
+    tokens.for_each(|w| {
+        let w = w.trim();
+        match w {
+            "LShift" => shift = true,
+            "LCtrl" => ctrl = true,
+            "LAlt" => alt = true,
+            "Lgui" => gui = true,
+            "RShift" => {
+                right = true;
+                shift = true;
+            }
+            "RCtrl" => {
+                right = true;
+                ctrl = true;
+            }
+            "RAlt" => {
+                right = true;
+                alt = true;
+            }
+            "Rgui" => {
+                right = true;
+                gui = true;
+            }
+            _ => (),
+        }
+    });
+    return (right, gui, alt, shift, ctrl);
+}
+
 /// Parse the key string at a single position
 fn parse_key(key: String) -> TokenStream2 {
     if key.len() < 5 {
@@ -63,38 +100,7 @@ fn parse_key(key: String) -> TokenStream2 {
 
                 let ident = format_ident!("{}", keys[0].to_string());
 
-                // Get modifier combination, in types of mod1 | mod2 | ...
-                let mut right = false;
-                let mut gui = false;
-                let mut alt = false;
-                let mut shift = false;
-                let mut ctrl = false;
-                keys[1].split_terminator("|").for_each(|w| {
-                    let w = w.trim();
-                    match w {
-                        "LShift" => shift = true,
-                        "LCtrl" => ctrl = true,
-                        "LAlt" => alt = true,
-                        "Lgui" => gui = true,
-                        "RShift" => {
-                            right = true;
-                            shift = true;
-                        }
-                        "RCtrl" => {
-                            right = true;
-                            ctrl = true;
-                        }
-                        "RAlt" => {
-                            right = true;
-                            alt = true;
-                        }
-                        "Rgui" => {
-                            right = true;
-                            gui = true;
-                        }
-                        _ => (),
-                    }
-                });
+                let (right, gui, alt, shift, ctrl) = parse_modifiers(keys[1]);
 
                 if (gui || alt || shift || ctrl) == false {
                     return quote! {
@@ -124,38 +130,7 @@ fn parse_key(key: String) -> TokenStream2 {
         }
         "OSM" => {
             if let Some(internal) = key.trim_start_matches("OSM(").strip_suffix(")") {
-                // Get modifier combination, in types of mod1 | mod2 | ...
-                let mut right = false;
-                let mut gui = false;
-                let mut alt = false;
-                let mut shift = false;
-                let mut ctrl = false;
-                internal.split_terminator("|").for_each(|w| {
-                    let w = w.trim();
-                    match w {
-                        "LShift" => shift = true,
-                        "LCtrl" => ctrl = true,
-                        "LAlt" => alt = true,
-                        "Lgui" => gui = true,
-                        "RShift" => {
-                            right = true;
-                            shift = true;
-                        }
-                        "RCtrl" => {
-                            right = true;
-                            ctrl = true;
-                        }
-                        "RAlt" => {
-                            right = true;
-                            alt = true;
-                        }
-                        "Rgui" => {
-                            right = true;
-                            gui = true;
-                        }
-                        _ => (),
-                    }
-                });
+                let (right, gui, alt, shift, ctrl) = parse_modifiers(internal);
 
                 if !(gui || alt || shift || ctrl) {
                     return quote! {
@@ -185,38 +160,7 @@ fn parse_key(key: String) -> TokenStream2 {
                 }
                 let layer = keys[0].parse::<u8>().unwrap();
 
-                // Get modifier combination, in types of mod1 | mod2 | ...
-                let mut right = false;
-                let mut gui = false;
-                let mut alt = false;
-                let mut shift = false;
-                let mut ctrl = false;
-                keys[1].split_terminator("|").for_each(|w| {
-                    let w = w.trim();
-                    match w {
-                        "LShift" => shift = true,
-                        "LCtrl" => ctrl = true,
-                        "LAlt" => alt = true,
-                        "Lgui" => gui = true,
-                        "RShift" => {
-                            right = true;
-                            shift = true;
-                        }
-                        "RCtrl" => {
-                            right = true;
-                            ctrl = true;
-                        }
-                        "RAlt" => {
-                            right = true;
-                            alt = true;
-                        }
-                        "Rgui" => {
-                            right = true;
-                            gui = true;
-                        }
-                        _ => (),
-                    }
-                });
+                let (right, gui, alt, shift, ctrl) = parse_modifiers(keys[1]);
 
                 if (gui || alt || shift || ctrl) == false {
                     return quote! {

--- a/rmk-macro/src/layout.rs
+++ b/rmk-macro/src/layout.rs
@@ -219,6 +219,54 @@ fn parse_key(key: String) -> TokenStream2 {
                 ::rmk::df!(#layer)
             }
         }
+        "MTH(" => {
+            let keys: Vec<&str> = key
+                .trim_start_matches("MTH(")
+                .trim_end_matches(")")
+                .split_terminator(",")
+                .map(|w| w.trim())
+                .filter(|w| w.len() > 0)
+                .collect();
+            if keys.len() != 2 {
+                return quote! {
+                    compile_error!("keyboard.toml: MTH(modifiers, key) invalid, please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
+                };
+            }
+            let ident = format_ident!("{}", keys[0].to_string());
+
+            let (right, gui, alt, shift, ctrl) = parse_modifiers(keys[1]);
+
+            if (gui || alt || shift || ctrl) == false {
+                return quote! {
+                    compile_error!("keyboard.toml: modifier in MTH(modifier, key) is not valid! Please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
+                };
+            }
+            quote! {
+                ::rmk::mth!(#ident, ::rmk::keycode::ModifierCombination::new_from(#right, #gui, #alt, #shift, #ctrl))
+            }
+
+        }
+        "TH(" => {
+            let keys: Vec<&str> = key
+                .trim_start_matches("TH(")
+                .trim_end_matches(")")
+                .split_terminator(",")
+                .map(|w| w.trim())
+                .filter(|w| w.len() > 0)
+                .collect();
+            if keys.len() != 2 {
+                return quote! {
+                    compile_error!("keyboard.toml: TH(modifiers, key) invalid, please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
+                };
+            }
+            let ident1 = format_ident!("{}", keys[0].to_string());
+            let ident2 = format_ident!("{}", keys[1].to_string());
+
+            quote! {
+                ::rmk::th!(#ident1, #ident2)
+            }
+
+        }
         _ => {
             let ident = format_ident!("{}", key);
             quote! {::rmk::k!(#ident) }

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -60,6 +60,28 @@ macro_rules! lt {
     };
 }
 
+/// Create a modifier-tap-hold action
+#[macro_export]
+macro_rules! mth {
+    ($m: expr, $k: ident) => {
+        $crate::action::KeyAction::ModifierTapHold(
+            $m,
+            $crate::action::Action::Key($crate::keycode::KeyCode::$k),
+        )
+    };
+}
+
+/// Create a tap-hold action
+#[macro_export]
+macro_rules! th {
+    ($h: ident, $t: ident) => {
+        $crate::action::KeyAction::TapHold(
+            $t,
+            $h,
+        )
+    };
+}
+
 /// Create an oneshot layer key in keymap
 #[macro_export]
 macro_rules! osl {

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -63,7 +63,7 @@ macro_rules! lt {
 /// Create a modifier-tap-hold action
 #[macro_export]
 macro_rules! mth {
-    ($m: expr, $k: ident) => {
+    ($k: ident, $m: expr) => {
         $crate::action::KeyAction::ModifierTapHold(
             $m,
             $crate::action::Action::Key($crate::keycode::KeyCode::$k),
@@ -74,7 +74,7 @@ macro_rules! mth {
 /// Create a tap-hold action
 #[macro_export]
 macro_rules! th {
-    ($h: ident, $t: ident) => {
+    ($t: ident, $h: ident) => {
         $crate::action::KeyAction::TapHold(
             $t,
             $h,

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -65,8 +65,8 @@ macro_rules! lt {
 macro_rules! mth {
     ($k: ident, $m: expr) => {
         $crate::action::KeyAction::ModifierTapHold(
-            $m,
             $crate::action::Action::Key($crate::keycode::KeyCode::$k),
+            $m,
         )
     };
 }
@@ -76,8 +76,8 @@ macro_rules! mth {
 macro_rules! th {
     ($t: ident, $h: ident) => {
         $crate::action::KeyAction::TapHold(
-            $t,
-            $h,
+            $crate::action::Action::Key($crate::keycode::KeyCode::$t),
+            $crate::action::Action::Key($crate::keycode::KeyCode::$h),
         )
     };
 }


### PR DESCRIPTION
This pull request closes issue #221.

I have been able to test the MTH(A,LShift) and it works correctly, but for some reason the TH(X,Y) is not working yet: has it been tested before? I see that Via does not have a binding for the TapHold.

I used all caps for MTH and TH for consistency with the other Layer actions, and i used the ordering <key>, <modifiers> for consistency with WM and LM.