### PR TITLE
Refactor/storage of combos n forks

### DIFF
--- a/rmk/src/combo.rs
+++ b/rmk/src/combo.rs
@@ -21,7 +21,7 @@ impl Default for Combo {
     }
 }
 
-// magic code for marking the combo as triggered 
+// magic code for marking the combo as triggered
 const COMBO_TRIGGERED: u8 = u8::MAX;
 
 impl Combo {
@@ -52,7 +52,7 @@ impl Combo {
         key_event: KeyEvent,
         active_layer: u8,
     ) -> bool {
-        if !key_event.pressed || self.actions.len() == 0 || self.state == COMBO_TRIGGERED {
+        if !key_event.pressed || self.actions.is_empty() || self.state == COMBO_TRIGGERED {
             //ignore combo that without actions
             return false;
         }
@@ -63,7 +63,10 @@ impl Combo {
             }
         }
 
-        debug!("combo {:?} search key action {:?} ", self.output, key_action);
+        debug!(
+            "combo {:?} search key action {:?} ",
+            self.output, key_action
+        );
         let action_idx = self.actions.iter().position(|&a| a == key_action);
         if let Some(i) = action_idx {
             self.state |= 1 << i;
@@ -90,19 +93,22 @@ impl Combo {
 
         if self.is_all_pressed() {
             self.state = COMBO_TRIGGERED;
-            debug!("combo {:?} mark triggered, updated state: {}", self.output, self.state);
+            debug!(
+                "combo {:?} mark triggered, updated state: {}",
+                self.output, self.state
+            );
         }
         self.output
     }
 
     // Check if the combo is dispatched into key event
     pub(crate) fn is_triggered(&self) -> bool {
-        return self.state == COMBO_TRIGGERED;
+        self.state == COMBO_TRIGGERED
     }
 
     // Check if all keys of this combo are pressed, but it does not mean the combo key event is sent
     pub(crate) fn is_all_pressed(&self) -> bool {
-        self.actions.len() > 0 && self.keys_pressed() == self.actions.len() as u32
+        !self.actions.is_empty() && self.keys_pressed() == self.actions.len() as u32
     }
 
     pub(crate) fn started(&self) -> bool {

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -167,7 +167,7 @@ impl Default for OneShotConfig {
 /// Config for combo behavior
 #[derive(Clone, Debug)]
 pub struct CombosConfig {
-    pub combos: [Combo; COMBO_MAX_NUM],
+    pub combos: Vec<Combo, COMBO_MAX_NUM>,
     pub timeout: Duration,
 }
 
@@ -175,7 +175,7 @@ impl Default for CombosConfig {
     fn default() -> Self {
         Self {
             timeout: Duration::from_millis(50),
-            combos: Vec::<Combo, COMBO_MAX_NUM>::new().into_array().unwrap(),
+            combos: Vec::new(),
         }
     }
 }

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -167,7 +167,7 @@ impl Default for OneShotConfig {
 /// Config for combo behavior
 #[derive(Clone, Debug)]
 pub struct CombosConfig {
-    pub combos: Vec<Combo, COMBO_MAX_NUM>,
+    pub combos: [Combo; COMBO_MAX_NUM],
     pub timeout: Duration,
 }
 
@@ -175,7 +175,7 @@ impl Default for CombosConfig {
     fn default() -> Self {
         Self {
             timeout: Duration::from_millis(50),
-            combos: Vec::new(),
+            combos: Vec::<Combo, COMBO_MAX_NUM>::new().into_array().unwrap(),
         }
     }
 }

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -358,13 +358,13 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
     /// The replacement decision is made at key_press time, and the decision
     /// is kept until the key is released.
     fn try_start_forks(&mut self, key_action: KeyAction, key_event: KeyEvent) -> KeyAction {
-        if self.keymap.borrow().forks.len() < 1 {
+        if self.keymap.borrow().behavior.fork.forks.len() < 1 {
             return key_action;
         }
 
         if !key_event.pressed {
             let mut i = 0;
-            for fork in &self.keymap.borrow().forks {
+            for fork in &self.keymap.borrow().behavior.fork.forks {
                 if fork.trigger == key_action {
                     if let Some(active) = self.fork_states[i] {
                         // If the originating key of a fork is released, simply release the replacement key
@@ -393,7 +393,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
 
         'bind: loop {
             let mut i = 0;
-            for fork in &self.keymap.borrow().forks {
+            for fork in &self.keymap.borrow().behavior.fork.forks {
                 if !triggered_forks[i]
                     && self.fork_states[i].is_none()
                     && fork.trigger == replacement
@@ -470,7 +470,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
     fn try_finish_forks(&mut self, original_key_action: KeyAction, key_event: KeyEvent) {
         if !key_event.pressed {
             let mut i = 0;
-            for fork in &self.keymap.borrow().forks {
+            for fork in &self.keymap.borrow().behavior.fork.forks {
                 if self.fork_states[i].is_some() && fork.trigger == original_key_action {
                     // if the originating key of a fork is released the replacement decision is not valid anymore
                     self.fork_states[i] = None;
@@ -487,7 +487,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
     ) -> Option<KeyAction> {
         let mut is_combo_action = false;
         let current_layer = self.keymap.borrow().get_activated_layer();
-        for combo in self.keymap.borrow_mut().combos.iter_mut() {
+        for combo in self.keymap.borrow_mut().behavior.combo.combos.iter_mut() {
             is_combo_action |= combo.update(key_action, key_event, current_layer);
         }
 
@@ -504,6 +504,8 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             let next_action = self
                 .keymap
                 .borrow_mut()
+                .behavior
+                .combo
                 .combos
                 .iter_mut()
                 .find_map(|combo| {
@@ -529,7 +531,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             next_action
         } else {
             if !key_event.pressed {
-                for combo in self.keymap.borrow_mut().combos.iter_mut() {
+                for combo in self.keymap.borrow_mut().behavior.combo.combos.iter_mut() {
                     if combo.is_triggered() && combo.actions.contains(&key_action) {
                         combo.reset();
                         return Some(combo.output);
@@ -551,6 +553,8 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
 
         self.keymap
             .borrow_mut()
+            .behavior
+            .combo
             .combos
             .iter_mut()
             .filter(|combo| !combo.is_triggered())

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -38,10 +38,6 @@ pub struct KeyMap<
     layer_cache: [[u8; COL]; ROW],
     /// Macro cache
     pub(crate) macro_cache: [u8; MACRO_SPACE_SIZE],
-    /// Combos
-    pub(crate) combos: [Combo; COMBO_MAX_NUM],
-    /// Forks
-    pub(crate) forks: [Fork; FORK_MAX_NUM],
     /// Options for configurable action behavior
     pub(crate) behavior: BehaviorConfig,
 }
@@ -80,8 +76,6 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             default_layer: 0,
             layer_cache: [[0; COL]; ROW],
             macro_cache: [0; MACRO_SPACE_SIZE],
-            combos,
-            forks,
             behavior,
         }
     }
@@ -132,8 +126,6 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             default_layer: 0,
             layer_cache: [[0; COL]; ROW],
             macro_cache,
-            combos,
-            forks,
             behavior,
         }
     }
@@ -369,7 +361,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
 
     //order combos by their actions length
     pub(crate) fn reorder_combos(&mut self) {
-        _reorder_combos(&mut self.combos);
+        _reorder_combos(&mut self.behavior.combo.combos);
     }
 }
 

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -42,7 +42,7 @@ pub struct KeyMap<
     pub(crate) behavior: BehaviorConfig,
 }
 
-fn _reorder_combos(combos: &mut [Combo; COMBO_MAX_NUM]) {
+fn _reorder_combos(combos: &mut heapless::Vec<Combo, COMBO_MAX_NUM>) {
     // Sort the combos by their length
     combos.sort_unstable_by(|c1, c2| c2.actions.len().cmp(&c1.actions.len()))
 }
@@ -56,7 +56,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
         behavior: BehaviorConfig,
     ) -> Self {
         // If the storage is initialized, read keymap from storage
-        let mut combos: [Combo; COMBO_MAX_NUM] = Default::default();
+        let mut combos: heapless::Vec<Combo, COMBO_MAX_NUM> = Default::default();
         for (i, combo) in behavior.combo.combos.iter().enumerate() {
             combos[i] = combo.clone();
         }

--- a/rmk/src/storage/mod.rs
+++ b/rmk/src/storage/mod.rs
@@ -4,9 +4,9 @@ mod eeconfig;
 use crate::{
     action::EncoderAction,
     channel::FLASH_CHANNEL,
-    combo::{Combo, COMBO_MAX_LENGTH},
+    combo::{Combo, COMBO_MAX_LENGTH, COMBO_MAX_NUM},
     config::StorageConfig,
-    fork::{Fork, StateBits},
+    fork::{Fork, StateBits, FORK_MAX_NUM},
     hid_state::{HidModifiers, HidMouseButtons},
     light::LedIndicator,
     BUILD_HASH,
@@ -893,7 +893,10 @@ impl<
         Ok(())
     }
 
-    pub(crate) async fn read_combos(&mut self, combos: &mut [Combo]) -> Result<(), ()> {
+    pub(crate) async fn read_combos(
+        &mut self,
+        combos: &mut Vec<Combo, COMBO_MAX_NUM>,
+    ) -> Result<(), ()> {
         for (i, item) in combos.iter_mut().enumerate() {
             let key = get_combo_key(i);
             let read_data = fetch_item::<u32, StorageData, _>(
@@ -918,7 +921,10 @@ impl<
         Ok(())
     }
 
-    pub(crate) async fn read_forks(&mut self, forks: &mut [Fork]) -> Result<(), ()> {
+    pub(crate) async fn read_forks(
+        &mut self,
+        forks: &mut Vec<Fork, FORK_MAX_NUM>,
+    ) -> Result<(), ()> {
         for (i, item) in forks.iter_mut().enumerate() {
             let key = get_fork_key(i);
             let read_data = fetch_item::<u32, StorageData, _>(

--- a/rmk/src/via/vial.rs
+++ b/rmk/src/via/vial.rs
@@ -300,7 +300,7 @@ pub(crate) async fn process_vial<
     }
 }
 
-fn vial_combo(combos: &[Combo; COMBO_MAX_NUM], idx: usize) -> Option<(usize, &Combo)> {
+fn vial_combo(combos: &heapless::Vec<Combo, COMBO_MAX_NUM>, idx: usize) -> Option<(usize, &Combo)> {
     combos
         .iter()
         .enumerate()
@@ -309,7 +309,10 @@ fn vial_combo(combos: &[Combo; COMBO_MAX_NUM], idx: usize) -> Option<(usize, &Co
         .find_map(|(i, combo)| (i == idx).then_some(combo))
 }
 
-fn vial_combo_mut(combos: &mut [Combo; COMBO_MAX_NUM], idx: usize) -> Option<(usize, &mut Combo)> {
+fn vial_combo_mut(
+    combos: &mut heapless::Vec<Combo, COMBO_MAX_NUM>,
+    idx: usize,
+) -> Option<(usize, &mut Combo)> {
     combos
         .iter_mut()
         .enumerate()

--- a/rmk/src/via/vial.rs
+++ b/rmk/src/via/vial.rs
@@ -143,7 +143,7 @@ pub(crate) async fn process_vial<
                     report.input_data[0] = 0; // Index 0 is the return code, 0 means success
 
                     let combo_idx = report.output_data[3] as usize;
-                    let combos = &keymap.borrow().combos;
+                    let combos = &keymap.borrow().behavior.combo.combos;
                     if let Some((_, combo)) = vial_combo(combos, combo_idx) {
                         for i in 0..VIAL_COMBO_MAX_LENGTH {
                             LittleEndian::write_u16(
@@ -169,7 +169,7 @@ pub(crate) async fn process_vial<
                         // Drop combos to release the borrowed keymap, avoid potential run-time panics
                         let combo_idx = report.output_data[3] as usize;
                         let km = &mut keymap.borrow_mut();
-                        let combos = &mut km.combos;
+                        let combos = &mut km.behavior.combo.combos;
                         let Some((real_idx, combo)) = vial_combo_mut(combos, combo_idx) else {
                             return;
                         };


### PR DESCRIPTION
I noticed that firmware configured combos & forks are copied in `keymap.rs`
```
        // If the storage is initialized, read keymap from storage
        let mut combos: heapless::Vec<Combo, COMBO_MAX_NUM> = Default::default();
        for (i, combo) in behavior.combo.combos.iter().enumerate() {
            combos[i] = combo.clone();
        }
```
(Same for fork.)

This PR uses the combos and forks from the configuration directly, using headless::Vec instead of Arrays.
Like before, the vectors are filled with default (empty) placeholders so Vial configured combos still work (I tested this).

The functionality of the code should not be changed at all, but the resulting firmware is smaller and the code a bit cleaner.