### PR TITLE
Add #[serde(deny_unknown_fields)] to config

### DIFF
--- a/examples/use_config/stm32h7/keyboard.toml
+++ b/examples/use_config/stm32h7/keyboard.toml
@@ -50,6 +50,6 @@ scrolllock.low_active = false
 
 [ble]
 enabled = true
-battery_pin = "PA0"
+battery_adc_pin = "PA0"
 charge_state.pin = "PA0"
 charge_state.low_active = true

--- a/rmk-macro/src/config/mod.rs
+++ b/rmk-macro/src/config/mod.rs
@@ -74,6 +74,7 @@ pub struct MatrixConfig {
 
 /// Config for storage
 #[derive(Clone, Copy, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct StorageConfig {
     /// Start address of local storage, MUST BE start of a sector.
     /// If start_addr is set to 0(this is the default value), the last `num_sectors` sectors will be used.
@@ -87,6 +88,7 @@ pub struct StorageConfig {
 }
 
 #[derive(Clone, Default, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BleConfig {
     pub enabled: bool,
     pub battery_adc_pin: Option<String>,
@@ -98,6 +100,7 @@ pub struct BleConfig {
 
 /// Config for lights
 #[derive(Clone, Default, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LightConfig {
     pub capslock: Option<PinConfig>,
     pub scrolllock: Option<PinConfig>,
@@ -106,6 +109,7 @@ pub struct LightConfig {
 
 /// Config for a single pin
 #[derive(Clone, Default, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PinConfig {
     pub pin: String,
     pub low_active: bool,
@@ -113,6 +117,7 @@ pub struct PinConfig {
 
 /// Configurations for dependencies
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DependencyConfig {
     /// Enable defmt log or not
     #[serde(default = "default_true")]
@@ -127,6 +132,7 @@ impl Default for DependencyConfig {
 
 /// Configurations for keyboard layout
 #[derive(Clone, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LayoutConfig {
     pub rows: u8,
     pub cols: u8,
@@ -136,6 +142,7 @@ pub struct LayoutConfig {
 
 /// Configurations for actions behavior
 #[derive(Clone, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BehaviorConfig {
     pub tri_layer: Option<TriLayerConfig>,
     pub tap_hold: Option<TapHoldConfig>,
@@ -145,6 +152,7 @@ pub struct BehaviorConfig {
 
 /// Configurations for tap hold
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TapHoldConfig {
     pub enable_hrm: Option<bool>,
     pub prior_idle_time: Option<DurationMillis>,
@@ -154,6 +162,7 @@ pub struct TapHoldConfig {
 
 /// Configurations for tri layer
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TriLayerConfig {
     pub upper: u8,
     pub lower: u8,
@@ -162,12 +171,14 @@ pub struct TriLayerConfig {
 
 /// Configurations for one shot
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OneShotConfig {
     pub timeout: Option<DurationMillis>,
 }
 
 /// Configurations for combos
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CombosConfig {
     pub combos: Vec<ComboConfig>,
     pub timeout: Option<DurationMillis>,
@@ -183,6 +194,7 @@ pub struct ComboConfig {
 
 /// Configurations for split keyboards
 #[derive(Clone, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SplitConfig {
     pub connection: String,
     pub central: SplitBoardConfig,
@@ -194,6 +206,7 @@ pub struct SplitConfig {
 /// Either ble_addr or serial must be set, but not both.
 #[allow(unused)]
 #[derive(Clone, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SplitBoardConfig {
     /// Row number of the split board
     pub rows: usize,
@@ -256,6 +269,7 @@ fn parse_duration_millis<'de, D: de::Deserializer<'de>>(deserializer: D) -> Resu
 ///
 #[derive(Clone, Debug, Default, Deserialize)]
 #[allow(unused)]
+#[serde(deny_unknown_fields)]
 pub struct InputDeviceConfig {
     pub encoder: Option<Vec<EncoderConfig>>,
     pub pointing: Option<Vec<PointingDeviceConfig>>,
@@ -263,6 +277,7 @@ pub struct InputDeviceConfig {
 
 #[derive(Clone, Debug, Default, Deserialize)]
 #[allow(unused)]
+#[serde(deny_unknown_fields)]
 pub struct EncoderConfig {
     // Pin a of the encoder
     pub pin_a: String,
@@ -280,6 +295,7 @@ pub struct EncoderConfig {
 /// Pointing device config
 #[derive(Clone, Debug, Default, Deserialize)]
 #[allow(unused)]
+#[serde(deny_unknown_fields)]
 pub struct PointingDeviceConfig {
     pub interface: Option<CommunicationProtocol>,
 }

--- a/rmk-macro/src/keyboard_config.rs
+++ b/rmk-macro/src/keyboard_config.rs
@@ -30,6 +30,7 @@ pub const COMBO_MAX_LENGTH: usize = 4;
 /// Keyboard's basic info
 #[allow(unused)]
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Basic {
     /// Keyboard name
     pub name: String,


### PR DESCRIPTION
This change will detect more `keyboard.toml` mistakes at compile time.

PS
Great job! You have the best default implementation of home row mods