### PR TITLE
allow macros count configuration

### DIFF
--- a/rmk-macro/src/behavior.rs
+++ b/rmk-macro/src/behavior.rs
@@ -1,7 +1,7 @@
 //! Initialize behavior config boilerplate of RMK
 //!
 
-use crate::config::{OneShotConfig, TapHoldConfig, TriLayerConfig};
+use crate::config::{OneShotConfig, TapHoldConfig, TriLayerConfig, MacrosConfig};
 use crate::keyboard_config::KeyboardConfig;
 use quote::quote;
 
@@ -82,16 +82,38 @@ fn expand_tap_hold(tap_hold: &Option<TapHoldConfig>) -> proc_macro2::TokenStream
     }
 }
 
+fn expand_macros(macros: &Option<MacrosConfig>) -> proc_macro2::TokenStream {
+    let default = quote! {::rmk::config::MacrosConfig::default()};
+    match macros {
+        Some(macros) => {
+            let count = match &macros.count {
+                Some(c) => c,
+                None => return default,
+            };
+
+            quote! {
+                ::rmk::config::MacrosConfig {
+                    count: #count,
+                }
+            }
+        }
+        None => default,
+    }
+}
+
+
 pub(crate) fn expand_behavior_config(keyboard_config: &KeyboardConfig) -> proc_macro2::TokenStream {
     let tri_layer = expand_tri_layer(&keyboard_config.behavior.tri_layer);
     let tap_hold = expand_tap_hold(&keyboard_config.behavior.tap_hold);
     let one_shot = expand_one_shot(&keyboard_config.behavior.one_shot);
+    let macros_config = expand_macros(&keyboard_config.behavior.macros);
 
     quote! {
         let behavior_config = ::rmk::config::BehaviorConfig {
             tri_layer: #tri_layer,
             tap_hold: #tap_hold,
             one_shot: #one_shot,
+            macros: #macros_config,
         };
     }
 }

--- a/rmk-macro/src/config/mod.rs
+++ b/rmk-macro/src/config/mod.rs
@@ -140,6 +140,7 @@ pub struct BehaviorConfig {
     pub tri_layer: Option<TriLayerConfig>,
     pub tap_hold: Option<TapHoldConfig>,
     pub one_shot: Option<OneShotConfig>,
+    pub macros: Option<MacrosConfig>,
 }
 
 /// Configurations for tap hold
@@ -165,6 +166,11 @@ pub struct OneShotConfig {
     pub timeout: Option<DurationMillis>,
 }
 
