### PR TITLE
feat/vial-lock(WIP): add security feature for vial

### DIFF
--- a/rmk/src/via/mod.rs
+++ b/rmk/src/via/mod.rs
@@ -22,7 +22,7 @@ use crate::{channel::FLASH_CHANNEL, keyboard_macro::NUM_MACRO, storage::FlashOpe
 
 pub(crate) mod keycode_convert;
 mod protocol;
-mod vial;
+pub(crate) mod vial;
 
 pub(crate) struct VialService<
     'a,


### PR DESCRIPTION
Support vial's lock and unlock method

To avoid malicious program's behavior as @pcasotti mentioned in #131, the security feature of vial is required.
And I'd like to add a calibration method for the joystick with the extended vial, this feature should be implemented first as well for the safety reason. 