### PR TITLE
feat(boot): jump to Adafruit Nrf52 bootloader

### DIFF
--- a/.github/workflows/build esp.yml
+++ b/.github/workflows/build esp.yml
@@ -42,5 +42,5 @@ jobs:
       - name: Build
         working-directory: ./examples/${{ matrix.example_type }}/${{ matrix.chip }}_ble
         run: |
-          cargo build --release 
+          cargo +esp build --release 
           cargo clean

--- a/.github/workflows/build esp.yml
+++ b/.github/workflows/build esp.yml
@@ -42,5 +42,5 @@ jobs:
       - name: Build
         working-directory: ./examples/${{ matrix.example_type }}/${{ matrix.chip }}_ble
         run: |
-          cargo +esp build --release 
+          cargo build --release 
           cargo clean

--- a/.github/workflows/build esp.yml
+++ b/.github/workflows/build esp.yml
@@ -41,6 +41,4 @@ jobs:
         run: espup install
       - name: Build
         working-directory: ./examples/${{ matrix.example_type }}/${{ matrix.chip }}_ble
-        run: |
-          cargo +esp build --release 
-          cargo clean
+        run: cargo build --release 

--- a/.github/workflows/build esp.yml
+++ b/.github/workflows/build esp.yml
@@ -41,4 +41,4 @@ jobs:
         run: espup install
       - name: Build
         working-directory: ./examples/${{ matrix.example_type }}/${{ matrix.chip }}_ble
-        run: cargo build --release 
+        run: cargo +esp build --release 

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -199,4 +199,4 @@ rp2040_pio = [
     "dep:fixed",
 ]
 
-adafruit = ["_nrf_ble"]
+adafruit_bl = ["_nrf_ble"]

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -134,7 +134,7 @@ _no_usb = []
 _no_external_storage = []
 
 #! ### BLE feature flags
-#! 
+#!
 #! ⚠️ Due to the limitation of docs.rs, functions gated by BLE features won't show in docs.rs. You have to head to [`examples`](https://github.com/HaoboGu/rmk/tree/main/examples) folder of RMK repo for their usages.
 ## Enable feature if you want to use nRF52840 with BLE.
 nrf52840_ble = [
@@ -196,5 +196,7 @@ rp2040_pio = [
     "dep:rp-pac",
     "dep:pio",
     "dep:pio-proc",
-    "dep:fixed"
+    "dep:fixed",
 ]
+
+adafruit = ["_nrf_ble"]

--- a/rmk/src/boot.rs
+++ b/rmk/src/boot.rs
@@ -1,14 +1,14 @@
 pub fn jump_to_bootloader() {
     // TODO: support more MCUs
 
-    #[cfg(feature = "adafruit")]
+    #[cfg(feature = "adafruit_bl")]
     //reference: https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/d6b28e66053eea467166f44875e3c7ec741cb471/src/main.c#L107
     embassy_nrf::pac::POWER
         .gpregret()
         .write_value(embassy_nrf::pac::power::regs::Gpregret(0x57));
 
-    #[cfg(not(any(feature = "adafruit")))]
-    warn!("Jump-to-Bootloader is unsupported for the chip");
+    #[cfg(not(any(feature = "adafruit_bl")))]
+    warn!("Please specified a bootloader to jump to!");
 
     reboot_keyboard();
 }

--- a/rmk/src/boot.rs
+++ b/rmk/src/boot.rs
@@ -1,0 +1,28 @@
+pub fn jump_to_bootloader() {
+    // TODO: support more MCUs
+
+    #[cfg(feature = "adafruit")]
+    //reference: https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/d6b28e66053eea467166f44875e3c7ec741cb471/src/main.c#L107
+    embassy_nrf::pac::POWER
+        .gpregret()
+        .write_value(embassy_nrf::pac::power::regs::Gpregret(0x57));
+
+    #[cfg(not(any(feature = "adafruit")))]
+    warn!("Jump-to-Bootloader is unsupported for the chip");
+
+    reboot_keyboard();
+}
+
+pub(crate) fn reboot_keyboard() {
+    warn!("Rebooting keyboard!");
+    // For cortex-m:
+    #[cfg(all(
+        target_arch = "arm",
+        target_os = "none",
+        any(target_abi = "eabi", target_abi = "eabihf")
+    ))]
+    cortex_m::peripheral::SCB::sys_reset();
+
+    #[cfg(feature = "_esp_ble")]
+    esp_idf_svc::hal::reset::restart();
+}

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1,3 +1,4 @@
+use crate::boot;
 use crate::channel::{KEYBOARD_REPORT_CHANNEL, KEY_EVENT_CHANNEL};
 use crate::combo::{Combo, COMBO_MAX_LENGTH};
 use crate::config::BehaviorConfig;
@@ -813,6 +814,8 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
             self.process_action_macro(key, key_event).await;
         } else if key.is_combo() {
             self.process_action_combo(key, key_event).await;
+        } else if key.is_boot() {
+            self.process_boot(key, key_event);
         } else {
             warn!("Unsupported key: {:?}", key);
         }
@@ -965,6 +968,20 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
                 embassy_time::Timer::after_millis(20).await;
                 KEY_EVENT_CHANNEL.try_send(key_event).ok();
             }
