### PR TITLE
fix/joystick: optimize the first polling and parameters about duration

### DIFF
--- a/examples/use_rust/nrf52840_ble/src/main.rs
+++ b/examples/use_rust/nrf52840_ble/src/main.rs
@@ -198,7 +198,12 @@ async fn main(spawner: Spawner) {
     let pin_b = Input::new(p.P1_04, embassy_nrf::gpio::Pull::None);
     let mut encoder = RotaryEncoder::with_phase(pin_a, pin_b, DefaultPhase, 0);
 
-    let mut adc_device = NrfAdc::new(saadc, [AnalogEventType::Battery], 12000, None);
+    let mut adc_device = NrfAdc::new(
+        saadc,
+        [AnalogEventType::Battery],
+        embassy_time::Duration::from_secs(12),
+        None,
+    );
     let mut batt_proc = BatteryProcessor::new(2000, 2806, &keymap);
 
     let mut encoder_processor = RotaryEncoderProcessor::new(&keymap);

--- a/examples/use_rust/nrf52840_ble_split/src/central.rs
+++ b/examples/use_rust/nrf52840_ble_split/src/central.rs
@@ -197,7 +197,12 @@ async fn main(spawner: Spawner) {
     // Initialize the encoder processor
     let mut encoder_processor = RotaryEncoderProcessor::new(&keymap);
 
-    let mut adc_device = NrfAdc::new(saadc, [AnalogEventType::Battery], 12000, None);
+    let mut adc_device = NrfAdc::new(
+        saadc,
+        [AnalogEventType::Battery],
+        embassy_time::Duration::from_secs(12),
+        None,
+    );
     let mut batt_proc = BatteryProcessor::new(2000, 2806, &keymap);
 
     // Start

--- a/rmk-macro/src/input_device/adc.rs
+++ b/rmk-macro/src/input_device/adc.rs
@@ -84,13 +84,14 @@ pub(crate) fn expand_adc_device(
             }
 
             if !processor_name.is_empty() {
-                let light_sleep_param = if let Some(light_sleep_interval) = light_sleep {
-                    quote! {Some(#light_sleep_interval)}
+                let light_sleep_option = if let Some(light_sleep_interval) = light_sleep {
+                    quote! {Some(Duration::from_millis(#light_sleep_interval as u64))}
                 } else {
                     quote! {None}
                 };
                 config.extend(quote! {
                     let mut adc_device = {
+                        use embassy_time::Duration;
                         use embassy_nrf::saadc::{self, Input as _};
                         let saadc_config = saadc::Config::default();
                         embassy_nrf::interrupt::SAADC.set_priority(embassy_nrf::interrupt::Priority::P3);
@@ -101,8 +102,8 @@ pub(crate) fn expand_adc_device(
                         rmk::input_device::adc::NrfAdc::new(
                                 adc,
                                 [#(#adc_type),*],
-                                #default_polling_interval,
-                                #light_sleep_param,
+                                Duration::from_millis(#default_polling_interval as u64),
+                                #light_sleep_option,
                             )};
                 });
                 (config, processor_name)


### PR DESCRIPTION
1. Get correct values rather than 0 in the first polling.
2. Replace the type of some integer parameters about time with `Duration`.