### PR TITLE
feat: added _matrix functions to allow passing custom matrix implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,8 @@ jobs:
           python-version: "3.11"
       - uses: cargo-bins/cargo-binstall@main
       - uses: actions/checkout@v3
-      - name: Install cargo-make
-        run: cargo binstall cargo-make
+      - name: Install cargo-make and flip-link
+        run: cargo binstall cargo-make flip-link
       - name: Install target
         run: rustup target add thumbv6m-none-eabi thumbv7em-none-eabihf thumbv7m-none-eabi
       - name: Build example

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,9 @@ jobs:
         run: rustup target add thumbv6m-none-eabi thumbv7em-none-eabihf thumbv7m-none-eabi
       - name: Build example
         working-directory: ./examples/${{ matrix.example_type }}/${{ matrix.example }}
+        run: cargo build --release
+      - name: Build example uf2
+        working-directory: ./examples/${{ matrix.example_type }}/${{ matrix.example }}
         run: cargo make uf2 --release
   binary-size:
     # Copied from sequential-storage: https://github.com/tweedegolf/sequential-storage/blob/master/.github/workflows/ci.yaml

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -210,8 +210,7 @@ pub async fn run_rmk_with_async_flash<
 ///
 /// # Arguments
 ///
-/// * `input_pins` - input gpio pins, if `async_matrix` is enabled, the input pins should implement `embedded_hal_async::digital::Wait` trait
-/// * `output_pins` - output gpio pins
+/// * `matrix` - the matrix scanning implementation to use.
 /// * `usb_driver` - (optional) embassy usb driver instance. Some microcontrollers would enable the `_no_usb` feature implicitly, which eliminates this argument
 /// * `flash` - (optional) async flash storage, which is used for storing keymap and keyboard configs. Some microcontrollers would enable the `_no_external_storage` feature implicitly, which eliminates this argument
 /// * `default_keymap` - default keymap definition

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -220,6 +220,7 @@ pub async fn run_rmk_with_async_flash<
 #[allow(unused_variables)]
 #[allow(unreachable_code)]
 pub async fn run_rmk_with_async_flash_and_matrix<
+    Out: OutputPin,
     M: MatrixTrait,
     #[cfg(not(feature = "_no_usb"))] D: Driver<'static>,
     #[cfg(not(feature = "_no_external_storage"))] F: AsyncNorFlash,

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -192,6 +192,49 @@ pub async fn run_rmk_with_async_flash<
     #[cfg(not(feature = "col2row"))]
     let matrix = Matrix::<_, _, _, COL, ROW>::new(input_pins, output_pins, debouncer);
 
