### PR TITLE
make the storage as an optional feature and enable by default

### DIFF
--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -15,8 +15,8 @@ rmk-macro = { version = "=0.4.2", path = "../rmk-macro" }
 embedded-hal = { version = "1.0.0" }
 embedded-hal-async = { version = "1.0.0", optional = true }
 embedded-io-async = { version = "0.6" }
-embedded-storage = "0.3"
-embedded-storage-async = "0.4"
+embedded-storage = { version = "0.3", optional = true }
+embedded-storage-async = { version = "0.4", optional = true }
 embassy-embedded-hal = { version = "0.3" }
 embassy-time = { version = "0.4" }
 embassy-usb = { version = "0.4", features = [
@@ -103,7 +103,13 @@ features = ["split"]
 cortex-m = { version = "0.7" }
 
 [features]
-default = ["col2row", "defmt"]
+default = ["col2row", "defmt", "storage"]
+
+## the storage is optional to save memory
+storage = [
+    "embedded-storage",
+    "embedded-storage-async"
+]
 
 ## If your PCB diode's direction is col2row, enable this feature. If it's row2col, disable this feature by `default-features = false`.
 col2row = []

--- a/rmk/src/channel.rs
+++ b/rmk/src/channel.rs
@@ -10,6 +10,7 @@ pub use embassy_sync::zerocopy_channel;
 use crate::ble::nrf::profile::BleProfileAction;
 use crate::event::{Event, KeyEvent};
 use crate::hid::Report;
+#[cfg(feature = "storage")]
 use crate::storage::FlashOperationMessage;
 #[cfg(feature = "_ble")]
 use {crate::light::LedIndicator, embassy_sync::signal::Signal};
@@ -28,6 +29,7 @@ pub static KEYBOARD_REPORT_CHANNEL: Channel<RawMutex, Report, REPORT_CHANNEL_SIZ
 /// Channel for reading vial reports from the host
 pub(crate) static VIAL_READ_CHANNEL: Channel<RawMutex, [u8; 32], 4> = Channel::new();
 // Sync messages from server to flash
+#[cfg(feature = "storage")]
 pub(crate) static FLASH_CHANNEL: Channel<RawMutex, FlashOperationMessage, 4> = Channel::new();
 #[cfg(feature = "_nrf_ble")]
 pub(crate) static BLE_PROFILE_CHANNEL: Channel<RawMutex, BleProfileAction, 1> = Channel::new();

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -13,12 +13,13 @@ use embassy_sync::channel::Channel;
 use embassy_time::Duration;
 use embedded_hal::digital::OutputPin;
 
+#[cfg(feature = "storage")]
+use crate::storage::FlashOperationMessage;
 use crate::{
     combo::{Combo, COMBO_MAX_NUM},
     event::{Event, KeyEvent},
     hid::Report,
     light::LedIndicator,
-    storage::FlashOperationMessage,
     RawMutex,
 };
 
@@ -53,6 +54,7 @@ pub struct ChannelConfig<
     pub key_event_channel: Channel<RawMutex, KeyEvent, KEY_EVENT_CHANNEL_SIZE>,
     pub event_channel: Channel<RawMutex, Event, EVENT_CHANNEL_SIZE>,
     pub keyboard_report_channel: Channel<RawMutex, Report, REPORT_CHANNEL_SIZE>,
+    #[cfg(feature = "storage")]
     pub(crate) flash_channel: Channel<RawMutex, FlashOperationMessage, 4>,
     pub(crate) led_channel: Channel<RawMutex, LedIndicator, 4>,
     pub(crate) vial_read_channel: Channel<RawMutex, [u8; 32], 4>,
@@ -69,6 +71,7 @@ impl<
             key_event_channel: Channel::new(),
             event_channel: Channel::new(),
             keyboard_report_channel: Channel::new(),
+            #[cfg(feature = "storage")]
             flash_channel: Channel::new(),
             led_channel: Channel::new(),
             vial_read_channel: Channel::new(),

--- a/rmk/src/input_device/rotary_encoder.rs
+++ b/rmk/src/input_device/rotary_encoder.rs
@@ -64,7 +64,7 @@ impl Phase for DefaultPhase {
     }
 }
 
-//// Phase implementation for E8H7 encoder
+/// Phase implementation for E8H7 encoder
 pub struct E8H7Phase;
 impl Phase for E8H7Phase {
     fn direction(&mut self, s: u8) -> Direction {

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -1,13 +1,14 @@
 use crate::{
     action::KeyAction,
-    boot::reboot_keyboard,
     combo::{Combo, COMBO_MAX_NUM},
     config::BehaviorConfig,
     event::KeyEvent,
     keyboard_macro::{MacroOperation, MACRO_SPACE_SIZE},
     keycode::KeyCode,
-    storage::Storage,
 };
+#[cfg(feature = "storage")]
+use crate::{boot::reboot_keyboard, storage::Storage};
+#[cfg(feature = "storage")]
 use embedded_storage_async::nor_flash::NorFlash;
 use num_enum::FromPrimitive;
 
@@ -57,7 +58,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize>
             behavior,
         }
     }
-
+    #[cfg(feature = "storage")]
     pub async fn new_from_storage<F: NorFlash>(
         action_map: &'a mut [[[KeyAction; COL]; ROW]; NUM_LAYER],
         storage: Option<&mut Storage<F, ROW, COL, NUM_LAYER>>,

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -134,6 +134,9 @@ macro_rules! df {
 #[macro_export]
 macro_rules! shifted {
     ($x: ident) => {
-        $crate::wm!($x, $crate::keycode::ModifierCombination::new_from(false, false, false, true, false))
+        $crate::wm!(
+            $x,
+            $crate::keycode::ModifierCombination::new_from(false, false, false, true, false)
+        )
     };
 }

--- a/rmk/src/via/vial.rs
+++ b/rmk/src/via/vial.rs
@@ -5,12 +5,17 @@ use num_enum::FromPrimitive;
 
 use crate::{
     action::KeyAction,
-    channel::FLASH_CHANNEL,
-    combo::{Combo, COMBO_MAX_LENGTH, COMBO_MAX_NUM},
+    combo::{Combo, COMBO_MAX_NUM},
     keymap::KeyMap,
-    storage::{ComboData, FlashOperationMessage},
     usb::descriptor::ViaReport,
-    via::keycode_convert::{from_via_keycode, to_via_keycode},
+    via::keycode_convert::to_via_keycode,
+};
+#[cfg(feature = "storage")]
+use crate::{
+    channel::FLASH_CHANNEL,
+    combo::COMBO_MAX_LENGTH,
+    storage::{ComboData, FlashOperationMessage},
+    via::keycode_convert::from_via_keycode,
 };
 
 /// Vial communication commands. Check [vial-qmk/quantum/vial.h`](https://github.com/vial-kb/vial-qmk/blob/20d61fcb373354dc17d6ecad8f8176be469743da/quantum/vial.h#L36)
@@ -155,6 +160,7 @@ pub(crate) async fn process_vial<const ROW: usize, const COL: usize, const NUM_L
                     debug!("DynamicEntryOp - DynamicVialComboSet");
                     report.input_data[0] = 0; // Index 0 is the return code, 0 means success
 
+                    #[cfg(feature = "storage")]
                     let (real_idx, actions, output) = {
                         // Drop combos to release the borrowed keymap, avoid potential run-time panics
                         let combo_idx = report.output_data[3] as usize;
@@ -189,6 +195,7 @@ pub(crate) async fn process_vial<const ROW: usize, const COL: usize, const NUM_L
 
                         (real_idx, actions, output)
                     };
+                    #[cfg(feature = "storage")]
                     FLASH_CHANNEL
                         .send(FlashOperationMessage::WriteCombo(ComboData {
                             idx: real_idx,


### PR DESCRIPTION
Hi @HaoboGu,

As https://github.com/HaoboGu/rmk/issues/297, I just added `storage` feature in this PR. Please help me review it
I put it in `default` because I don't want to disrupt other examples that are using `storage`.
To remove the storage feature we just need to change `Cargo.toml`:
```
[dependencies]
rmk = { version = "0.5.2", default-features = false  }
```

Then, in the source, we can go with:

```Rust
    // Keyboard config
    let rmk_config = RmkConfig {
        usb_config: keyboard_usb_config,
        vial_config: VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF),
        ..Default::default()
    };

    // Initialize the keymap
    let mut default_keymap = keymap::get_default_keymap();
    let keymap = initialize_keymap(
        &mut default_keymap,
        rmk_config.behavior_config.clone(),
    )
    .await;

    // Initialize the matrix + keyboard
    let debouncer = DefaultDebouncer::<ROW, COL>::new();
    let mut matrix = DirectPinMatrix::<_, _, ROW, COL, SIZE>::new(direct_pins, debouncer, true);
    let mut keyboard = Keyboard::new(&keymap, rmk_config.behavior_config.clone());

    // Initialize the light controller
    let light_controller: LightController<Output> =
        LightController::new(ControllerConfig::default().light_config);

    // Run RMK
    join3(
        keyboard.run(),
        run_rmk(&keymap, driver, light_controller, rmk_config),
        run_devices! (
            (matrix) => EVENT_CHANNEL,
        ),
    )
    .await;
```