### PR TITLE
Fix generated clippy::redundant-static-lifetimes warning

### DIFF
--- a/examples/use_config/esp32c3_ble/build.rs
+++ b/examples/use_config/esp32c3_ble/build.rs
@@ -43,6 +43,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/esp32c6_ble/build.rs
+++ b/examples/use_config/esp32c6_ble/build.rs
@@ -43,6 +43,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/esp32s3_ble/build.rs
+++ b/examples/use_config/esp32s3_ble/build.rs
@@ -43,6 +43,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/nrf52832_ble/build.rs
+++ b/examples/use_config/nrf52832_ble/build.rs
@@ -81,6 +81,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/nrf52840_ble/build.rs
+++ b/examples/use_config/nrf52840_ble/build.rs
@@ -81,6 +81,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/nrf52840_ble_split/build.rs
+++ b/examples/use_config/nrf52840_ble_split/build.rs
@@ -81,6 +81,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/nrf52840_ble_split_direct_pin/build.rs
+++ b/examples/use_config/nrf52840_ble_split_direct_pin/build.rs
@@ -80,6 +80,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/rp2040/build.rs
+++ b/examples/use_config/rp2040/build.rs
@@ -80,6 +80,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/rp2040_direct_pin/build.rs
+++ b/examples/use_config/rp2040_direct_pin/build.rs
@@ -80,6 +80,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/rp2040_split/build.rs
+++ b/examples/use_config/rp2040_split/build.rs
@@ -80,6 +80,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/rp2040_split_pio/build.rs
+++ b/examples/use_config/rp2040_split_pio/build.rs
@@ -79,6 +79,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/stm32f1/build.rs
+++ b/examples/use_config/stm32f1/build.rs
@@ -66,6 +66,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/stm32f4/build.rs
+++ b/examples/use_config/stm32f4/build.rs
@@ -66,6 +66,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_config/stm32h7/build.rs
+++ b/examples/use_config/stm32h7/build.rs
@@ -66,6 +66,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/ch32v307/build.rs
+++ b/examples/use_rust/ch32v307/build.rs
@@ -38,6 +38,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/esp32c3_ble/build.rs
+++ b/examples/use_rust/esp32c3_ble/build.rs
@@ -41,6 +41,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/esp32c6_ble/build.rs
+++ b/examples/use_rust/esp32c6_ble/build.rs
@@ -41,6 +41,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/esp32s3_ble/build.rs
+++ b/examples/use_rust/esp32s3_ble/build.rs
@@ -41,6 +41,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/hpm5300/build.rs
+++ b/examples/use_rust/hpm5300/build.rs
@@ -39,6 +39,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/nrf52832_ble/build.rs
+++ b/examples/use_rust/nrf52832_ble/build.rs
@@ -79,6 +79,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/nrf52840/build.rs
+++ b/examples/use_rust/nrf52840/build.rs
@@ -79,6 +79,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/nrf52840_ble/build.rs
+++ b/examples/use_rust/nrf52840_ble/build.rs
@@ -79,6 +79,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/nrf52840_ble_split/build.rs
+++ b/examples/use_rust/nrf52840_ble_split/build.rs
@@ -79,6 +79,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/py32f07x/build.rs
+++ b/examples/use_rust/py32f07x/build.rs
@@ -63,6 +63,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/rp2040/build.rs
+++ b/examples/use_rust/rp2040/build.rs
@@ -78,6 +78,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/rp2040_direct_pin/build.rs
+++ b/examples/use_rust/rp2040_direct_pin/build.rs
@@ -78,6 +78,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/rp2040_split/build.rs
+++ b/examples/use_rust/rp2040_split/build.rs
@@ -78,6 +78,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/rp2040_split_pio/build.rs
+++ b/examples/use_rust/rp2040_split_pio/build.rs
@@ -78,6 +78,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/rp2350/build.rs
+++ b/examples/use_rust/rp2350/build.rs
@@ -78,6 +78,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/stm32f1/build.rs
+++ b/examples/use_rust/stm32f1/build.rs
@@ -64,6 +64,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/stm32f4/build.rs
+++ b/examples/use_rust/stm32f4/build.rs
@@ -64,6 +64,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/stm32g4/build.rs
+++ b/examples/use_rust/stm32g4/build.rs
@@ -64,6 +64,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }

--- a/examples/use_rust/stm32h7/build.rs
+++ b/examples/use_rust/stm32h7/build.rs
@@ -64,6 +64,7 @@ fn generate_vial_config() {
         const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
         const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
     ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
     .join("\n");
     fs::write(out_file, const_declarations).unwrap();
 }


### PR DESCRIPTION
This is not ideal. But, I don't like to work with clippy warning. If you merge it, I will open similar PR on the template repository.

See https://github.com/Eolu/const-gen/issues/12 for more information.

B. r