### PR TITLE
feat(display): a demo to use display in RMK

### DIFF
--- a/rmk-macro/src/bind_interrupt.rs
+++ b/rmk-macro/src/bind_interrupt.rs
@@ -75,6 +75,7 @@ pub(crate) fn bind_interrupt_default(keyboard_config: &KeyboardConfig) -> TokenS
                     quote! {
                         #interrupt_name => ::embassy_nrf::usb::InterruptHandler<::embassy_nrf::peripherals::#peripheral_name>;
                         #saadc_interrupt
+                        SPIM3 => ::embassy_nrf::spim::InterruptHandler<::embassy_nrf::peripherals::SPI3>;
                         CLOCK_POWER => ::embassy_nrf::usb::vbus_detect::InterruptHandler;
                     }
                 } else {

--- a/rmk-macro/src/bus.rs
+++ b/rmk-macro/src/bus.rs
@@ -1,0 +1,90 @@
+use std::fmt::format;
+
+use crate::{
+    config::{CommunicationProtocol, CommunicationProtocolType},
+    ChipModel, ChipSeries,
+};
+use quote::{format_ident, quote};
+pub(crate) fn convert_bus_name_into_identity(
+    name: &String,
+    protocol_type: &CommunicationProtocolType,
+) -> proc_macro2::Ident {
+    match protocol_type {
+        CommunicationProtocolType::I2C(_) => {
+            format_ident!("{}_i2c_protocol", name)
+        }
+        CommunicationProtocolType::SPI(_) => {
+            format_ident!("{}_spi_protocol", name)
+        }
+    }
+}
+
+pub(crate) fn expand_communication_bus_config(
+    bus_config: &Option<Vec<CommunicationProtocol>>,
+    chip: &ChipModel,
+) -> proc_macro2::TokenStream {
+    let mut initializers = proc_macro2::TokenStream::new();
+    if let Some(config) = bus_config {
+        config.iter().for_each(|conf| match conf {
+            CommunicationProtocol::I2C(_i2c) => {
+                // let protocol_name = convert_bus_name_into_identity(
+                //     &i1c.instance,
+                //     CommunicationProtocolType::I1C(String::new()),
+                // );
+                initializers.extend(quote! {
+                    // TODO
+                    compile_error!("I2C is not supported yet");
+                    // let #protocol_name =
+                });
+            }
+            CommunicationProtocol::SPI(spi) => {
+                let protocol_name = convert_bus_name_into_identity(
+                                        &spi.instance,
+                                        &CommunicationProtocolType::SPI(String::new()),
+                                    );
+                match chip.series {
+                    ChipSeries::Nrf52 => {
+                        let config = quote!{
+                            ::embassy_nrf::interrupt::SPIM3.set_priority(::embassy_nrf::interrupt::Priority::P5);
+                            let mut config = ::embassy_nrf::spim::Config::default();
+                            config.frequency = ::embassy_nrf::spim::Frequency::M1;
+                        };
+                        let sck_pin = format_ident!("{}", spi.sck);
+                        if spi.miso.is_none() && spi.mosi.is_none() {
+                            initializers.extend(quote!{compile_error!("MISO or MOSI pin is required for SPI");});
+                        } else if spi.miso.is_none() {
+                            let mosi_pin = format_ident!("{}", spi.mosi.as_ref().unwrap());
+                            initializers.extend(quote! {
+                                let #protocol_name = {
+                                    #config
+                                    ::embassy_nrf::spim::Spim::new_txonly(p.SPI3, Irqs, p.#sck_pin, p.#mosi_pin, config)
+                                };
+                            });
+                        } else if spi.mosi.is_none() {
+                            let miso_pin = format_ident!("{}", spi.miso.as_ref().unwrap());
+                            initializers.extend(quote! {
+                                let #protocol_name = {
+                                    #config
+                                    ::embassy_nrf::spim::Spim::new_rxonly(p.SPI3, Irqs, p.#sck_pin, p.#miso_pin, config)
+                                };
+                            });
+                        } else {
+                            let miso_pin = format_ident!("{}", spi.miso.as_ref().unwrap());
+                            let mosi_pin = format_ident!("{}", spi.mosi.as_ref().unwrap());
+                            initializers.extend(quote! {
+                                let #protocol_name = {
+                                    #config
+                                    ::embassy_nrf::spim::Spim::new(p.SPI3, Irqs, p.#sck_pin, p.#miso_pin, p.#mosi_pin, config)
+                                };
+                            });
+                        }
+                    },
+                    _ => {
+                        initializers.extend(quote!{compile_error!("SPI is not supported except nrf52 yet");});
+                    }
+                }
+            }
+        });
+    }
+    initializers
+}

--- a/rmk-macro/src/config/mod.rs
+++ b/rmk-macro/src/config/mod.rs
@@ -26,6 +26,10 @@ pub struct KeyboardTomlConfig {
     pub split: Option<SplitConfig>,
     /// Input device config
     pub input_device: Option<InputDeviceConfig>,
+    /// Display config
+    pub display: Option<DisplayConfig>,
+    /// Bus config
+    pub bus: Option<CommunicationProtocol>,
 }
 
 /// Configurations for keyboard info
@@ -224,6 +228,19 @@ pub struct SplitBoardConfig {
     pub matrix: MatrixConfig,
     /// Input device config for the split
     pub input_device: Option<InputDeviceConfig>,
+    /// Display
+    pub display: Option<DisplayConfig>,
+    /// Bus
+    pub bus: Option<Vec<CommunicationProtocol>>,
+}
+
+/// Display config
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DisplayConfig {
+    pub instance: Option<String>,
+    pub bus: String,
+    pub interface: CommunicationProtocolType,
 }
 
 /// Serial port config
@@ -293,30 +310,43 @@ pub struct EncoderConfig {
 }
 
 /// Pointing device config
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[allow(unused)]
 #[serde(deny_unknown_fields)]
 pub struct PointingDeviceConfig {
-    pub interface: Option<CommunicationProtocol>,
+    pub bus: Option<String>,
+    pub interface: CommunicationProtocolType,
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "protocol", content = "config")]
+#[serde(deny_unknown_fields)]
 #[allow(unused)]
 pub enum CommunicationProtocol {
     I2C(I2cConfig),
     SPI(SpiConfig),
 }
 
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "protocol", content = "config")]
+#[serde(deny_unknown_fields)]
+#[allow(unused)]
+pub enum CommunicationProtocolType {
+    /// I2C with address
+    I2C(String),
+    /// SPI with cs pin
+    SPI(String),
+}
+
 /// SPI config
 #[derive(Clone, Debug, Default, Deserialize)]
 #[allow(unused)]
