### PR TITLE
Fix esp32 BLE serial number characteristic UUID

### DIFF
--- a/rmk/src/ble/esp/server.rs
+++ b/rmk/src/ble/esp/server.rs
@@ -93,7 +93,7 @@ impl BleServer {
         block_on(server.get_service(BleUuid::from_uuid16(0x180a)))
             .unwrap()
             .lock()
-            .create_characteristic(BleUuid::from_uuid16(0x2a50), NimbleProperties::READ)
+            .create_characteristic(BleUuid::from_uuid16(0x2a25), NimbleProperties::READ)
             .lock()
             .set_value(usb_config.serial_number.as_bytes());
 

--- a/rmk/src/ble/esp/server.rs
+++ b/rmk/src/ble/esp/server.rs
@@ -118,7 +118,7 @@ impl BleServer {
         block_on(server.get_service(BleUuid::from_uuid16(0x180a)))
             .unwrap()
             .lock()
-            .create_characteristic(BleUuid::from_uuid16(0x2a50), NimbleProperties::READ)
+            .create_characteristic(BleUuid::from_uuid16(0x2a25), NimbleProperties::READ)
             .lock()
             .set_value(usb_config.serial_number.as_bytes());
         let input_vial = vial_hid.input_report(0);


### PR DESCRIPTION
The serial number string for Esp32 BLE was stored in a characteristic with the wrong UUID 0x2a50 (PnP ID) instead of 0x2A25 (Serial Number String) [see here](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Assigned_Numbers/out/en/Assigned_Numbers.pdf?v=1740135081988) page 92.
Note: that later in the code your setting the PnP ID, essentially overriding whatever serial number was there anyway