### PR TITLE
Sort combo by length desc #302

### DIFF
--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1417,7 +1417,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
 mod test {
     use super::*;
     use crate::action::KeyAction;
-    use crate::config::{BehaviorConfig, ForksConfig, CombosConfig};
+    use crate::config::{BehaviorConfig, CombosConfig, ForksConfig};
     use crate::fork::Fork;
     use crate::hid_state::HidModifiers;
     use crate::{a, k, layer, mo};

--- a/rmk/src/via/vial.rs
+++ b/rmk/src/via/vial.rs
@@ -168,7 +168,8 @@ pub(crate) async fn process_vial<
                     let (real_idx, actions, output) = {
                         // Drop combos to release the borrowed keymap, avoid potential run-time panics
                         let combo_idx = report.output_data[3] as usize;
-                        let combos = &mut keymap.borrow_mut().combos;
+                        let km = &mut keymap.borrow_mut();
+                        let combos = &mut km.combos;
                         let Some((real_idx, combo)) = vial_combo_mut(combos, combo_idx) else {
                             return;
                         };
@@ -196,6 +197,9 @@ pub(crate) async fn process_vial<
                         combo.actions.clear();
                         let _ = combo.actions.extend_from_slice(&actions[0..n]);
                         combo.output = output;
+
+                        //reordering combo order
+                        km.reorder_combos();
 
                         (real_idx, actions, output)
                     };


### PR DESCRIPTION
This is a simple solution for combo triggering order. Just to make it works.

This PR will prevent early triggering of j+k before j+k+l 
