### PR TITLE
added artificial pull up resistor to pio tx line.

### DIFF
--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -96,7 +96,7 @@ features = ["split"]
 cortex-m = { version = "0.7" }
 
 [features]
-default = ["col2row", "split", "rp2040_pio", "rp2040_bl", "defmt"]
+default = ["col2row", "defmt"]
 
 ## If your PCB diode's direction is col2row, enable this feature. If it's row2col, disable this feature by `default-features = false`.
 col2row = []

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -96,7 +96,7 @@ features = ["split"]
 cortex-m = { version = "0.7" }
 
 [features]
-default = ["col2row", "defmt"]
+default = ["col2row", "split", "rp2040_pio", "rp2040_bl", "defmt"]
 
 ## If your PCB diode's direction is col2row, enable this feature. If it's row2col, disable this feature by `default-features = false`.
 col2row = []

--- a/rmk/src/split/rp/uart.rs
+++ b/rmk/src/split/rp/uart.rs
@@ -213,7 +213,6 @@ impl<'a, PIO: Instance + UartPioAccess> BufferedUart<'a, PIO> {
             pin.set_schmitt(true);
             pin.set_pull(Pull::Up);
             pin.set_slew_rate(SlewRate::Fast);
-            pin.set_drive_strength(Drive::_12mA);
         }
     }
 
@@ -241,9 +240,8 @@ impl<'a, PIO: Instance + UartPioAccess> BufferedUart<'a, PIO> {
         cfg.fifo_join = FifoJoin::TxOnly;
         self.sm_tx.set_config(&cfg);
 
-        self.set_pin_tx();
-
         if self.full_duplex {
+            self.set_pin_tx();
             self.sm_tx.set_enable(true);
         }
     }