+        }
+    }
+
+    fn process_boot(&mut self, key: KeyCode, key_event: KeyEvent) {
+        if key_event.pressed {
+            match key {
+                KeyCode::Bootloader => {
+                    boot::jump_to_bootloader();
+                }
+                KeyCode::Reboot => {
+                    boot::reboot_keyboard();
+                }
+                _ => (), // unreachable, do nothing
+            };
         }
     }
 

--- a/rmk/src/keycode.rs
+++ b/rmk/src/keycode.rs
@@ -7,7 +7,7 @@ use num_enum::FromPrimitive;
 /// 1 bit for Left/Right, 4 bits for modifier type. Represented in LSB format.
 ///
 /// | bit4 | bit3 | bit2 | bit1 | bit0 |
-/// | --- | --- | --- | --- | --- |  
+/// | --- | --- | --- | --- | --- |
 /// | L/R | GUI | ALT |SHIFT| CTRL|
 #[bitfield(u8, order = Lsb)]
 #[derive(Eq, PartialEq)]
@@ -998,6 +998,11 @@ impl KeyCode {
     /// Returns `true` if the keycode is a combo keycode
     pub(crate) fn is_combo(self) -> bool {
         KeyCode::ComboOn <= self && self <= KeyCode::ComboToggle
+    }
+
+    /// Returns `true` if the keycode is a combo keycode
+    pub(crate) fn is_boot(self) -> bool {
+        KeyCode::Bootloader <= self && self <= KeyCode::Reboot
     }
 
     /// Returns `true` if the keycode is a kb keycode

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -1,11 +1,11 @@
 use crate::{
     action::KeyAction,
+    boot::reboot_keyboard,
     combo::{Combo, COMBO_MAX_NUM},
     config::BehaviorConfig,
     event::KeyEvent,
     keyboard_macro::{MacroOperation, MACRO_SPACE_SIZE},
     keycode::KeyCode,
-    reboot_keyboard,
     storage::Storage,
 };
 use embedded_storage_async::nor_flash::NorFlash;

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -79,6 +79,7 @@ use {
 pub mod action;
 #[cfg(feature = "_ble")]
 pub mod ble;
+mod boot;
 pub mod channel;
 pub mod combo;
 pub mod config;
@@ -395,20 +396,6 @@ pub(crate) async fn run_keyboard<
 
 pub(crate) async fn run_usb_device<'d, D: Driver<'d>>(usb_device: &mut UsbDevice<'d, D>) {
     usb_device.run().await;
-}
-
-pub(crate) fn reboot_keyboard() {
-    warn!("Rebooting keyboard!");
-    // For cortex-m:
-    #[cfg(all(
-        target_arch = "arm",
-        target_os = "none",
-        any(target_abi = "eabi", target_abi = "eabihf")
-    ))]
-    cortex_m::peripheral::SCB::sys_reset();
-
-    #[cfg(feature = "_esp_ble")]
-    esp_idf_svc::hal::reset::restart();
 }
 
 /// Runnable trait defines `run` function for running the task

--- a/rmk/src/via/keycode_convert.rs
+++ b/rmk/src/via/keycode_convert.rs
@@ -15,8 +15,9 @@ pub(crate) fn to_via_keycode(key_action: KeyAction) -> u16 {
                     k as u16 & 0xFF | 0x7700
                 } else if k.is_user() {
                     k as u16 & 0xF | 0x7E00
-                } else if k.is_combo() {
-                    k as u16 & 0xF | 0x7C50
+                } else if k.is_combo() || k.is_boot() {
+                    // is_rmk() 's subset
+                    k as u16 & 0xFF | 0x7C00
                 } else {
                     k as u16
                 }
@@ -164,9 +165,10 @@ pub(crate) fn from_via_keycode(via_keycode: u16) -> KeyAction {
             warn!("Backlight and RGB configuration key not supported");
             KeyAction::No
         }
-        0x7C50..=0x7C52 => {
-            // Combo
-            let keycode = via_keycode & 0xFF | 0x750;
+        // boot related | combo related
+        0x7C00..=0x7C01 | 0x7C50..=0x7C52 => {
+            // is_rmk() 's related
+            let keycode = via_keycode & 0xFF | 0x700;
             KeyAction::Single(Action::Key(KeyCode::from_primitive(keycode)))
         }
         0x7C00..=0x7C5F => {

--- a/rmk/src/via/mod.rs
+++ b/rmk/src/via/mod.rs
@@ -1,4 +1,5 @@
 use crate::{
+    boot,
     channel::FLASH_CHANNEL,
     config::VialConfig,
     hid::{HidError, HidReaderTrait, HidWriterTrait},
@@ -202,7 +203,8 @@ impl<
                 // TODO: Reboot after a eeprom reset?
             }
             ViaCommand::BootloaderJump => {
-                warn!("Bootloader jump -- not supported")
+                warn!("Bootloader jumping");
+                boot::jump_to_bootloader();
             }
             ViaCommand::DynamicKeymapMacroGetCount => {
                 report.input_data[1] = 8;


### PR DESCRIPTION
Add support for Bootloader key (only non-split or central in split support now)

configure in vial: 
- RESET for reset into bootloader
- 0x7c51 for normal reset

related issue: #253 