### PR TITLE
removed pio-proc, as it is an internal use crate.

### DIFF
--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -79,7 +79,6 @@ embassy-rp = { version = "0.4", optional = true }
 embassy-hal-internal = { version = "0.2.0", optional = true }
 rp-pac = { version = "7.0.0", optional = true }
 pio = { version = "0.3.0", optional = true }
-pio-proc = { version = "0.3.0", optional = true }
 fixed = { version = "1.28.0", optional = true }
 
 # Document feature
@@ -197,7 +196,6 @@ rp2040_pio = [
     "dep:embassy-hal-internal",
     "dep:rp-pac",
     "dep:pio",
-    "dep:pio-proc",
     "dep:fixed",
 ]
 

--- a/rmk/src/split/rp/uart.rs
+++ b/rmk/src/split/rp/uart.rs
@@ -23,7 +23,6 @@ use embassy_sync::waitqueue::AtomicWaker;
 use embassy_time::{Duration, Timer};
 use embedded_io_async::{ErrorType, Read, Write};
 use fixed::traits::ToFixed;
-use pio_proc;
 use rp_pac::io::vals::Oeover;
 
 pub struct IrqBinding;
@@ -219,7 +218,7 @@ impl<'a, PIO: Instance + UartPioAccess> BufferedUart<'a, PIO> {
     }
 
     fn setup_sm_tx(&mut self) {
-        let prg = pio_proc::pio_asm!(
+        let prg = pio::pio_asm!(
             ".side_set 1 opt pindirs",
             ".wrap_target",
             "pull   block           side 1 [7]",
@@ -252,7 +251,7 @@ impl<'a, PIO: Instance + UartPioAccess> BufferedUart<'a, PIO> {
     }
 
     fn setup_sm_rx(&mut self) {
-        let prg = pio_proc::pio_asm!(
+        let prg = pio::pio_asm!(
             ".wrap_target",
             "wait_idle:",
             "    wait 0 pin, 0",


### PR DESCRIPTION
Using pio directly instead. Compiles, and works on the central, still haven't gotten the peripheral working.