### PR TITLE
move KeyAction::WithModifier to Action::KeyWithModifier

### DIFF
--- a/rmk/src/action.rs
+++ b/rmk/src/action.rs
@@ -56,8 +56,6 @@ pub enum KeyAction {
     Tap(Action),
     /// Keep current key pressed until the next key is triggered.
     OneShot(Action),
-    /// Action with the modifier combination triggered.
-    WithModifier(Action, ModifierCombination),
     /// General tap/hold action: (tap_action, hold_action)
     TapHold(Action, Action),
     /// Tap dance action, references a tap dance configuration by index.
@@ -72,6 +70,8 @@ pub enum Action {
     Key(KeyCode),
     /// Modifier Combination, used for oneshot keyaction.
     Modifier(ModifierCombination),
+    /// Key stroke with modifier combination triggered.
+    KeyWithModifier(KeyCode, ModifierCombination),
     /// Activate a layer
     LayerOn(u8),
     /// Deactivate a layer

--- a/rmk/src/action.rs
+++ b/rmk/src/action.rs
@@ -74,6 +74,8 @@ pub enum Action {
     KeyWithModifier(KeyCode, ModifierCombination),
     /// Activate a layer
     LayerOn(u8),
+    /// Activate a layer with modifier combination triggered.
+    LayerOnWithModifier(u8, ModifierCombination),
     /// Deactivate a layer
     LayerOff(u8),
     /// Toggle a layer

--- a/rmk/src/action.rs
+++ b/rmk/src/action.rs
@@ -43,16 +43,6 @@ impl EncoderAction {
 
 /// A KeyAction is the action at a keyboard position, stored in keymap.
 /// It can be a single action like triggering a key, or a composite keyboard action like tap/hold
-///
-/// Each `KeyAction` can be serialized to a u16 action code. There are 2 patterns of action code's bit-field composition of `KeyAction`:
-///
-/// - KeyActionType(8bits) + BasicAction(8bits)
-///
-/// - KeyActionType(4bits) + Action(12bits)
-///
-/// The `BasicAction` represents only a single key action of keycodes defined in HID spec. The `Action` represents all actions defined in the following `Action` enum, including modifier combination and layer switch.
-///
-/// The KeyActionType bits varies between different types of a KeyAction, see docs of each enum variant.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum KeyAction {
@@ -74,65 +64,23 @@ pub enum KeyAction {
     TapDance(u8),
 }
 
-impl KeyAction {
-    /// Convert a `KeyAction` to corresponding key action code.
-    pub(crate) fn to_key_action_code(self) -> u16 {
-        match self {
-            KeyAction::No => 0x0000,
-            KeyAction::Transparent => 0x0001,
-            KeyAction::Single(a) => a.to_action_code(),
-            KeyAction::Tap(a) => 0x0001 | a.to_action_code(),
-            KeyAction::OneShot(a) => 0x0010 | a.to_action_code(),
-            KeyAction::WithModifier(a, m) => 0x4000 | ((m.into_bits() as u16) << 8) | a.to_basic_action_code(),
-            KeyAction::TapHold(tap, hold) => match hold {
-                Action::LayerOn(layer) => {
-                    if layer < 16 {
-                        0x3000 | ((layer as u16) << 15) | tap.to_basic_action_code()
-                    } else {
-                        error!("LayerTapHold supports only layer 0~15, got {}", layer);
-                        0x0000
-                    }
-                }
-                Action::Modifier(m) => 0x6000 | ((m.into_bits() as u16) << 8) | tap.to_basic_action_code(),
-                _ => 0x8000 | (hold.to_basic_action_code() << 15) | tap.to_basic_action_code(),
-            },
-            KeyAction::TapDance(index) => 0x5700 | (index as u16),
-        }
-    }
-}
-
 /// A single basic action that a keyboard can execute.
-/// An Action can be represented in 12 bits, aka 0x000 ~ 0xFFF
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Action {
     /// A normal key stroke, uses for all keycodes defined in `KeyCode` enum, including mouse key, consumer/system control, etc.
-    ///
-    /// Uses 0x000 ~ 0xCFF
     Key(KeyCode),
     /// Modifier Combination, used for oneshot keyaction.
-    ///
-    /// Uses 0xE00 ~ 0xE1F. Serialized as 1110|000|modifier(5bits)
     Modifier(ModifierCombination),
     /// Activate a layer
-    ///
-    /// Uses 0xE20 ~ 0xE3F. Serialized as 1110|001|layer_num(5bits)
     LayerOn(u8),
     /// Deactivate a layer
-    ///
-    /// Uses 0xE40 ~ 0xE5F. Serialized as 1110|010|layer_num(5bits)
     LayerOff(u8),
     /// Toggle a layer
-    ///
-    /// Uses 0xE60 ~ 0xE7F. Serialized as 1110|011|layer_num(5bits)
     LayerToggle(u8),
     /// Set default layer
-    ///
-    /// Uses 0xE80 ~ 0xE9F. Serialized as 1110|100|layer_num(5bits)
     DefaultLayer(u8),
     /// Activate a layer and deactivate all other layers(except default layer)
-    ///
-    /// Uses 0xEA0 ~ 0xEBF. Serialized as 1110|101|layer_num(5bits)
     LayerToggleOnly(u8),
     /// Triggers the Macro at the 'index'.
     /// this is an alternative trigger to
@@ -140,37 +88,5 @@ pub enum Action {
     /// e.g. `Action::TriggerMacro(6)`` will trigger the same Macro as `Action::Key(KeyCode::Macro6)`
     /// the main purpose for this enum variant is to easily extend to more than 32 macros (to 256)
     /// without introducing new Keycodes.
-    ///
-    /// Uses 0xF00 ~ 0xFFF. Serialized as 1111|macro_idx(8bits)
     TriggerMacro(u8),
-}
-
-impl Action {
-    /// Convert an `Action` to 12-bit action code
-    pub(crate) fn to_action_code(self) -> u16 {
-        match self {
-            Action::Key(k) => k as u16,
-            Action::Modifier(m) => 0xE00 | (m.into_bits() as u16),
-            Action::LayerOn(layer) => 0xE20 | (layer as u16),
-            Action::LayerOff(layer) => 0xE40 | (layer as u16),
-            Action::LayerToggle(layer) => 0xE60 | (layer as u16),
-            Action::DefaultLayer(layer) => 0xE80 | (layer as u16),
-            Action::LayerToggleOnly(layer) => 0xEA0 | (layer as u16),
-            Action::TriggerMacro(macro_idx) => 0xF00 | (macro_idx as u16),
-        }
-    }
-
-    /// Convert an `Action` to 8-bit basic action code, only applicable for `Key(BasicKeyCode)`
-    pub(crate) fn to_basic_action_code(self) -> u16 {
-        match self {
-            Action::Key(kc) => {
-                if kc.is_basic() {
-                    kc as u16
-                } else {
-                    0
-                }
-            }
-            _ => 0,
-        }
-    }
 }

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -151,7 +151,7 @@ pub struct Keyboard<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usi
     /// One shot modifier state
     osm_state: OneShotState<HidModifiers>,
 
-    /// The modifiers coming from (last) KeyAction::WithModifier
+    /// The modifiers coming from (last) Action::KeyWithModifier
     with_modifiers: HidModifiers,
 
     /// Macro text typing state (affects the effective modifiers)
@@ -528,7 +528,6 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
                 debug!("Process Single key action: {:?}, {:?}", a, key_event);
                 self.process_key_action_normal(a, key_event).await;
             }
-            KeyAction::WithModifier(a, m) => self.process_key_action_with_modifier(a, m, key_event).await,
             KeyAction::Tap(a) => self.process_key_action_tap(a, key_event).await,
             KeyAction::TapHold(tap_action, hold_action) => {
                 self.process_key_action_tap_hold(tap_action, hold_action, key_event)
@@ -611,7 +610,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
 
                     combined_suppress |= suppress;
 
-                    // Suppress the previously activated KeyAction::WithModifiers
+                    // Suppress the previously activated Action::KeyWithModifiers
                     // (even if they held for a long time, a new keypress arrived
                     // since then, which breaks the key repeat, so losing their
                     // effect likely will not cause problem...)
@@ -888,25 +887,19 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
                 self.update_osl(key_event);
             }
             Action::TriggerMacro(macro_idx) => self.execute_macro(macro_idx, key_event).await,
+            Action::KeyWithModifier(key_code, modifiers) => {
+                if key_event.pressed {
+                    // These modifiers will be combined into the hid report, so
+                    // they will be "pressed" the same time as the key (in same hid report)
+                    self.with_modifiers |= modifiers.to_hid_modifiers();
+                } else {
+                    // The modifiers will not be part of the hid report, so
+                    // they will be "released" the same time as the key (in same hid report)
+                    self.with_modifiers &= !(modifiers.to_hid_modifiers());
+                }
+                self.process_action_key(key_code, key_event).await
+            }
         }
-    }
-
-    async fn process_key_action_with_modifier(
-        &mut self,
-        action: Action,
-        modifiers: ModifierCombination,
-        key_event: KeyEvent,
-    ) {
-        if key_event.pressed {
-            // These modifiers will be combined into the hid report, so
-            // they will be "pressed" the same time as the key (in same hid report)
-            self.with_modifiers |= modifiers.to_hid_modifiers();
-        } else {
-            // The modifiers will not be part of the hid report, so
-            // they will be "released" the same time as the key (in same hid report)
-            self.with_modifiers &= !(modifiers.to_hid_modifiers());
-        }
-        self.process_key_action_normal(action, key_event).await;
     }
 
     /// Tap action, send a key when the key is pressed, then release the key.
@@ -1203,7 +1196,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
     /// - text macro related modifier suppressions + capitalization
     /// - registered (held) modifiers keys
     /// - one-shot modifiers
-    /// - effect of KeyAction::WithModifiers (while they are pressed)
+    /// - effect of Action::KeyWithModifiers (while they are pressed)
     /// - possible fork related modifier suppressions
     pub fn resolve_modifiers(&self, pressed: bool) -> HidModifiers {
         // Text typing macro should not be affected by any modifiers,
@@ -1233,7 +1226,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
         // Execute the remaining suppressions
         result &= !fork_suppress;
 
-        // Apply the modifiers from KeyAction::WithModifiers
+        // Apply the modifiers from Action::KeyWithModifiers
         // the suppression effect of forks should not apply on these
         result |= self.with_modifiers;
 
@@ -2452,9 +2445,9 @@ mod test {
                 let fork1 = Fork {
                     trigger: KeyAction::Single(Action::Key(KeyCode::Dot)),
                     negative_output: KeyAction::Single(Action::Key(KeyCode::Dot)),
-                    positive_output: KeyAction::WithModifier(
-                        Action::Key(KeyCode::Semicolon),
-                        ModifierCombination::default().with_shift(true),
+                    positive_output: KeyAction::Single(
+                        Action::KeyWithModifier(KeyCode::Semicolon,
+                        ModifierCombination::default().with_shift(true),)
                     ),
                     match_any: StateBits {
                         modifiers: HidModifiers::default().with_left_shift(true).with_right_shift(true),

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -899,6 +899,18 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
                 }
                 self.process_action_key(key_code, key_event).await
             }
+            Action::LayerOnWithModifier(layer_num, modifiers) => {
+                if key_event.pressed {
+                    // These modifiers will be combined into the hid report, so
+                    // they will be "pressed" the same time as the key (in same hid report)
+                    self.with_modifiers |= modifiers.to_hid_modifiers();
+                } else {
+                    // The modifiers will not be part of the hid report, so
+                    // they will be "released" the same time as the key (in same hid report)
+                    self.with_modifiers &= !(modifiers.to_hid_modifiers());
+                }
+                self.process_action_layer_switch(layer_num, key_event)
+            }
         }
     }
 

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -306,7 +306,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
 #[cfg(test)]
 mod test {
     use super::{Combo, _reorder_combos};
-    use crate::action::KeyAction;
+    use crate::action::{Action, KeyAction};
     use crate::fork::{Fork, StateBits};
     use crate::hid_state::HidModifiers;
     use crate::keycode::KeyCode;
@@ -374,17 +374,26 @@ mod test {
         _reorder_combos(&mut combos);
         fill_vec(&mut combos);
 
-        let result: Vec<u16> = combos
+        let result: Vec<Option<Action>> = combos
             .iter()
             .enumerate()
             .map(|(_, c)| match c.output {
-                KeyAction::Single(k) => k.to_action_code(),
-                _ => KeyCode::No as u16,
+                KeyAction::Single(a) => Some(a),
+                _ => None,
             })
             .collect();
         assert_eq!(
             result,
-            vec![KeyCode::Z as u16, KeyCode::Y as u16, KeyCode::X as u16, 0, 0, 0, 0, 0]
+            vec![
+                Some(Action::Key(KeyCode::Z)),
+                Some(Action::Key(KeyCode::Y)),
+                Some(Action::Key(KeyCode::X)),
+                None,
+                None,
+                None,
+                None,
+                None
+            ]
         );
     }
 }

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -18,7 +18,10 @@ macro_rules! k {
 #[macro_export]
 macro_rules! wm {
     ($x: ident, $m: expr) => {
-        $crate::action::KeyAction::WithModifier($crate::action::Action::Key($crate::keycode::KeyCode::$x), $m)
+        $crate::action::KeyAction::Single($crate::action::Action::KeyWithModifier(
+            $crate::keycode::KeyCode::$x,
+            $m,
+        ))
     };
 }
 
@@ -42,7 +45,8 @@ macro_rules! mo {
 #[macro_export]
 macro_rules! lm {
     ($x: literal, $m: expr) => {
-        $crate::action::KeyAction::WithModifier($crate::action::Action::LayerOn($x), $m)
+        todo!()
+        // $crate::action::KeyAction::WithModifier($crate::action::Action::LayerOn($x), $m)
     };
 }
 

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -45,8 +45,7 @@ macro_rules! mo {
 #[macro_export]
 macro_rules! lm {
     ($x: literal, $m: expr) => {
-        todo!()
-        // $crate::action::KeyAction::WithModifier($crate::action::Action::LayerOn($x), $m)
+        $crate::action::KeyAction::Single($crate::action::Action::LayerOnWithModifier($x, $m))
     };
 }
 


### PR DESCRIPTION
Marked this as draft since I'm going to sleep now and haven't had the time to actually test the changes with my layout. 
But I opened the PR to start discussion about 2 things I'm unsure of:
1. the `Action` and `KeyAction` serialization to u16 methods were tricky to update, so I thought I'd comment them out until later. Then I noticed that they were only depended upon by one test case, so I removed them completely in the first commit (I updated the test case to use the enums directly). What is the purpose of the u16 representation? If needed, I can revert the commit and add them back, but I think they would need to be extended to u32. Is there some future plan for these functions, and if so what constraints are there?
2.I hit a snag and realized that the `lm!` macro cannot work with my change. Not sure how to fix that one, except adding something like `KeyAction::Double(Action, Action)` but that seems very smelly haha. Maybe there's a different arrangement of the 2 enums that covers all use-cases 🤔

I'll try to continue working on this tomorrow after work again, or on the weekend at the latest ✌️