### PR TITLE
refactor(macro): fix clippy warnings in rmk-macro

### DIFF
--- a/rmk-macro/src/behavior.rs
+++ b/rmk-macro/src/behavior.rs
@@ -146,34 +146,6 @@ struct StateBitsMacro {
 }
 
 impl StateBitsMacro {
-    fn new() -> Self {
-        Self {
-            modifiers_left_ctrl: false,
-            modifiers_left_shift: false,
-            modifiers_left_alt: false,
-            modifiers_left_gui: false,
-            modifiers_right_ctrl: false,
-            modifiers_right_shift: false,
-            modifiers_right_alt: false,
-            modifiers_right_gui: false,
-
-            leds_num_lock: false,
-            leds_caps_lock: false,
-            leds_scroll_lock: false,
-            leds_compose: false,
-            leds_kana: false,
-
-            mouse_button1: false,
-            mouse_button2: false,
-            mouse_button3: false,
-            mouse_button4: false,
-            mouse_button5: false,
-            mouse_button6: false,
-            mouse_button7: false,
-            mouse_button8: false,
-        }
-    }
-
     fn is_empty(&self) -> bool {
         !(self.modifiers_left_ctrl
             || self.modifiers_left_shift
@@ -236,7 +208,7 @@ impl quote::ToTokens for StateBitsMacro {
 
 /// Get modifier combination, in types of mod1 | mod2 | ...
 fn parse_state_combination(states_str: &str) -> StateBitsMacro {
-    let mut combination = StateBitsMacro::new();
+    let mut combination = StateBitsMacro::default();
     let tokens = states_str.split_terminator("|");
     tokens.for_each(|w| {
         let w = w.trim();
@@ -279,9 +251,9 @@ fn expand_forks(forks: &Option<ForksConfig>) -> proc_macro2::TokenStream {
                 let trigger = parse_key(fork.trigger.to_owned());
                 let negative_output = parse_key(fork.negative_output.to_owned());
                 let positive_output = parse_key(fork.positive_output.to_owned());
-                let match_any  = fork.match_any.as_ref().map(|s| parse_state_combination(&s)).unwrap_or(StateBitsMacro::new());
-                let match_none = fork.match_none.as_ref().map(|s| parse_state_combination(&s)).unwrap_or(StateBitsMacro::new());
-                let kept = fork.kept_modifiers.as_ref().map(|s| parse_state_combination(&s)).unwrap_or(StateBitsMacro::new());
+                let match_any  = fork.match_any.as_ref().map(|s| parse_state_combination(s)).unwrap_or_default();
+                let match_none = fork.match_none.as_ref().map(|s| parse_state_combination(s)).unwrap_or_default();
+                let kept = fork.kept_modifiers.as_ref().map(|s| parse_state_combination(s)).unwrap_or_default();
                 let bindable = fork.bindable.unwrap_or(false);
 
                 if match_any.is_empty() && match_none.is_empty() {

--- a/rmk-macro/src/bind_interrupt.rs
+++ b/rmk-macro/src/bind_interrupt.rs
@@ -17,8 +17,8 @@ pub(crate) fn expand_bind_interrupt(keyboard_config: &KeyboardConfig, item_mod: 
             .find_map(|item| {
                 if let syn::Item::Fn(item_fn) = &item {
                     if item_fn.attrs.len() == 1 {
-                        if let Some(i) = &item_fn.attrs[0].meta.path().get_ident() {
-                            if i.to_string() == "bind_interrupt" {
+                        if let Some(i) = item_fn.attrs[0].meta.path().get_ident() {
+                            if i == "bind_interrupt" {
                                 let content = &item_fn.block.stmts;
                                 return Some(quote! {
                                     #(#content)*

--- a/rmk-macro/src/chip_init.rs
+++ b/rmk-macro/src/chip_init.rs
@@ -116,9 +116,9 @@ pub(crate) fn expand_chip_init(keyboard_config: &KeyboardConfig, item_mod: &Item
                 }
                 None
             })
-            .unwrap_or(chip_init_default(&keyboard_config))
+            .unwrap_or(chip_init_default(keyboard_config))
     } else {
-        chip_init_default(&keyboard_config)
+        chip_init_default(keyboard_config)
     }
 }
 

--- a/rmk-macro/src/config/mod.rs
+++ b/rmk-macro/src/config/mod.rs
@@ -41,7 +41,7 @@ pub struct LayoutTomlConfig {
     pub cols: u8,
     pub layers: u8,
     pub keymap: Option<Vec<Vec<Vec<String>>>>, // will be deprecated in the future
-    pub matrix_map: Option<String>, //temporarily allow both matrix_map and keymap to be set
+    pub matrix_map: Option<String>,            //temporarily allow both matrix_map and keymap to be set
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -370,8 +370,8 @@ pub struct PointingDeviceConfig {
 #[derive(Clone, Debug, Deserialize)]
 #[allow(unused)]
 pub enum CommunicationProtocol {
-    I2C(I2cConfig),
-    SPI(SpiConfig),
+    I2c(I2cConfig),
+    Spi(SpiConfig),
 }
 
 /// SPI config

--- a/rmk-macro/src/gpio_config.rs
+++ b/rmk-macro/src/gpio_config.rs
@@ -203,7 +203,7 @@ pub(crate) fn convert_gpio_str_to_input_pin(
 
 /// Get pin number from pin str.
 /// For example, if the pin str is "PD13", this function will return "13".
-fn get_pin_num_stm32(gpio_name: &String) -> Option<String> {
+fn get_pin_num_stm32(gpio_name: &str) -> Option<String> {
     if gpio_name.len() < 3 {
         None
     } else {

--- a/rmk-macro/src/input_device/encoder.rs
+++ b/rmk-macro/src/input_device/encoder.rs
@@ -31,8 +31,8 @@ pub(crate) fn expand_encoder_device(
         let pull = if encoder.internal_pullup { Some(true) } else { None };
 
         // Initialize pins
-        let pin_a = convert_gpio_str_to_input_pin(&chip, encoder.pin_a.clone(), false, pull);
-        let pin_b = convert_gpio_str_to_input_pin(&chip, encoder.pin_b.clone(), false, pull);
+        let pin_a = convert_gpio_str_to_input_pin(chip, encoder.pin_a.clone(), false, pull);
+        let pin_b = convert_gpio_str_to_input_pin(chip, encoder.pin_b.clone(), false, pull);
 
         let encoder_name = format_ident!("encoder_{}", encoder_id);
         encoder_names.push(encoder_name.clone());

--- a/rmk-macro/src/keyboard.rs
+++ b/rmk-macro/src/keyboard.rs
@@ -276,7 +276,7 @@ pub(crate) fn expand_matrix_and_keyboard_init(
                 },
                 MatrixType::direct_pin => {
                     let low_active = split_config.central.matrix.direct_pin_low_active;
-                    let size = split_config.central.rows as usize * split_config.central.cols as usize;
+                    let size = split_config.central.rows * split_config.central.cols;
                     quote! {
                         let debouncer = #debouncer_type::<COL, ROW>::new();
                         let mut matrix = ::rmk::split::central::CentralDirectPinMatrix::<_, _, #central_row_offset, #central_col_offset, #central_row, #central_col, #size>::new(direct_pins, debouncer, #low_active);

--- a/rmk-macro/src/layout.rs
+++ b/rmk-macro/src/layout.rs
@@ -27,7 +27,7 @@ pub(crate) fn expand_default_keymap(keyboard_config: &KeyboardConfig) -> TokenSt
         encoder_map.push(quote! { [#(#encoders), *] });
     }
 
-    return quote! {
+    quote! {
         pub const fn get_default_keymap() -> [[[::rmk::action::KeyAction; COL]; ROW]; NUM_LAYER] {
             [#(#layers), *]
         }
@@ -35,7 +35,7 @@ pub(crate) fn expand_default_keymap(keyboard_config: &KeyboardConfig) -> TokenSt
         pub const fn get_default_encoder_map() -> [[::rmk::action::EncoderAction; NUM_ENCODER]; NUM_LAYER] {
             [#(#encoder_map), *]
         }
-    };
+    }
 }
 
 /// Push rows in the layer
@@ -139,7 +139,7 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
                 let keys: Vec<&str> = internal
                     .split_terminator(",")
                     .map(|w| w.trim())
-                    .filter(|w| w.len() > 0)
+                    .filter(|w| !w.is_empty())
                     .collect();
                 if keys.len() != 2 {
                     return quote! {
@@ -160,9 +160,9 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
                     ::rmk::wm!(#ident, #modifiers)
                 }
             } else {
-                return quote! {
+                quote! {
                     compile_error!("keyboard.toml: WM(layer, modifier) invalid, please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
-                };
+                }
             }
         }
         s if s.starts_with("MO(") => {
@@ -200,7 +200,7 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
                 let keys: Vec<&str> = internal
                     .split_terminator(",")
                     .map(|w| w.trim())
-                    .filter(|w| w.len() > 0)
+                    .filter(|w| !w.is_empty())
                     .collect();
                 if keys.len() != 2 {
                     return quote! {
@@ -220,9 +220,9 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
                     ::rmk::lm!(#layer, #modifiers)
                 }
             } else {
-                return quote! {
+                quote! {
                     compile_error!("keyboard.toml: LM(layer, modifier) invalid, please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
-                };
+                }
             }
         }
         s if s.starts_with("LT(") => {
@@ -231,7 +231,7 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
                 .trim_end_matches(")")
                 .split_terminator(",")
                 .map(|w| w.trim())
-                .filter(|w| w.len() > 0)
+                .filter(|w| !w.is_empty())
                 .collect();
             if keys.len() != 2 {
                 return quote! {
@@ -273,7 +273,7 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
                 let keys: Vec<&str> = internal
                     .split_terminator(",")
                     .map(|w| w.trim())
-                    .filter(|w| w.len() > 0)
+                    .filter(|w| !w.is_empty())
                     .collect();
                 if keys.len() != 2 {
                     return quote! {
@@ -292,9 +292,9 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
                     ::rmk::mt!(#ident, #modifiers)
                 }
             } else {
-                return quote! {
+                quote! {
                     compile_error!("keyboard.toml: MT(key, modifier) invalid, please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
-                };
+                }
             }
         }
         s if s.starts_with("TH(") => {
@@ -302,7 +302,7 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
                 let keys: Vec<&str> = internal
                     .split_terminator(",")
                     .map(|w| w.trim())
-                    .filter(|w| w.len() > 0)
+                    .filter(|w| !w.is_empty())
                     .collect();
                 if keys.len() != 2 {
                     return quote! {
@@ -316,9 +316,9 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
                     ::rmk::th!(#ident1, #ident2)
                 }
             } else {
-                return quote! {
+                quote! {
                     compile_error!("keyboard.toml: TH(key_tap, key_hold) invalid, please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
-                };
+                }
             }
         }
         s if s.starts_with("SHIFTED(") => {
@@ -331,9 +331,9 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
                 let ident = format_ident!("{}", internal);
                 quote! { ::rmk::shifted!(#ident) }
             } else {
-                return quote! {
+                quote! {
                     compile_error!("keyboard.toml: SHIFTED(key) invalid, please check the documentation: https://haobogu.github.io/rmk/keyboard_configuration.html");
-                };
+                }
             }
         }
         _ => get_key_with_alias(key),

--- a/rmk-macro/src/matrix.rs
+++ b/rmk-macro/src/matrix.rs
@@ -81,14 +81,10 @@ pub(crate) fn expand_matrix_direct_pins(
     // Get input pin type
     let input_pin_type = get_input_pin_type(chip, async_matrix);
     let rows = direct_pins.len();
-    let cols = if direct_pins.len() == 0 {
-        0
-    } else {
-        direct_pins[0].len()
-    };
+    let cols = direct_pins.first().map_or(0, |row| row.len());
     // Initialize input pins
     pin_initialization.extend(convert_direct_pins_to_initializers(
-        &chip,
+        chip,
         direct_pins,
         async_matrix,
         low_active,
@@ -126,9 +122,9 @@ pub(crate) fn expand_matrix_input_output_pins(
     let output_pin_type = get_output_pin_type(chip);
 
     // Initialize input pins
-    pin_initialization.extend(convert_input_pins_to_initializers(&chip, input_pins, async_matrix));
+    pin_initialization.extend(convert_input_pins_to_initializers(chip, input_pins, async_matrix));
     // Initialize output pins
-    pin_initialization.extend(convert_output_pins_to_initializers(&chip, output_pins));
+    pin_initialization.extend(convert_output_pins_to_initializers(chip, output_pins));
     // Generate a macro that does pin matrix config
     quote! {
         #extra_import


### PR DESCRIPTION
I tried to solve all clippy warnings in the rmk-macro crate.

Some of the adjustments concern the coding style and are a matter of taste.