+/// Configurations for keyboard macros
+#[derive(Clone, Debug, Deserialize)]
+pub struct MacrosConfig {
+    pub count: Option<usize>,
+}
 /// Configurations for split keyboards
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct SplitConfig {

--- a/rmk-macro/src/keyboard_config.rs
+++ b/rmk-macro/src/keyboard_config.rs
@@ -442,6 +442,7 @@ impl KeyboardConfig {
 
                 behavior.tap_hold = behavior.tap_hold.or(default.tap_hold);
                 behavior.one_shot = behavior.one_shot.or(default.one_shot);
+                behavior.macros = behavior.macros.or(default.macros);
 
                 Ok(behavior)
             }

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -41,13 +41,23 @@ impl<'a, O: OutputPin> Default for RmkConfig<'a, O> {
 }
 
 /// Config for configurable action behavior
-#[derive(Default)]
 pub struct BehaviorConfig {
     pub tri_layer: Option<[u8; 3]>,
     pub tap_hold: TapHoldConfig,
     pub one_shot: OneShotConfig,
+    pub macros: MacrosConfig,
 }
 
+impl Default for BehaviorConfig {
+    fn default() -> Self {
+        Self {
+            tri_layer: None,
+            tap_hold: TapHoldConfig::default(),
+            one_shot: OneShotConfig::default(),
+            macros: MacrosConfig::default(),
+        }
+    }
+}
 /// Configurations for tap hold behavior
 pub struct TapHoldConfig {
     pub enable_hrm: bool,
@@ -77,6 +87,17 @@ impl Default for OneShotConfig {
         Self {
             timeout: Duration::from_secs(1),
         }
+    }
+}
+
+/// Configurations for keyboard macros
+pub struct MacrosConfig {
+    pub count: usize,
+}
+
+impl Default for MacrosConfig {
+    fn default() -> Self {
+        Self { count: 8 }
     }
 }
 

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -4,7 +4,7 @@ use crate::CONNECTION_STATE;
 use crate::{
     action::{Action, KeyAction},
     hid::{ConnectionType, HidWriterWrapper},
-    keyboard_macro::{MacroOperation, NUM_MACRO},
+    keyboard_macro::MacroOperation,
     keycode::{KeyCode, ModifierCombination},
     keymap::KeyMap,
     usb::descriptor::{CompositeReport, CompositeReportType, ViaReport},
@@ -936,7 +936,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
 
         // Get macro index
         if let Some(macro_idx) = key.as_macro_index() {
-            if macro_idx as usize >= NUM_MACRO {
+            if macro_idx as usize >= self.behavior.macros.count {
                 error!("Macro idx invalid: {}", macro_idx);
                 return;
             }

--- a/rmk/src/keyboard_macro.rs
+++ b/rmk/src/keyboard_macro.rs
@@ -4,7 +4,7 @@ use crate::keycode::KeyCode;
 pub(crate) const MACRO_SPACE_SIZE: usize = 256;
 
 // Default number of keyboard macros
-pub(crate) const NUM_MACRO: usize = 8;
+pub(crate) const DEFAULT_NUM_MACRO: usize = 8;
 
 pub(crate) enum MacroOperation {
     Press(KeyCode),

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -258,6 +258,7 @@ pub async fn initialize_usb_keyboard_and_run<
     let keyboard_report_receiver = KEYBOARD_REPORT_CHANNEL.receiver();
 
     // Create keyboard services and devices
+    let macros_count = keyboard_config.behavior_config.macros.count;
     let (mut keyboard, mut usb_device, mut vial_service, mut light_service) = (
         Keyboard::new(
             &keymap,
@@ -265,7 +266,7 @@ pub async fn initialize_usb_keyboard_and_run<
             keyboard_config.behavior_config,
         ),
         KeyboardUsbDevice::new(usb_driver, keyboard_config.usb_config),
-        VialService::new(&keymap, keyboard_config.vial_config),
+        VialService::new(&keymap, keyboard_config.vial_config, macros_count),
         LightService::from_config(keyboard_config.light_config),
     );
 

--- a/rmk/src/split/central.rs
+++ b/rmk/src/split/central.rs
@@ -276,6 +276,7 @@ pub async fn initialize_usb_split_central_and_run<
     let keyboard_report_receiver = KEYBOARD_REPORT_CHANNEL.receiver();
 
     // Create keyboard services and devices
+    let macros_count = keyboard_config.behavior_config.macros.count;
     let (mut keyboard, mut usb_device, mut vial_service, mut light_service) = (
         Keyboard::new(
             &keymap,
@@ -283,7 +284,7 @@ pub async fn initialize_usb_split_central_and_run<
             keyboard_config.behavior_config,
         ),
         KeyboardUsbDevice::new(usb_driver, keyboard_config.usb_config),
-        VialService::new(&keymap, keyboard_config.vial_config),
+        VialService::new(&keymap, keyboard_config.vial_config, macros_count),
         LightService::from_config(keyboard_config.light_config),
     );
 


### PR DESCRIPTION
Hello, I open this pull request as a draft: I wanted to use more via macros than the default 8, so i tried implementing it myself. It turned out to be quite a lot of code, so feel free to instruct me where you don't like the naming or the structure of things. 

I still have not tested this, but it compiles and basically it allows to configure the keyboard.toml like this:
```
[behavior.macros]
count = 32
```
.

I still need to 

- [ ] cleanup, 
- [ ] setup the default better, without the magic number, 
- [ ] document the config option
