### PR TITLE
fix: No with whitespace at the end of layer.keys

### DIFF
--- a/rmk-config/src/keymap.pest
+++ b/rmk-config/src/keymap.pest
@@ -41,7 +41,7 @@ modifier_combination = { modifier_name ~ ("|" ~ modifier_name)* }
 simple_keycode = { keycode_name }
 
 // Rule 2: No Key
-no_action = { ^"No" ~ !ASCII_ALPHANUMERIC } // Case-insensitive "No" followed by non-alphanumeric
+no_action = @{ ^"No" ~ !ASCII_ALPHANUMERIC } // Case-insensitive "No" followed by non-alphanumeric
 
 // Rule 3: Transparent Key
 transparent_action = @{ ("_")+ | (^"Trns" ~ !ASCII_ALPHANUMERIC) } // One or more underscores or "Trns" followed by non-alphanumeric 


### PR DESCRIPTION
Fixes #437

`no_action` should be an atomic rule.
Maybe the lookahead expression was hindered by WHITESPACE. https://docs.rs/pest/latest/pest/#whitespace-and-comment