@@ -326,8 +324,9 @@ impl<'a, PIO: Instance + UartPioAccess> BufferedUart<'a, PIO> {
         // OEOVER set to INVERT, Direction::Out inverted to Direction:In
         self.sm_tx.set_pins(Level::Low, &[&self.pin_rx]);
 
+        let pin_tx = self.pin_tx.as_mut().unwrap_or(&mut self.pin_rx);
         // unset our fake-pull-up trickery
-        self.pin_rx.set_drive_strength(Drive::_12mA);
+        pin_tx.set_drive_strength(Drive::_12mA);
     }
 
     fn set_pin_rx(&mut self){

--- a/rmk/src/split/rp/uart.rs
+++ b/rmk/src/split/rp/uart.rs
@@ -322,12 +322,12 @@ impl<'a, PIO: Instance + UartPioAccess> BufferedUart<'a, PIO> {
     }
 
     fn set_pin_tx(&mut self){
-        // unset our fake-pull-up trickery
-        self.pin_rx.set_drive_strength(Drive::_12mA);
-
+        self.sm_tx.set_pin_dirs(Direction::Out, &[&self.pin_rx]);
         // OEOVER set to INVERT, Direction::Out inverted to Direction:In
         self.sm_tx.set_pins(Level::Low, &[&self.pin_rx]);
-        self.sm_tx.set_pin_dirs(Direction::Out, &[&self.pin_rx]);
+
+        // unset our fake-pull-up trickery
+        self.pin_rx.set_drive_strength(Drive::_12mA);
     }
 
     fn set_pin_rx(&mut self){

--- a/rmk/src/split/rp/uart.rs
+++ b/rmk/src/split/rp/uart.rs
@@ -241,9 +241,7 @@ impl<'a, PIO: Instance + UartPioAccess> BufferedUart<'a, PIO> {
         cfg.fifo_join = FifoJoin::TxOnly;
         self.sm_tx.set_config(&cfg);
 
-        // OEOVER set to INVERT, Direction::Out inverted to Direction:In
-        self.sm_tx.set_pin_dirs(Direction::Out, &[pin_tx]);
-        self.sm_tx.set_pins(Level::Low, &[pin_tx]);
+        self.set_pin_tx();
 
         if self.full_duplex {
             self.sm_tx.set_enable(true);
@@ -290,9 +288,7 @@ impl<'a, PIO: Instance + UartPioAccess> BufferedUart<'a, PIO> {
         cfg.fifo_join = FifoJoin::RxOnly;
         self.sm_rx.set_config(&cfg);
 
-        // OEOVER set to INVERT, Direction::Out inverted to Direction:In
-        self.sm_rx.set_pin_dirs(Direction::Out, &[&self.pin_rx]);
-
+        self.set_pin_rx();
         self.sm_rx.set_enable(true);
     }
 
@@ -304,18 +300,7 @@ impl<'a, PIO: Instance + UartPioAccess> BufferedUart<'a, PIO> {
             .await;
         }
         self.sm_rx.set_enable(false);
-
-        // unset our fake-pull-up trickery
-        let pins = [Some(&mut self.pin_rx), self.pin_tx.as_mut()];
-        for pin in pins.into_iter().flatten() {
-            pin.set_drive_strength(Drive::_12mA);
-        }
-
-        let pin_tx = self.pin_tx.as_ref().unwrap_or(&self.pin_rx);
-        // OEOVER set to INVERT, Direction::Out inverted to Direction:In
-        self.sm_tx.set_pin_dirs(Direction::Out, &[pin_tx]);
-        self.sm_tx.set_pins(Level::Low, &[pin_tx]);
-
+        self.set_pin_tx();
         self.sm_tx.restart();
         self.sm_tx.set_enable(true);
     }
@@ -328,26 +313,35 @@ impl<'a, PIO: Instance + UartPioAccess> BufferedUart<'a, PIO> {
         .await;
         self.sm_tx.set_enable(false);
 
+        self.set_pin_rx();
+
+        PIO::uart_buffer()
+            .idle_line
+            .lock(|b| *b.borrow_mut() = true);
+        self.sm_rx.set_enable(true);
+    }
+
+    fn set_pin_tx(&mut self){
+        // unset our fake-pull-up trickery
+        self.pin_rx.set_drive_strength(Drive::_12mA);
+
+        // OEOVER set to INVERT, Direction::Out inverted to Direction:In
+        self.sm_tx.set_pins(Level::Low, &[&self.pin_rx]);
+        self.sm_tx.set_pin_dirs(Direction::Out, &[&self.pin_rx]);
+    }
+
+    fn set_pin_rx(&mut self){
         // The rp2040 has weak pull up resistors, from 80k to 50k. This does not provide enough
         // current to provide fast rise times at high baud rates with any moderately high
         // capacitance, even as little capacitance as can be found with long traces, a few vias, or
         // a longer TRRS cable. The solution is to also drive the line high at a weak drive current
         // from the reciving side, providing plenty of current to drive the line high quickly while
         // still being weak enough to be driven low from the tx side.
-        let pins = [Some(&mut self.pin_rx), self.pin_tx.as_mut()];
-        for pin in pins.into_iter().flatten() {
-            pin.set_drive_strength(Drive::_2mA);
-        }
+        self.pin_rx.set_drive_strength(Drive::_2mA);
 
-        let pin_tx = self.pin_tx.as_ref().unwrap_or(&self.pin_rx);
         // OEOVER set to INVERT, Direction::In inverted to Direction:Out
-        self.sm_tx.set_pin_dirs(Direction::In, &[pin_tx]);
-        self.sm_tx.set_pins(Level::High, &[pin_tx]);
-
-        PIO::uart_buffer()
-            .idle_line
-            .lock(|b| *b.borrow_mut() = true);
-        self.sm_rx.set_enable(true);
+        self.sm_rx.set_pins(Level::High, &[&self.pin_rx]);
+        self.sm_rx.set_pin_dirs(Direction::In, &[&self.pin_rx]);
     }
 
     fn read_buffer<'c>(


### PR DESCRIPTION
The rp2040 has weak pull up resistors, from 80k to 50k. This does not provide enough current to provide fast rise times at high baud rates with any moderately high capacitance, even as little capacitance as can be found with long traces, a few vias, or a longer TRRS cable. The solution is to also drive the line high at a weak drive current from the reciving side, providing plenty of current to drive the line high quickly while still being weak enough to be driven low from the tx side.