### PR TITLE
Feature/tap hold hold on other press

### DIFF
--- a/docs/en/docs/features/configuration/behavior.md
+++ b/docs/en/docs/features/configuration/behavior.md
@@ -15,6 +15,7 @@ In the `tap_hold` sub-table, you can configure the following parameters:
 - `enable_hrm`: Enables or disables HRM (Home Row Mod) mode. When enabled, the `prior_idle_time` setting becomes functional. Defaults to `false`.
 - `permissive_hold`: Enables permissive hold mode. When enabled, hold action will be triggered when a key is pressed and released during tap-hold decision. This option is recommended to set to true when `enable_hrm` is set to true.
 - `chordal_hold`: (Experimental) Enables chordal hold mode. When enabled, hold action will be triggered when a key from "opposite" hand is pressed. In current experimental version, the "opposite" hand is calculated [according to the number of cols/rows](https://github.com/HaoboGu/rmk/blob/c0ef95b1185c25972c62458c878ee9f1a8e1a837/rmk/src/tap_hold.rs#L111-L136). This option is recommended to set to true when `enable_hrm` is set to true.
+- `hold_on_other_press`: Enables hold-on-other-key-press mode. When enabled, hold action will be triggered immediately when any other non-tap-hold key is pressed while a tap-hold key is being held. This provides faster modifier activation without waiting for the timeout. **Priority rules**: When HRM is disabled, permissive hold takes precedence over this feature. When HRM is enabled, this feature works normally. Defaults to `false`.
 - `prior_idle_time`: If the previous non-modifier key is released within this period before pressing the current tap-hold key, the tap action for the tap-hold behavior will be triggered. This parameter is effective only when enable_hrm is set to `true`. Defaults to 120ms.
 - `hold_timeout`: Defines the duration a tap-hold key must be pressed to determine hold behavior. If tap-hold key is released within this time, the key is recognized as a "tap". Holding it beyond this duration triggers the "hold" action. Defaults to 250ms.
 - `post_wait_time`: Adds an additional delay after releasing a tap-hold key to check if any keys pressed during the `hold_timeout` are released. This helps accommodate fast typing scenarios where some keys may not be fully released during a hold. Defaults to 50ms
@@ -23,8 +24,10 @@ The following are the typical configurations:
 
 ```toml
 [behavior]
-# Enable HRM
-tap_hold = { enable_hrm = true, permissive_hold = true, chordal_hold = true, prior_idle_time = "120ms", hold_timeout = "250ms" }
+# Enable HRM with all tap-hold features
+tap_hold = { enable_hrm = true, permissive_hold = true, chordal_hold = true, hold_on_other_press = true, prior_idle_time = "120ms", hold_timeout = "250ms" }
+# Fast modifier usage without HRM
+tap_hold = { enable_hrm = false, hold_on_other_press = true, hold_timeout = "200ms" }
 # Disable HRM, you can safely ignore any fields if you don't want to change them
 tap_hold = { enable_hrm = false, hold_timeout = "200ms" }
 ```

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -420,6 +420,7 @@ pub struct TapHoldConfig {
     pub enable_hrm: Option<bool>,
     pub permissive_hold: Option<bool>,
     pub chordal_hold: Option<bool>,
+    pub hold_on_other_press: Option<bool>,
     pub prior_idle_time: Option<DurationMillis>,
     /// Depreciated
     pub post_wait_time: Option<DurationMillis>,

--- a/rmk-macro/src/behavior.rs
+++ b/rmk-macro/src/behavior.rs
@@ -57,6 +57,10 @@ fn expand_tap_hold(tap_hold: &Option<TapHoldConfig>) -> proc_macro2::TokenStream
                 Some(enable) => quote! { chordal_hold: #enable, },
                 None => quote! {},
             };
+            let hold_on_other_press = match tap_hold.hold_on_other_press {
+                Some(enable) => quote! { hold_on_other_press: #enable, },
+                None => quote! {},
+            };
             let prior_idle_time = match &tap_hold.prior_idle_time {
                 Some(t) => {
                     let timeout = t.0;
@@ -87,6 +91,7 @@ fn expand_tap_hold(tap_hold: &Option<TapHoldConfig>) -> proc_macro2::TokenStream
                     #hold_timeout
                     #permissive_hold
                     #chordal_hold
+                    #hold_on_other_press
                     ..Default::default()
                 }
             }

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -97,6 +97,8 @@ pub struct TapHoldConfig {
     pub permissive_hold: bool,
     /// If the previous key is on the same "hand", the current key will be determined as a tap
     pub chordal_hold: bool,
+    /// Trigger hold when any other non-tap-hold key is pressed
+    pub hold_on_other_press: bool,
 }
 
 impl Default for TapHoldConfig {
@@ -105,6 +107,7 @@ impl Default for TapHoldConfig {
             enable_hrm: false,
             permissive_hold: false,
             chordal_hold: false,
+            hold_on_other_press: false,
             prior_idle_time: Duration::from_millis(120),
             post_wait_time: Duration::from_millis(50),
             hold_timeout: Duration::from_millis(250),

--- a/rmk/src/config/tap_hold_config.rs
+++ b/rmk/src/config/tap_hold_config.rs
@@ -1,0 +1,9 @@
+pub enum HandFlags {
+    Left,
+    Right,
+    None,
+}
+pub struct ChordalHoldMapConfig<'a, const ROW: usize, const COL: usize> {
+    // a matrix to store chordal hold flags for every key
+    pub(crate) matrix: &'a mut [[[HandFlags; COL]; ROW]],
+}

--- a/rmk/tests/common/mod.rs
+++ b/rmk/tests/common/mod.rs
@@ -30,9 +30,10 @@ pub fn init_log() {
         .try_init();
 }
 
+pub const KC_LCTRL: u8 = 1 << 0;
 pub const KC_LSHIFT: u8 = 1 << 1;
+pub const KC_LALT: u8 = 1 << 2;
 pub const KC_LGUI: u8 = 1 << 3;
-pub const KC_LCTRL: u8 = 1;
 
 #[derive(Debug, Clone)]
 pub struct TestKeyPress {

--- a/rmk/tests/common/test_macro.rs
+++ b/rmk/tests/common/test_macro.rs
@@ -4,7 +4,7 @@ extern crate rmk;
 ///
 /// # Arguments:
 ///     - keyboard: keyboard initialization
-///     - sequence: key sequence: [row, col, pressed, delay], where delay is the time interval in ms between last key action and current key
+///     - sequence: key sequence: [row, col, pressed, press_delay], where press_delay is the time interval in ms between last key action and current key
 ///     - expected_reports: [modifiers, [keycodes; 6]], represents the hid report which will be sent to the host
 #[macro_export]
 macro_rules! key_sequence_test {

--- a/rmk/tests/keyboard_hold_on_other_key_press_test.rs
+++ b/rmk/tests/keyboard_hold_on_other_key_press_test.rs
@@ -1,0 +1,556 @@
+//! Tests for the hold-on-other-key-press tap-hold feature
+//!
+//! This feature immediately triggers the hold action when any other non-tap-hold key
+//! is pressed while a tap-hold key is being held.
+
+pub mod common;
+
+use rmk::config::{BehaviorConfig, TapHoldConfig};
+use rmk::{k, lt, th};
+use rusty_fork::rusty_fork_test;
+
+/// Helper to create tap-hold config with hold-on-other-key-press enabled
+fn tap_hold_config_with_hold_on_other_press() -> TapHoldConfig {
+    TapHoldConfig {
+        hold_on_other_press: true,
+        enable_hrm: false,
+        permissive_hold: false,
+        chordal_hold: false,
+        hold_timeout: embassy_time::Duration::from_millis(200),
+        prior_idle_time: embassy_time::Duration::from_millis(120),
+        post_wait_time: embassy_time::Duration::from_millis(80),
+    }
+}
+
+/// Helper to create tap-hold config with both hold-on-other-press and permissive hold
+fn tap_hold_config_with_hold_on_other_press_and_permissive() -> TapHoldConfig {
+    TapHoldConfig {
+        hold_on_other_press: true,
+        permissive_hold: true,
+        enable_hrm: false,
+        chordal_hold: false,
+        hold_timeout: embassy_time::Duration::from_millis(200),
+        prior_idle_time: embassy_time::Duration::from_millis(120),
+        post_wait_time: embassy_time::Duration::from_millis(80),
+    }
+}
+
+mod hold_on_other_press_tests {
+    use super::*;
+    use crate::common::{create_test_keyboard_with_config, wrap_keymap, KC_LALT, KC_LCTRL, KC_LGUI, KC_LSHIFT};
+    use embassy_futures::block_on;
+    use rmk::keyboard::Keyboard;
+
+    rusty_fork_test! {
+        #[test]
+        fn test_hold_on_other_press_basic() {
+            // Basic test: tap-hold key becomes hold when another key is pressed
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_config(BehaviorConfig {
+                    tap_hold: tap_hold_config_with_hold_on_other_press(),
+                    ..BehaviorConfig::default()
+                }),
+                sequence: [
+                    [2, 1, true, 10],   // Press th!(A, LShift)
+                    [2, 3, true, 50],   // Press D (regular key) - should trigger hold immediately
+                    [2, 3, false, 10],  // Release D
+                    [2, 1, false, 10],  // Release A
+                ],
+                expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],  // Hold triggered immediately
+                    [KC_LSHIFT, [kc_to_u8!(D), 0, 0, 0, 0, 0]],  // D pressed with shift
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],  // D released
+                    [0, [0, 0, 0, 0, 0, 0]],  // All released
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_disabled() {
+            // When disabled, should wait for timeout
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_config(BehaviorConfig {
+                    tap_hold: TapHoldConfig {
+                        hold_on_other_press: false,  // Disabled
+                        ..tap_hold_config_with_hold_on_other_press()
+                    },
+                    ..BehaviorConfig::default()
+                }),
+                sequence: [
+                    [2, 1, true, 10],   // Press th!(A, LShift)
+                    [2, 3, true, 50],   // Press D - should NOT trigger hold
+                    [2, 1, false, 10],  // Release A - should tap
+                    [2, 3, false, 10],  // Release D
+                ],
+                expected_reports: [
+                    [0, [kc_to_u8!(D), 0, 0, 0, 0, 0]],  // Tap A
+                    [0, [kc_to_u8!(D), kc_to_u8!(A), 0, 0, 0, 0]],  // A + D
+                    [0, [kc_to_u8!(D), 0, 0, 0, 0, 0]],  // Release A
+                    [0, [0, 0, 0, 0, 0, 0]],  // All released
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_with_another_taphold() {
+            // Critical test: pressing another tap-hold key should NOT trigger hold
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_config(BehaviorConfig {
+                    tap_hold: tap_hold_config_with_hold_on_other_press(),
+                    ..BehaviorConfig::default()
+                }),
+                sequence: [
+                    [2, 1, true, 10],   // Press th!(A, LShift)
+                    [2, 2, true, 30],   // Press th!(S, LGui) - should NOT trigger hold
+                    [2, 3, true, 30],   // Press D (regular key) - NOW should trigger hold
+                    [2, 1, false, 10],  // Release A
+                    [2, 2, false, 10],  // Release S
+                    [2, 3, false, 10],  // Release D
+                ],
+                expected_reports: [
+                    // Both tap-hold keys become hold when D is pressed
+                    [KC_LSHIFT , [0, 0, 0, 0, 0, 0]],
+                    [KC_LSHIFT | KC_LGUI, [0, 0, 0, 0, 0, 0]],
+                    [KC_LSHIFT | KC_LGUI, [kc_to_u8!(D), 0, 0, 0, 0, 0]],
+                    [KC_LGUI, [kc_to_u8!(D), 0, 0, 0, 0, 0]],  // Release A
+                    [0, [kc_to_u8!(D), 0, 0, 0, 0, 0]],  // Release S
+                    [0, [0, 0, 0, 0, 0, 0]],  // All released
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_tap_hold_combinations() {
+
+
+            let keymap = wrap_keymap(
+                [[[
+                    th!(Tab, LCtrl),  // Layer tap-hold
+                    th!(CapsLock, LAlt),
+                    k!(B),
+                    k!(Delete),
+                ]], [[
+                    k!(No),
+                    k!(Kc1),
+                    k!(Kc2),
+                    k!(Kc3),
+                ]]],
+                BehaviorConfig {
+                    tap_hold: tap_hold_config_with_hold_on_other_press(),
+                    ..BehaviorConfig::default()
+                }
+            );
+            // Test that we can still do Ctrl+Alt+Delete style combinations
+
+            key_sequence_test! {
+                keyboard: Keyboard::new(keymap),
+                sequence: [
+                    [0, 0, true, 10],   // Press th!(Tab, LCtrl)
+                    [0, 1, true, 10],   // Press th!(CapsLock, LAlt) - should NOT trigger
+                    [0, 3, true, 10],   // Press Delete - triggers both holds
+                    [0, 3, false, 10],  // Release Delete
+                    [0, 0, false, 10],  // Release Tab
+                    [0, 1, false, 10],  // Release CapsLock
+                ],
+                expected_reports: [
+                    [KC_LCTRL , [0, 0, 0, 0, 0, 0]],  // Both TAP-HOLD
+                    [KC_LCTRL | KC_LALT, [0, 0, 0, 0, 0, 0]],  // Both TAP-HOLD
+                    [KC_LCTRL | KC_LALT, [kc_to_u8!(Delete), 0, 0, 0, 0, 0]],  // Ctrl+Alt+Delete
+                    [KC_LCTRL | KC_LALT, [0, 0, 0, 0, 0, 0]],  // Release Delete
+                    [KC_LALT, [0, 0, 0, 0, 0, 0]],  // Release Ctrl
+                    [0, [0, 0, 0, 0, 0, 0]],  // All released
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_quick_tap() {
+            // Quick tap should still work as tap
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_config(BehaviorConfig {
+                    tap_hold: tap_hold_config_with_hold_on_other_press(),
+                    ..BehaviorConfig::default()
+                }),
+                sequence: [
+                    [2, 1, true, 10],   // Press th!(A, LShift)
+                    [2, 1, false, 30],  // Release A quickly - should tap
+                ],
+                expected_reports: [
+                    [0, [kc_to_u8!(A), 0, 0, 0, 0, 0]],  // Tap A
+                    [0, [0, 0, 0, 0, 0, 0]],  // Released
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_with_permissive_hold() {
+            // Both features enabled - hold-on-other-press should take precedence
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_config(BehaviorConfig {
+                    tap_hold: tap_hold_config_with_hold_on_other_press_and_permissive(),
+                    ..BehaviorConfig::default()
+                }),
+                sequence: [
+                    [2, 1, true, 10],   // Press th!(A, LShift)
+                    [2, 3, true, 50],   // Press D - should trigger hold immediately
+                    [2, 3, false, 10],  // Release D
+                    [2, 1, false, 10],  // Release A
+                ],
+                expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],  // Hold triggered on press
+                    [KC_LSHIFT, [kc_to_u8!(D), 0, 0, 0, 0, 0]],
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
+                    [0, [0, 0, 0, 0, 0, 0]],
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_layer_tap() {
+            // Test with layer tap-hold keys
+            let keymap = wrap_keymap(
+                [[[
+                    lt!(1, D),  // Layer tap-hold
+                    k!(A),
+                    k!(B),
+                    k!(C),
+                ]], [[
+                    k!(No),
+                    k!(Kc1),
+                    k!(Kc2),
+                    k!(Kc3),
+                ]]],
+                BehaviorConfig {
+                    tap_hold: tap_hold_config_with_hold_on_other_press(),
+                    ..BehaviorConfig::default()
+                }
+            );
+
+            key_sequence_test! {
+                keyboard: Keyboard::new(keymap),
+                sequence: [
+                    [0, 0, true, 10],   // Press LT!(1, D)
+                    [0, 1, true, 50],   // Press A (which is 1 on layer 1) - should trigger layer
+                    [0, 1, false, 10],  // Release A
+                    [0, 0, false, 10],  // Release mo!(1)
+                ],
+                expected_reports: [
+                    [0, [kc_to_u8!(Kc1), 0, 0, 0, 0, 0]],  // 1 from layer 1
+                    [0, [0, 0, 0, 0, 0, 0]],  // Released
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_rolling() {
+            // Test rolling keys with hold-on-other-press
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_config(BehaviorConfig {
+                    tap_hold: tap_hold_config_with_hold_on_other_press(),
+                    ..BehaviorConfig::default()
+                }),
+                sequence: [
+                    [2, 1, true, 10],   // Press th!(A, LShift)
+                    [2, 3, true, 20],   // Press D - triggers hold
+                    [2, 4, true, 20],   // Press F
+                    [2, 1, false, 10],  // Release A
+                    [2, 5, true, 10],   // Press G
+                    [2, 3, false, 10],  // Release D
+                    [2, 4, false, 10],  // Release F
+                    [2, 5, false, 10],  // Release G
+                ],
+                expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],  // Hold triggered
+                    [KC_LSHIFT, [kc_to_u8!(D), 0, 0, 0, 0, 0]],  // D with shift
+                    [KC_LSHIFT, [kc_to_u8!(D), kc_to_u8!(F), 0, 0, 0, 0]],  // D+F with shift
+                    [0, [kc_to_u8!(D), kc_to_u8!(F), 0, 0, 0, 0]],  // Release shift
+                    [0, [kc_to_u8!(D), kc_to_u8!(F), kc_to_u8!(G), 0, 0, 0]],  // Add G
+                    [0, [0, kc_to_u8!(F), kc_to_u8!(G), 0, 0, 0]],  // Release D
+                    [0, [0, 0, kc_to_u8!(G), 0, 0, 0]],  // Release F
+                    [0, [0, 0, 0, 0, 0, 0]],  // All released
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_multiple_taphold_then_regular() {
+            // Multiple tap-hold keys pressed, then a regular key
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_config(BehaviorConfig {
+                    tap_hold: tap_hold_config_with_hold_on_other_press(),
+                    ..BehaviorConfig::default()
+                }),
+                sequence: [
+                    [2, 1, true, 10],   // Press th!(A, LShift)
+                    [2, 2, true, 10],   // Press th!(S, LGui)
+                    [3, 1, true, 10],   // Press th!(Z, LAlt)
+                    [2, 3, true, 30],   // Press D - triggers all holds
+                    [2, 1, false, 10],  // Release A
+                    [2, 2, false, 10],  // Release S
+                    [3, 1, false, 10],  // Release Z
+                    [2, 3, false, 10],  // Release D
+                ],
+                expected_reports: [
+                    // All modifiers activated when D is pressed
+                    [KC_LSHIFT , [0, 0, 0, 0, 0, 0]],
+                    [KC_LSHIFT | KC_LGUI , [0, 0, 0, 0, 0, 0]],
+                    [KC_LSHIFT | KC_LGUI | KC_LALT, [0, 0, 0, 0, 0, 0]],
+                    [KC_LSHIFT | KC_LGUI | KC_LALT, [kc_to_u8!(D), 0, 0, 0, 0, 0]],
+                    [KC_LGUI | KC_LALT, [kc_to_u8!(D), 0, 0, 0, 0, 0]],  // Release Shift
+                    [KC_LALT, [kc_to_u8!(D), 0, 0, 0, 0, 0]],  // Release Gui
+                    [0, [kc_to_u8!(D), 0, 0, 0, 0, 0]],  // Release Alt
+                    [0, [0, 0, 0, 0, 0, 0]],  // All released
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_timeout_still_works() {
+            // Verify timeout still works when no other key is pressed
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_config(BehaviorConfig {
+                    tap_hold: tap_hold_config_with_hold_on_other_press(),
+                    ..BehaviorConfig::default()
+                }),
+                sequence: [
+                    [2, 1, true, 0],   // Press th!(A, LShift) and hold past timeout
+                    [2, 1, false, 250],  // Release A
+                ],
+                expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],  // Hold triggered by timeout
+                    [0, [0, 0, 0, 0, 0, 0]],  // Released
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_priority_with_hrm_disabled() {
+            // When HRM is disabled and permissive hold is enabled,
+            // hold-on-other-press should be disabled (permissive hold takes precedence)
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_config(BehaviorConfig {
+                    tap_hold: TapHoldConfig {
+                        hold_on_other_press: true,
+                        permissive_hold: true,
+                        enable_hrm: false,  // HRM disabled
+                        chordal_hold: false,
+                        hold_timeout: embassy_time::Duration::from_millis(200),
+                        prior_idle_time: embassy_time::Duration::from_millis(120),
+                        post_wait_time: embassy_time::Duration::from_millis(80),
+                    },
+                    ..BehaviorConfig::default()
+                }),
+                sequence: [
+                    [2, 1, true, 10],   // Press th!(A, LShift)
+                    [2, 3, true, 50],   // Press D - should NOT trigger hold immediately
+                    [2, 3, false, 10],  // Release D - should trigger permissive hold
+                    [2, 1, false, 10],  // Release A
+                ],
+                expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],  // LShift became HOLD
+                    [KC_LSHIFT, [kc_to_u8!(D), 0, 0, 0, 0, 0]],  // Permissive hold triggered on D release
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],  // D released
+                    [0, [0, 0, 0, 0, 0, 0]],  // All released
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_priority_with_hrm_enabled() {
+            // When HRM is enabled, hold-on-other-press should work normally
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_config(BehaviorConfig {
+                    tap_hold: TapHoldConfig {
+                        hold_on_other_press: true,
+                        permissive_hold: true,
+                        enable_hrm: true,  // HRM enabled
+                        chordal_hold: false,
+                        hold_timeout: embassy_time::Duration::from_millis(200),
+                        prior_idle_time: embassy_time::Duration::from_millis(120),
+                        post_wait_time: embassy_time::Duration::from_millis(80),
+                    },
+                    ..BehaviorConfig::default()
+                }),
+                sequence: [
+                    [2, 1, true, 10],   // Press th!(A, LShift)
+                    [2, 3, true, 50],   // Press D - should trigger hold immediately
+                    [2, 3, false, 10],  // Release D
+                    [2, 1, false, 10],  // Release A
+                ],
+                expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],  // Hold triggered on press
+                    [KC_LSHIFT, [kc_to_u8!(D), 0, 0, 0, 0, 0]],
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
+                    [0, [0, 0, 0, 0, 0, 0]],
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_simple_tap_hold() {
+            // th! key should become hold when another key is pressed
+            key_sequence_test! {
+                keyboard: Keyboard::new(wrap_keymap(
+                    [[[
+                        th!(A, LShift), k!(B), k!(C)
+                    ]]],
+                    BehaviorConfig {
+                        tap_hold: tap_hold_config_with_hold_on_other_press(),
+                        ..BehaviorConfig::default()
+                    }
+                )),
+                sequence: [
+                    [0, 0, true, 10],   // Press th!(A, LShift)
+                    [0, 1, true, 20],  // Press B - should trigger hold
+                    [0, 1, false, 10], // Release B
+                    [0, 0, false, 10], // Release A
+                ],
+                expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
+                    [KC_LSHIFT, [kc_to_u8!(B), 0, 0, 0, 0, 0]],
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
+                    [0, [0, 0, 0, 0, 0, 0]],
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_simple_layer_tap() {
+            // lt! key should become hold (activate layer) when another key is pressed
+            key_sequence_test! {
+                keyboard: Keyboard::new(wrap_keymap(
+                    [[[
+                        lt!(1, D), k!(A), k!(B)
+                    ]], [[
+                        k!(No), k!(Kc1), k!(Kc2)
+                    ]]],
+                    BehaviorConfig {
+                        tap_hold: tap_hold_config_with_hold_on_other_press(),
+                        ..BehaviorConfig::default()
+                    }
+                )),
+                sequence: [
+                    [0, 0, true, 10],   // Press LT!(1, D)
+                    [0, 1, true, 20],  // Press A - should trigger layer 1
+                    [0, 1, false, 10], // Release A
+                    [0, 0, false, 10], // Release LT
+                ],
+                expected_reports: [
+                    [0, [kc_to_u8!(Kc1), 0, 0, 0, 0, 0]],  // Layer 1 active, Kc1
+                    [0, [0, 0, 0, 0, 0, 0]],
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_simple_layer_tap_hrm() {
+            // lt! key should become hold (activate layer) when another key is pressed
+            key_sequence_test! {
+                keyboard: Keyboard::new(wrap_keymap(
+                    [[[
+                        lt!(1, D), k!(A), k!(B)
+                    ]], [[
+                        k!(No), k!(Kc1), k!(Kc2)
+                    ]]],
+                    BehaviorConfig {
+                        tap_hold: TapHoldConfig {
+                            hold_on_other_press: true,
+                            permissive_hold: true,
+                            enable_hrm: true,  // HRM enabled
+                            chordal_hold: false,
+                            hold_timeout: embassy_time::Duration::from_millis(200),
+                            prior_idle_time: embassy_time::Duration::from_millis(120),
+                            post_wait_time: embassy_time::Duration::from_millis(80),
+                        },
+                        ..BehaviorConfig::default()
+                    }
+                )),
+                sequence: [
+                    [0, 0, true, 10],   // Press LT!(1, D)
+                    [0, 1, true, 20],  // Press A - should trigger layer 1
+                    [0, 1, false, 10], // Release A
+                    [0, 0, false, 10], // Release LT
+                ],
+                expected_reports: [
+                    [0, [kc_to_u8!(Kc1), 0, 0, 0, 0, 0]],  // Layer 1 active, Kc1
+                    [0, [0, 0, 0, 0, 0, 0]],
+                ]
+            };
+        }
+        #[test]
+        fn test_hold_on_other_press_both_th_and_lt_no_hrm() {
+            let keymap = wrap_keymap(
+                    [[[
+                        th!(A, LShift), lt!(1, D), k!(B)
+                    ]], [[
+                        k!(No), k!(Kc1), k!(Kc2)
+                    ]]],
+                    BehaviorConfig {
+                        tap_hold: tap_hold_config_with_hold_on_other_press(),
+                        ..BehaviorConfig::default()
+                    }
+                );
+            // Both th! and lt! held, then another key triggers both holds
+
+            key_sequence_test! {
+                keyboard: Keyboard::new(keymap),
+                sequence: [
+                    [0, 0, true, 10],   // Press th!(A, LShift)
+                    [0, 1, true, 10],   // Press LT!(1, D)
+                    [0, 2, true, 20],   // Press B - should trigger both holds
+                    [0, 2, false, 10],  // Release B
+                    [0, 0, false, 10],  // Release th!
+                    [0, 1, false, 10],  // Release LT!
+                ],
+                expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
+                    [KC_LSHIFT, [kc_to_u8!(Kc2), 0, 0, 0, 0, 0]],  // Both hold: shift + layer 1
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
+                    [0, [0, 0, 0, 0, 0, 0]],
+                ]
+            };
+        }
+
+        #[test]
+        fn test_hold_on_other_press_both_th_and_lt_hrm() {
+            let keymap = wrap_keymap(
+                    [[[
+                        th!(A, LShift), lt!(1, D), k!(B)
+                    ]], [[
+                        k!(No), k!(Kc1), k!(Kc2)
+                    ]]],
+                    BehaviorConfig {
+                        tap_hold: TapHoldConfig {
+                            hold_on_other_press: true,
+                            permissive_hold: true,
+                            enable_hrm: true,  // HRM enabled
+                            chordal_hold: false,
+                            hold_timeout: embassy_time::Duration::from_millis(200),
+                            prior_idle_time: embassy_time::Duration::from_millis(120),
+                            post_wait_time: embassy_time::Duration::from_millis(80),
+                        },
+                        ..BehaviorConfig::default()
+                    }
+                );
+            // Both th! and lt! held, then another key triggers both holds
+
+            key_sequence_test! {
+                keyboard: Keyboard::new(keymap),
+                sequence: [
+                    [0, 0, true, 10],   // Press th!(A, LShift)
+                    [0, 1, true, 10],   // Press LT!(1, D)
+                    [0, 2, true, 20],   // Press B - should trigger both holds, since previous key is LT(hold on other key press)
+                    [0, 2, false, 10],  // Release B
+                    [0, 0, false, 10],  // Release th!
+                    [0, 1, false, 10],  // Release LT!
+                ],
+                expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
+                    [KC_LSHIFT, [kc_to_u8!(Kc2), 0, 0, 0, 0, 0]],  // Both hold: shift + layer 1
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
+                    [0, [0, 0, 0, 0, 0, 0]],
+                ]
+            };
+        }
+    }
+}

--- a/rmk/tests/keyboard_taphold_test.rs
+++ b/rmk/tests/keyboard_taphold_test.rs
@@ -8,6 +8,7 @@ fn tap_hold_config_with_hrm_and_permissive_hold() -> TapHoldConfig {
         enable_hrm: true,
         permissive_hold: true,
         chordal_hold: false,
+        hold_on_other_press: false,
         post_wait_time: Duration::from_millis(0),
         ..TapHoldConfig::default()
     }
@@ -18,6 +19,7 @@ fn tap_hold_config_with_hrm_and_chordal_hold() -> TapHoldConfig {
         enable_hrm: true,
         chordal_hold: true,
         permissive_hold: true,
+        hold_on_other_press: false,
         post_wait_time: Duration::from_millis(0),
         ..TapHoldConfig::default()
     }
@@ -278,6 +280,7 @@ mod tap_hold_test {
                 sequence: [
                     [2, 1, true, 10], // Tap th!(A,shift)
                     [2, 1, false, 50],
+                    // last release should record as tap
                     [2, 1, true, 100], // Hold th!(A,shift) after tapping
                     [2, 1, false, 400],
                 ],
@@ -385,17 +388,17 @@ mod tap_hold_test {
 
                 // rolling A , then ctrl d
                 sequence: [
-                    [2, 1, true, 200], // Press th!(A,shift)
+                    [2, 1, true, 20], // Press th!(A,shift)
                     [2, 8, true, 50],  // Press K
-                    [2, 1, false, 20], // Release A
                     [2, 8, false, 50],  //Release K
+                    [2, 1, false, 20], // Release A
 
                 ],
                 expected_reports: [
                     // chord hold , should become (shift x)
                     [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
                     [KC_LSHIFT, [kc_to_u8!(K), 0, 0, 0, 0, 0]],
-                    [0, [kc_to_u8!(K), 0, 0, 0, 0, 0]],
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
                     [0, [0, 0, 0, 0, 0, 0]],
 
                 ]
@@ -492,7 +495,7 @@ mod tap_hold_test {
 
                 // rolling A , then ctrl d
                 sequence: [
-                    [2, 1, true, 200], // Press th!(A,shift)
+                    [2, 1, true, 20], // Press th!(A,shift)
                     [2, 5, true, 50],  // Press g
                     [2, 1, false, 20], // Release A
                     [2, 5, false, 50],  // Release g
@@ -501,7 +504,7 @@ mod tap_hold_test {
                 expected_reports: [
                     [0, [kc_to_u8!(A), 0, 0, 0, 0, 0]],
                     [0, [kc_to_u8!(A),kc_to_u8!(G), 0, 0, 0, 0]],
-                    [0, [0 ,kc_to_u8!(G),  0, 0, 0, 0]],
+                    [0, [0 ,kc_to_u8!(G), 0, 0, 0, 0]],
                     [0, [0, 0, 0, 0, 0, 0]],
                 ]
             };
@@ -511,7 +514,7 @@ mod tap_hold_test {
         fn test_taphold_with_layer_tap() {
             key_sequence_test! {
                 keyboard: create_test_keyboard_with_config(BehaviorConfig {
-                    tap_hold: tap_hold_config_with_hrm_and_chordal_hold(),
+                    tap_hold: tap_hold_config_with_hrm_and_permissive_hold(),
                     ..BehaviorConfig::default()
                 }),
                 sequence: [
@@ -541,7 +544,7 @@ mod tap_hold_test {
         fn test_taphold_rolling_with_layer_tap() {
             key_sequence_test! {
                 keyboard: create_test_keyboard_with_config(BehaviorConfig {
-                    tap_hold: tap_hold_config_with_hrm_and_chordal_hold(),
+                    tap_hold: tap_hold_config_with_hrm_and_permissive_hold(),
                     ..BehaviorConfig::default()
                 }),
                 sequence: [
@@ -582,20 +585,20 @@ mod tap_hold_test {
                     ..BehaviorConfig::default()
                 }),
                 sequence: [
-                    [2, 1, true, 200],  // Press th!(A,shift)
+                    [2, 1, true, 20],  // Press th!(A,shift)
                     [2, 2, true, 10],   // Press th!(S,lgui)
-                    [2, 8, true, 50],   // Press K
+                    [2, 8, true, 20],   // Press K
+                    [2, 8, false, 20],  // Release K should trigger permissive hold
                     [2, 1, false, 20],  // Release A
-                    [2, 8, false, 50],  // Release K
-                    [2, 2, false, 400], // Release S
+                    [2, 2, false, 20], // Release S
                 ],
                 expected_reports: [
                     [KC_LSHIFT, [0, 0, 0, 0, 0, 0]], // Hold LShift
                     [KC_LSHIFT| KC_LGUI, [0, 0, 0, 0, 0, 0]], // Hold LShift + LGui
                     [KC_LSHIFT| KC_LGUI, [kc_to_u8!(K), 0, 0, 0, 0, 0]], // Press K
-                    [KC_LGUI, [kc_to_u8!(K), 0, 0, 0, 0, 0]], // Release A
-                    [KC_LGUI, [0, 0, 0, 0, 0, 0]], // Release K
-                    [0, [0, 0, 0, 0, 0, 0]], // Release S
+                    [KC_LSHIFT|KC_LGUI , [0, 0, 0, 0, 0, 0]], // Release K
+                    [KC_LGUI, [0, 0, 0, 0, 0, 0]], // Release S
+                    [0, [0, 0, 0, 0, 0, 0]], // Release A
                 ]
             }
         }


### PR DESCRIPTION
### Feature: Patched `hold_on_other_release` Option for LT Keys  

This PR introduces a patch for LT keys with the `hold_on_other_release` option, configurable as follows:  

```ini
[taphold]
hrm=true
permissive_hold=true
hold_on_other_release=true  # Only affects LT keys for now
```  

#### Behavior Rules:  
- **HRM Enabled (`hrm=true`):**  
  - `hold_on_other_release` applies **only to LT keys** if `permissive_hold` is also enabled.  
- **HRM Disabled (`hrm=false`):**  
  - `hold_on_other_release` is **disabled** if `permissive_hold` is enabled.  

This provides a temporary solution for HRM users until the new `behavior_map` branch is finalized.  

---  

### Fix: Correct Chordal Hold Behavior  

Previously, chordal holds exhibited inconsistent behavior:  
```  
MT(a, ctrl) + c → Permissive hold  
MT(a, ctrl) + k → Hold on press  
```  

**New Behavior (with `chordal_hold` enabled):**  
```  
MT(a, ctrl) + c → Force tapping  
MT(a, ctrl) + k → Default behavior (ignore/press-on-hold/permissive hold)  
```  

This aligns chordal holds with expected keypress outcomes.