### PR TITLE
Add Delay for Buffered Key Events to Ensure HID Recognition

### DIFF
--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -22,7 +22,7 @@ use core::cmp::Ordering;
 use core::fmt::Debug;
 
 use embassy_futures::select::{select, Either};
-use embassy_futures::yield_now;
+use embassy_futures::{join, yield_now};
 use embassy_time::{Duration, Instant, Timer};
 use heapless::{Deque, FnvIndexMap, Vec};
 use usbd_hid::descriptor::{MediaKeyboardReport, MouseReport, SystemControlReport};
@@ -805,6 +805,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
         while let Some((action, event)) = self.combo_actions_buffer.pop_front() {
             debug!("Dispatching combo action: {:?}", action);
             self.process_key_action(action, event).await;
+            Timer::after_millis(1).await;
         }
 
         self.keymap
@@ -1726,8 +1727,10 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
                         debug!("Tap Key {:?} now press down", hold_key.key_event);
                         //TODO ignored return value
                         self.process_key_action(key_action, hold_key.key_event).await;
+                        //wait for hid send
                     }
                 }
+                Timer::after_millis(1).await;
             }
             // Update the state of the key in the buffer after firing its action.
             // This ensures that the buffer accurately reflects which keys have been resolved as tap or hold,


### PR DESCRIPTION
Description:
In certain scenarios, key events are sent too quickly for the HID layer to reliably register state changes, especially when using buffered input behaviors like tap-hold or combos. This patch introduces a minimum delay (e.g., 1ms) to ensure that HID devices have enough time to process key transitions.
Problem:

For example:

    A press event on key A is queued in the event buffer.

    After just 10ms, a release event for the same key A arrives.

    Tap-hold logic detects this and flushes the buffer, sending a tap action for key A.

If this transition (press → release ) happens too quickly, the HID system may miss the state change and fail to report the key correctly.
Solution:

    Introduce a manual delay (at least 1ms) during key buffering (e.g., tap-hold and combo behaviors).

    Ensure that any emitted key event has a visible time gap before the next state change is sent.

Testing:

    The test module now verifies that all reported key events include a minimum inter-event delay of 1ms to ensure HID stability.