### PR TITLE
Configure unit test, add several simple unit test for keyboard

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,0 +1,38 @@
+name: Unit Test
+
+on:
+  push:
+    branches: ["main"]
+    paths: ["rmk/**"]
+  pull_request:
+    branches: ["main"]
+    paths: ["rmk/**"]
+  workflow_dispatch:
+
+# Cancel any currently running workflows from the same PR, branch, or
+# tag when a new workflow is triggered.
+#
+# https://stackoverflow.com/a/66336834
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+env: 
+  CARGO_TERM_COLOR: always
+
+jobs:
+  unit_test:
+    name: Run RMK unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Run tests
+        working-directory: ./rmk
+        run: cargo test --tests --no-default-features --verbose

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -221,3 +221,7 @@ rp2040_bl = ["dep:embassy-rp"]
 
 ## Enable feature if you're using Adafruit nRF52 bootloader and want bootloader jumping key
 adafruit_bl = ["_nrf_ble"]
+
+[lib]
+# Don't run doctest for lib
+doctest = false

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -48,7 +48,6 @@ postcard = { version = "1", features = ["experimental-derive"] }
 # Used in macro
 paste = "1"
 
-
 # Optional dependencies
 # nRF dependencies
 once_cell = { version = "1.19", features = [
@@ -84,6 +83,14 @@ fixed = { version = "1.28.0", optional = true }
 # Document feature
 document-features = "0.2"
 
+critical-section = { version = "1.2", optional = true }
+
+[dev-dependencies]
+# A hack for enabling 'std' feature in testing, ref: https://github.com/rust-lang/cargo/issues/2911
+rmk = { path = ".", default-features = false, features = ["std", "log"] }
+env_logger = "0.11"
+ctor = "0.4.1"
+
 [build-dependencies]
 chrono = "0.4"
 crc32fast = "1.3"
@@ -117,6 +124,16 @@ defmt = [
     "embassy-nrf?/defmt",
     "nrf-softdevice?/defmt",
     "postcard/use-defmt",
+]
+
+## Add std feature for testing
+std = [
+    "embassy-executor/arch-std",
+    "embassy-executor/executor-thread",
+    "embassy-executor/task-arena-size-32768",
+    "embassy-time/std",
+    "embassy-time/generic-queue-128",
+    "critical-section?/std",
 ]
 
 ## Enable async matrix scan

--- a/rmk/src/via/mod.rs
+++ b/rmk/src/via/mod.rs
@@ -66,7 +66,7 @@ impl<
             match self.process().await {
                 Ok(_) => continue,
                 Err(e) => {
-                    error!("Process vial error: {}", e);
+                    error!("Process vial error: {:?}", e);
                     Timer::after_millis(500).await
                 }
             }
@@ -164,7 +164,7 @@ impl<
                 let keycode = BigEndian::read_u16(&report.output_data[4..6]);
                 let action = from_via_keycode(keycode);
                 info!(
-                    "Setting keycode: 0x{:02X} at ({},{}), layer {} as {}",
+                    "Setting keycode: 0x{:02X} at ({},{}), layer {} as {:?}",
                     keycode, row, col, layer, action
                 );
                 keymap.borrow_mut().set_action_at(
@@ -222,7 +222,7 @@ impl<
                     report.input_data[4..4 + size]
                         .copy_from_slice(&self.keymap.borrow().macro_cache[offset..offset + size]);
                     debug!(
-                        "Get macro buffer: offset: {}, data: {:02X}",
+                        "Get macro buffer: offset: {}, data: {:?}",
                         offset, report.input_data
                     );
                 } else {
@@ -245,6 +245,7 @@ impl<
 
                 // Update macro cache
                 info!("Setting macro buffer, offset: {}, size: {}", offset, size);
+                #[cfg(feature = "defmt")]
                 info!("Data: {=[u8]:x}", report.output_data[4..]);
                 self.keymap.borrow_mut().macro_cache[offset as usize..end as usize]
                     .copy_from_slice(&report.output_data[4..4 + size as usize]);
@@ -340,7 +341,7 @@ impl<
                 .await
             }
             ViaCommand::Unhandled => {
-                info!("Unknown cmd: {}", report.output_data);
+                info!("Unknown cmd: {:?}", report.output_data);
                 report.input_data[0] = ViaCommand::Unhandled as u8
             }
         }

--- a/rmk/src/via/vial.rs
+++ b/rmk/src/via/vial.rs
@@ -64,7 +64,7 @@ pub(crate) async fn process_vial<const ROW: usize, const COL: usize, const NUM_L
 ) {
     // report.output_data[0] == 0xFE -> vial commands
     let vial_command = VialCommand::from_primitive(report.output_data[1]);
-    info!("Received vial command: {}", vial_command);
+    info!("Received vial command: {:?}", vial_command);
     match vial_command {
         VialCommand::GetKeyboardId => {
             debug!("Received Vial - GetKeyboardId");
@@ -259,7 +259,7 @@ pub(crate) async fn process_vial<const ROW: usize, const COL: usize, const NUM_L
             //         }
             //     }
             // }
-            debug!("Received Vial - SetEncoder, data: {}", report.output_data);
+            debug!("Received Vial - SetEncoder, data: {:?}", report.output_data);
         }
         _ => (),
     }


### PR DESCRIPTION
This PR enables unit test for RMK, add several simple unit test for keyboard as demonstration.

Some logging format issue are also fixed to be compatible with both `defmt` and `log`.