+#[serde(deny_unknown_fields)]
 pub struct SpiConfig {
     pub instance: String,
     pub sck: String,
-    pub mosi: String,
-    pub miso: String,
-    pub cs: Option<String>,
-    pub cpi: Option<u32>,
+    pub mosi: Option<String>,
+    pub miso: Option<String>,
 }
 
 /// I2C config
@@ -326,5 +356,4 @@ pub struct I2cConfig {
     pub instance: String,
     pub sda: String,
     pub scl: String,
-    pub address: u8,
 }

--- a/rmk-macro/src/display.rs
+++ b/rmk-macro/src/display.rs
@@ -1,0 +1,49 @@
+use std::convert;
+
+use crate::{
+    bus::convert_bus_name_into_identity,
+    config::{CommunicationProtocolType, DisplayConfig},
+};
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+
+pub(crate) fn convert_display_name_into_identity(
+    config_name: &Option<String>,
+) -> proc_macro2::Ident {
+    let name = if let Some(n) = config_name {
+        n
+    } else {
+        "default"
+    };
+    let ident = format_ident!("{}_display", name);
+    ident
+}
+
+pub(crate) fn expand_display_config(config: &Option<DisplayConfig>) -> TokenStream2 {
+    if let Some(conf) = config {
+        let bus_ident = convert_bus_name_into_identity(&conf.bus, &conf.interface);
+        let display_name = convert_display_name_into_identity(&conf.instance);
+        match &conf.interface {
+            CommunicationProtocolType::I2C(_address) => {
+                quote! {
+                    compile_error!("I2C protocol display is not supported yet");
+                }
+            }
+            CommunicationProtocolType::SPI(cs) => {
+                let cs_pin = format_ident!("{}", cs);
+                quote! {
+                    let #display_name =
+                        ::rmk::display::memory_lcd_spi::MemoryLCD::<::rmk::display::NiceView, _, _>::new(
+                            #bus_ident,
+                            ::embassy_nrf::gpio::Output::new(
+                                ::embassy_nrf::gpio::AnyPin::from(p.#cs_pin),
+                                ::embassy_nrf::gpio::Level::High,
+                                ::embassy_nrf::gpio::OutputDrive::Standard
+                            ));
+                }
+            }
+        }
+    } else {
+        quote! {}
+    }
+}

--- a/rmk-macro/src/lib.rs
+++ b/rmk-macro/src/lib.rs
@@ -1,10 +1,12 @@
 mod behavior;
 mod bind_interrupt;
 mod ble;
+mod bus;
 mod chip_init;
 mod comm;
 mod config;
 mod default_config;
+mod display;
 mod entry;
 mod feature;
 mod flash;

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -43,6 +43,9 @@ sequential-storage = { version = "4.0.0" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 postcard = { version = "1", features = ["experimental-derive"] }
 
+embedded-graphics = { version = "0.8", optional = true }
+memory-lcd-spi = { version = "0.0.8", git = "https://github.com/andelf/memory-lcd-spi", optional = true }
+
 # Optional dependencies
 # nRF dependencies
 once_cell = { version = "1.19", features = [
@@ -119,7 +122,7 @@ _no_usb = []
 _no_external_storage = []
 
 #! ### BLE feature flags
-#! 
+#!
 #! ⚠️ Due to the limitation of docs.rs, functions gated by BLE features won't show in docs.rs. You have to head to [`examples`](https://github.com/HaoboGu/rmk/tree/main/examples) folder of RMK repo for their usages.
 ## Enable feature if you want to use nRF52840 with BLE.
 nrf52840_ble = [
@@ -173,3 +176,4 @@ _esp_ble = [
 ]
 _nrf_ble = ["_ble", "dep:nrf-softdevice", "dep:embassy-nrf", "dep:once_cell"]
 _ble = ["_no_external_storage"]
+display = ["dep:embedded-graphics", "dep:memory-lcd-spi"]

--- a/rmk/src/display/mod.rs
+++ b/rmk/src/display/mod.rs
@@ -1,0 +1,49 @@
+use embassy_time::Timer;
+use embedded_graphics::{
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::{PrimitiveStyle, Rectangle},
+};
+use embedded_hal::{digital::OutputPin, spi::SpiBus};
+pub use memory_lcd_spi;
+use memory_lcd_spi::{
+    framebuffer::{FramebufferBW, Sharp},
+    DisplaySpec, MemoryLCD,
+};
+
+pub struct NiceView;
+impl DisplaySpec for NiceView {
+    const WIDTH: u16 = 160;
+    const HEIGHT: u16 = 68;
+
+    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, Sharp>;
+}
+
+pub async fn run_display<SPEC, SPI, CS>(mut display: MemoryLCD<SPEC, SPI, CS>)
+where
+    SPEC: DisplaySpec,
+    <<SPEC as DisplaySpec>::Framebuffer as embedded_graphics::draw_target::DrawTarget>::Error:
+        core::fmt::Debug,
+    <SPEC as DisplaySpec>::Framebuffer: DrawTarget<Color = BinaryColor>,
+    SPI: SpiBus,
+    CS: OutputPin,
+{
+    let mut battery = 0;
+    let screen_size = display.size();
+    loop {
+        display.clear(BinaryColor::Off).unwrap();
+        battery += 5;
+        if battery > 100 {
+            battery = 0;
+        }
+        Rectangle::new(
+            Point::new(0, 0),
+            Size::new(screen_size.width * battery / 100, screen_size.height),
+        )
+        .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+        .draw(&mut *display)
+        .unwrap();
+        display.update().unwrap();
+        Timer::after_millis(200).await;
+    }
+}

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -68,6 +68,8 @@ pub mod combo;
 pub mod config;
 pub mod debounce;
 pub mod direct_pin;
+#[cfg(feature = "display")]
+pub mod display;
 pub mod event;
 mod flash;
 mod hid;


### PR DESCRIPTION
This is just a demo
add SPI and I2C bus support for TOML configuration 
add display support for RMK firmware

- [ ] migrate to abstract layer `controller`
- [ ] display BLE status
- [ ] display battery status
- [ ] some arts (image?)