### PR TITLE
doc(layout): fix mouse key code in the example

### DIFF
--- a/docs/en/docs/features/configuration/appendix.md
+++ b/docs/en/docs/features/configuration/appendix.md
@@ -104,7 +104,7 @@ TO(base_layer)   @MyCut     @MyCopy          @MyPaste
 MouseBtn1        MouseUp    MouseBtn2        MouseWheelUp
 MouseLeft        MouseBtn4  MouseRight
 MouseWheelLeft   MouseDown  MouseWheelRight  MouseWheelDown
-          MouseBtn1         MouseBtn12
+          MouseBtn1         MouseBtn2
 """
 
 # Behavior configuration, if you don't want to customize anything, just ignore this section

--- a/docs/en/docs/features/configuration/layout.md
+++ b/docs/en/docs/features/configuration/layout.md
@@ -64,7 +64,7 @@ TO(base_layer)   @my_cut    @my_copy         @my_paste
 MouseBtn1        MouseUp    MouseBtn2        MouseWheelUp
 MouseLeft        MouseBtn4  MouseRight
 MouseWheelLeft   MouseDown  MouseWheelRight  MouseWheelDown
-       MouseBtn1            MouseBtn12
+       MouseBtn1            MouseBtn2
 """
 ```
 


### PR DESCRIPTION
Error building the example layout config

    error[E0599]: no variant or associated item named `MouseBtn12` found for enum `KeyCode` in the current scope
