### PR TITLE
refactry tap hold （testing）

### DIFF
--- a/rmk/src/event.rs
+++ b/rmk/src/event.rs
@@ -1,7 +1,8 @@
+use embassy_time::Instant;
 use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
 
-use crate::input_device::rotary_encoder::Direction;
+use crate::{action::Action, input_device::rotary_encoder::Direction};
 
 /// Raw events from input devices and keyboards
 ///
@@ -92,4 +93,15 @@ pub struct KeyEvent {
     pub row: u8,
     pub col: u8,
     pub pressed: bool,
+}
+
+// record pressing tap hold keys
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PressedKeyEvent {
+    pub key_event: KeyEvent,
+    pub tap_action: Action,
+    pub hold_action: Action,
+    pub pressed_time: Instant,
+    pub deadline: u64,
 }


### PR DESCRIPTION
## issue 1  hold key is not properly trigger while it's first pressed key while rolling keys

assume the  keymap is 

h for normal h
d for  modtap (d, lgui)
g for  modtap (g, lsfhit)

when inputing key event sequence  [ d press, g press , d release, g release ] within hold timeout

will trigger  Lgui + g

in key event sequence: [  h press, g press, h release, g release ]

will output `h g`

to process rolling keys properly, tap hold should detect self release before hold time and idle timeout and trigger a tapping instead of holding

## issue 2   tap-hold key's hold behavior is ignored by enable_hrm option while quick typing

When enable_hrm is enabled, holding a tap-hold key after the previous key is released within the key timeout will always trigger the tapping action. This behavior makes it difficult to activate the "hold" functionality during fast typing.

To address this, I plan to modify the detection mechanism so that it triggers on key release or after the hold timeout, rather than during the initial press event. This change will prevent the "tap" action from being triggered too eagerly.

updates：

I reimplemented the time processing of taphold. Move the clock part to the main event loop.
This reconstruction is not complete, I can only guarantee that the main hrm capabilities in my test model and daily use can meet my personal requirements.