+    run_rmk_with_async_flash_and_matrix(
+        matrix,
+        #[cfg(not(feature = "_no_usb"))]
+        usb_driver,
+        #[cfg(not(feature = "_no_external_storage"))]
+        flash,
+        default_keymap,
+        keyboard_config,
+        #[cfg(not(feature = "_esp_ble"))]
+        spawner,
+    )
+    .await;
+}
+
+/// Run RMK keyboard service. This function should never return.
+///
+/// # Arguments
+///
+/// * `input_pins` - input gpio pins, if `async_matrix` is enabled, the input pins should implement `embedded_hal_async::digital::Wait` trait
+/// * `output_pins` - output gpio pins
+/// * `usb_driver` - (optional) embassy usb driver instance. Some microcontrollers would enable the `_no_usb` feature implicitly, which eliminates this argument
+/// * `flash` - (optional) async flash storage, which is used for storing keymap and keyboard configs. Some microcontrollers would enable the `_no_external_storage` feature implicitly, which eliminates this argument
+/// * `default_keymap` - default keymap definition
+/// * `keyboard_config` - other configurations of the keyboard, check [RmkConfig] struct for details
+/// * `spawner`: (optional) embassy spawner used to spawn async tasks. This argument is enabled for non-esp microcontrollers
+#[allow(unused_variables)]
+#[allow(unreachable_code)]
+pub async fn run_rmk_with_async_flash_and_matrix<
+    M: MatrixTrait,
+    #[cfg(not(feature = "_no_usb"))] D: Driver<'static>,
+    #[cfg(not(feature = "_no_external_storage"))] F: AsyncNorFlash,
+    const ROW: usize,
+    const COL: usize,
+    const NUM_LAYER: usize,
+>(
+    matrix: M,
+    #[cfg(not(feature = "_no_usb"))] usb_driver: D,
+    #[cfg(not(feature = "_no_external_storage"))] flash: F,
+    default_keymap: &mut [[[KeyAction; COL]; ROW]; NUM_LAYER],
+
+    keyboard_config: RmkConfig<'static, Out>,
+    #[cfg(not(feature = "_esp_ble"))] spawner: Spawner,
+) -> ! {
     // Dispatch according to chip and communication type
     #[cfg(feature = "_nrf_ble")]
     initialize_nrf_ble_keyboard_and_run(

--- a/rmk/src/split/central.rs
+++ b/rmk/src/split/central.rs
@@ -205,6 +205,7 @@ pub async fn run_rmk_split_central_direct_pin<
 #[allow(unused_variables)]
 #[allow(unreachable_code)]
 pub async fn run_rmk_split_central_with_matrix<
+    Out: OutputPin,
     M: MatrixTrait,
     #[cfg(not(feature = "_no_usb"))] D: Driver<'static>,
     #[cfg(not(feature = "_no_external_storage"))] F: NorFlash,

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -7,7 +7,7 @@ use crate::debounce::fast_debouncer::RapidDebouncer;
 use crate::debounce::DebouncerTrait;
 use crate::direct_pin::DirectPinMatrix;
 use crate::keyboard::KEY_EVENT_CHANNEL;
-use crate::matrix::Matrix;
+use crate::matrix::{Matrix, MatrixTrait};
 use crate::CONNECTION_STATE;
 #[cfg(feature = "_nrf_ble")]
 use embassy_executor::Spawner;

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -61,17 +61,15 @@ pub async fn run_rmk_split_peripheral<
     #[cfg(not(feature = "col2row"))]
     let matrix = Matrix::<_, _, _, COL, ROW>::new(input_pins, output_pins, debouncer);
 
-    #[cfg(not(feature = "_nrf_ble"))]
-    crate::split::serial::initialize_serial_split_peripheral_and_run::<_, S, ROW, COL>(
-        matrix, serial,
-    )
-    .await;
-
-    #[cfg(feature = "_nrf_ble")]
-    crate::split::nrf::peripheral::initialize_nrf_ble_split_peripheral_and_run::<_, ROW, COL>(
+    run_rmk_split_peripheral_with_matrix(
         matrix,
+        #[cfg(feature = "_nrf_ble")]
         central_addr,
+        #[cfg(feature = "_nrf_ble")]
         peripheral_addr,
+        #[cfg(not(feature = "_nrf_ble"))]
+        serial,
+        #[cfg(feature = "_nrf_ble")]
         spawner,
     )
     .await;
@@ -112,6 +110,41 @@ pub async fn run_rmk_split_peripheral_direct_pin<
     // Keyboard matrix
     let matrix = DirectPinMatrix::<_, _, ROW, COL, SIZE>::new(direct_pins, debouncer, low_active);
 
+    run_rmk_split_peripheral_with_matrix(
+        matrix,
+        #[cfg(feature = "_nrf_ble")]
+        central_addr,
+        #[cfg(feature = "_nrf_ble")]
+        peripheral_addr,
+        #[cfg(not(feature = "_nrf_ble"))]
+        serial,
+        #[cfg(feature = "_nrf_ble")]
+        spawner,
+    )
+    .await;
+}
+
+/// Run the split peripheral service.
+///
+/// # Arguments
+///
+/// * `matrix` - the matrix scanning implementation to use.
+/// * `central_addr` - (optional) central's BLE static address. This argument is enabled only for nRF BLE split now
+/// * `peripheral_addr` - (optional) peripheral's BLE static address. This argument is enabled only for nRF BLE split now
+/// * `serial` - (optional) serial port used to send peripheral split message. This argument is enabled only for serial split now
+/// * `spawner`: (optional) embassy spawner used to spawn async tasks. This argument is enabled for non-esp microcontrollers
+pub async fn run_rmk_split_peripheral_with_matrix<
+    M: MatrixTrait,
+    #[cfg(not(feature = "_nrf_ble"))] S: Write + Read,
+    const ROW: usize,
+    const COL: usize,
+>(
+    matrix: M,
+    #[cfg(feature = "_nrf_ble")] central_addr: [u8; 6],
+    #[cfg(feature = "_nrf_ble")] peripheral_addr: [u8; 6],
+    #[cfg(not(feature = "_nrf_ble"))] serial: S,
+    #[cfg(feature = "_nrf_ble")] spawner: Spawner,
+) {
     #[cfg(not(feature = "_nrf_ble"))]
     crate::split::serial::initialize_serial_split_peripheral_and_run::<_, S, ROW, COL>(
         matrix, serial,

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -61,7 +61,11 @@ pub async fn run_rmk_split_peripheral<
     #[cfg(not(feature = "col2row"))]
     let matrix = Matrix::<_, _, _, COL, ROW>::new(input_pins, output_pins, debouncer);
 
-    run_rmk_split_peripheral_with_matrix(
+    run_rmk_split_peripheral_with_matrix::<
+        Matrix<In, Out, DefaultDebouncer<ROW, COL>, ROW, COL>,
+        ROW,
+        COL,
+    >(
         matrix,
         #[cfg(feature = "_nrf_ble")]
         central_addr,
@@ -110,7 +114,11 @@ pub async fn run_rmk_split_peripheral_direct_pin<
     // Keyboard matrix
     let matrix = DirectPinMatrix::<_, _, ROW, COL, SIZE>::new(direct_pins, debouncer, low_active);
 
-    run_rmk_split_peripheral_with_matrix(
+    run_rmk_split_peripheral_with_matrix::<
+        DirectPinMatrix<In, DefaultDebouncer<COL, ROW>, ROW, COL, SIZE>,
+        ROW,
+        COL,
+    >(
         matrix,
         #[cfg(feature = "_nrf_ble")]
         central_addr,

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -63,6 +63,7 @@ pub async fn run_rmk_split_peripheral<
 
     run_rmk_split_peripheral_with_matrix::<
         Matrix<In, Out, DefaultDebouncer<ROW, COL>, ROW, COL>,
+        #[cfg(not(feature = "_nrf_ble"))] S,
         ROW,
         COL,
     >(
@@ -116,6 +117,7 @@ pub async fn run_rmk_split_peripheral_direct_pin<
 
     run_rmk_split_peripheral_with_matrix::<
         DirectPinMatrix<In, DefaultDebouncer<COL, ROW>, ROW, COL, SIZE>,
+        #[cfg(not(feature = "_nrf_ble"))] S,
         ROW,
         COL,
     >(

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -63,7 +63,7 @@ pub async fn run_rmk_split_peripheral<
 
     #[cfg(feature = "_nrf_ble")]
     run_rmk_split_peripheral_with_matrix::<
-        Matrix<In, Out, DefaultDebouncer<ROW, COL>, ROW, COL>,
+        _,
         ROW,
         COL,
     >(matrix, central_addr, peripheral_addr, spawner)
@@ -71,7 +71,7 @@ pub async fn run_rmk_split_peripheral<
 
     #[cfg(not(feature = "_nrf_ble"))]
     run_rmk_split_peripheral_with_matrix::<
-        Matrix<In, Out, DefaultDebouncer<ROW, COL>, ROW, COL>,
+        _,
         S,
         ROW,
         COL,
@@ -116,7 +116,7 @@ pub async fn run_rmk_split_peripheral_direct_pin<
 
     #[cfg(feature = "_nrf_ble")]
     run_rmk_split_peripheral_with_matrix::<
-        DirectPinMatrix<In, DefaultDebouncer<COL, ROW>, ROW, COL, SIZE>,
+        _,
         ROW,
         COL,
     >(matrix, central_addr, peripheral_addr, spawner)
@@ -124,7 +124,7 @@ pub async fn run_rmk_split_peripheral_direct_pin<
 
     #[cfg(not(feature = "_nrf_ble"))]
     run_rmk_split_peripheral_with_matrix::<
-        DirectPinMatrix<In, DefaultDebouncer<COL, ROW>, ROW, COL, SIZE>,
+        _,
         S,
         ROW,
         COL,

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -61,22 +61,21 @@ pub async fn run_rmk_split_peripheral<
     #[cfg(not(feature = "col2row"))]
     let matrix = Matrix::<_, _, _, COL, ROW>::new(input_pins, output_pins, debouncer);
 
+    #[cfg(feature = "_nrf_ble")]
     run_rmk_split_peripheral_with_matrix::<
         Matrix<In, Out, DefaultDebouncer<ROW, COL>, ROW, COL>,
-        #[cfg(not(feature = "_nrf_ble"))] S,
         ROW,
         COL,
-    >(
-        matrix,
-        #[cfg(feature = "_nrf_ble")]
-        central_addr,
-        #[cfg(feature = "_nrf_ble")]
-        peripheral_addr,
-        #[cfg(not(feature = "_nrf_ble"))]
-        serial,
-        #[cfg(feature = "_nrf_ble")]
-        spawner,
-    )
+    >(matrix, central_addr, peripheral_addr, spawner)
+    .await;
+
+    #[cfg(not(feature = "_nrf_ble"))]
+    run_rmk_split_peripheral_with_matrix::<
+        Matrix<In, Out, DefaultDebouncer<ROW, COL>, ROW, COL>,
+        S,
+        ROW,
+        COL,
+    >(matrix, serial)
     .await;
 }
 
@@ -115,22 +114,21 @@ pub async fn run_rmk_split_peripheral_direct_pin<
     // Keyboard matrix
     let matrix = DirectPinMatrix::<_, _, ROW, COL, SIZE>::new(direct_pins, debouncer, low_active);
 
+    #[cfg(feature = "_nrf_ble")]
     run_rmk_split_peripheral_with_matrix::<
         DirectPinMatrix<In, DefaultDebouncer<COL, ROW>, ROW, COL, SIZE>,
-        #[cfg(not(feature = "_nrf_ble"))] S,
         ROW,
         COL,
-    >(
-        matrix,
-        #[cfg(feature = "_nrf_ble")]
-        central_addr,
-        #[cfg(feature = "_nrf_ble")]
-        peripheral_addr,
-        #[cfg(not(feature = "_nrf_ble"))]
-        serial,
-        #[cfg(feature = "_nrf_ble")]
-        spawner,
-    )
+    >(matrix, central_addr, peripheral_addr, spawner)
+    .await;
+
+    #[cfg(not(feature = "_nrf_ble"))]
+    run_rmk_split_peripheral_with_matrix::<
+        DirectPinMatrix<In, DefaultDebouncer<COL, ROW>, ROW, COL, SIZE>,
+        S,
+        ROW,
+        COL,
+    >(matrix, serial)
     .await;
 }
 


### PR DESCRIPTION
Added `run_rmk_with_async_flash_and_matrix`, `run_rmk_split_central_with_matrix`, and `run_rmk_split_peripheral_with_matrix`.

This will allow keyboards to override matrix scanning, in order to adjust timing, logic levels, etc.