### PR TITLE
Fixed issues that caused compilation to fail on esp32-s3 when using direct pins

### DIFF
--- a/rmk-macro/src/entry.rs
+++ b/rmk-macro/src/entry.rs
@@ -120,7 +120,7 @@ pub(crate) fn rmk_entry_direct_pin(keyboard_config: &KeyboardConfig) -> TokenStr
             .await;
         },
         ChipSeries::Esp32 => quote! {
-            ::esp_idf_svc::hal::task::block_on(::rmk::direct_pin::run_rmk_direct_pin::<_, ::esp_idf_svc::hal::gpio::Output, ROW, COL, SIZE, NUM_LAYER>(
+            ::esp_idf_svc::hal::task::block_on(::rmk::direct_pin::run_rmk_direct_pin::<_, ::esp_idf_svc::hal::gpio::PinDriver<AnyOutputPin, Output>, ROW, COL, SIZE, NUM_LAYER>(
                 direct_pins,
                 &mut get_default_keymap(),
                 keyboard_config,

--- a/rmk/src/storage/mod.rs
+++ b/rmk/src/storage/mod.rs
@@ -580,10 +580,12 @@ impl<F: AsyncNorFlash, const ROW: usize, const COL: usize, const NUM_LAYER: usiz
             {
                 match item {
                     StorageData::KeymapKey(key) => {
-                        assert!(key.layer < NUM_LAYER);
-                        assert!(key.row < ROW);
-                        assert!(key.col < COL);
-                        keymap[key.layer][key.row][key.col] = key.action;
+                        if key.layer < NUM_LAYER && key.row < ROW && key.col < COL {
+                            assert!(key.layer < NUM_LAYER);
+                            assert!(key.row < ROW);
+                            assert!(key.col < COL);
+                            keymap[key.layer][key.row][key.col] = key.action;
+                        }
                     }
                     _ => continue,
                 }

--- a/rmk/src/storage/mod.rs
+++ b/rmk/src/storage/mod.rs
@@ -581,9 +581,6 @@ impl<F: AsyncNorFlash, const ROW: usize, const COL: usize, const NUM_LAYER: usiz
                 match item {
                     StorageData::KeymapKey(key) => {
                         if key.layer < NUM_LAYER && key.row < ROW && key.col < COL {
-                            assert!(key.layer < NUM_LAYER);
-                            assert!(key.row < ROW);
-                            assert!(key.col < COL);
                             keymap[key.layer][key.row][key.col] = key.action;
                         }
                     }


### PR DESCRIPTION
For the first commit, it was discovered that esp-idf-srv::hal::gpio::Output, in fact, does not implement embedded_hal::digital::OutputPin at all. The trait was only implemented for PinDriver.
For the second commit, the iterator returned more keymaps than was defined. The patch was hacky, but it works, review required.