### PR TITLE
doc: fix a typo

### DIFF
--- a/docs/en/docs/features/configuration/appendix.md
+++ b/docs/en/docs/features/configuration/appendix.md
@@ -110,7 +110,7 @@ MouseWheelLeft   MouseDown  MouseWheelRight  MouseWheelDown
 # Behavior configuration, if you don't want to customize anything, just ignore this section
 [behavior]
 # Tri Layer configuration
-tri_layer = { uppper = 1, lower = 2, adjust = 3 }
+tri_layer = { upper = 1, lower = 2, adjust = 3 }
 # One Shot configuration
 one_shot = { timeout = "1s" }
 

--- a/docs/en/docs/features/configuration/behavior.md
+++ b/docs/en/docs/features/configuration/behavior.md
@@ -4,7 +4,7 @@ The `[behavior]` section contains configuration for how different keyboard actio
 
 ```toml
 [behavior]
-tri_layer = { uppper = 1, lower = 2, adjust = 3 }
+tri_layer = { upper = 1, lower = 2, adjust = 3 }
 one_shot = { timeout = "1s" }
 ```
 
@@ -16,7 +16,7 @@ You can enable Tri Layer by specifying the `upper`, `lower` and `adjust` layers 
 
 ```toml
 [behavior.tri_layer]
-uppper = 1
+upper = 1
 lower = 2
 adjust = 3
 ```


### PR DESCRIPTION
uppper -> upper