### PR TITLE
Battery report changes for controller

### DIFF
--- a/rmk/src/event.rs
+++ b/rmk/src/event.rs
@@ -150,7 +150,7 @@ pub enum ControllerEvent {
     /// Key event and action
     Key(KeyboardEvent, KeyAction),
     /// Battery percent changed
-    Battery(u16),
+    Battery(u8),
     /// Charging state changed
     ChargingState(bool),
     /// Ble profile changed

--- a/rmk/src/input_device/adc/nrf.rs
+++ b/rmk/src/input_device/adc/nrf.rs
@@ -48,16 +48,16 @@ impl<'a, const PIN_NUM: usize, const EVENT_NUM: usize> InputDevice for NrfAdc<'a
             // filling for the first polling
             self.saadc.sample(&mut self.buf[1]).await;
             self.active_instant = Instant::now();
-        }
-
-        if let Some(light_sleep) = self.light_sleep {
-            if self.adc_state == AdcState::LightSleep {
-                embassy_time::Timer::after(light_sleep).await;
+        } else {
+            if let Some(light_sleep) = self.light_sleep {
+                if self.adc_state == AdcState::LightSleep {
+                    embassy_time::Timer::after(light_sleep).await;
+                } else {
+                    embassy_time::Timer::after(self.polling_interval).await;
+                }
             } else {
                 embassy_time::Timer::after(self.polling_interval).await;
             }
-        } else {
-            embassy_time::Timer::after(self.polling_interval).await;
         }
 
         if self.active_instant.elapsed().as_millis() > 1200 {

--- a/rmk/src/input_device/battery.rs
+++ b/rmk/src/input_device/battery.rs
@@ -131,17 +131,19 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             Event::Battery(val) => {
                 trace!("Detected battery ADC value: {:?}", val);
 
-                #[cfg(feature = "controller")]
-                send_controller_event(&mut self.controller_pub, ControllerEvent::Battery(val));
-
                 #[cfg(feature = "_ble")]
                 {
                     let current_value =
                         crate::ble::trouble::battery_service::BATTERY_LEVEL.load(core::sync::atomic::Ordering::Relaxed);
                     if current_value < 100 || current_value == 255 {
+                        let battery_percent = self.get_battery_percent(val);
+
+                        #[cfg(feature = "controller")]
+                        send_controller_event(&mut self.controller_pub, ControllerEvent::Battery(battery_percent));
+
                         // When charging, don't update the battery level(which is inaccurate)
                         crate::ble::trouble::battery_service::BATTERY_LEVEL
-                            .store(self.get_battery_percent(val), core::sync::atomic::Ordering::Relaxed);
+                            .store(battery_percent, core::sync::atomic::Ordering::Relaxed);
                     }
                 }
                 ProcessResult::Stop
@@ -149,11 +151,11 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             Event::ChargingState(charging) => {
                 info!("Charging state changed: {:?}", charging);
 
-                #[cfg(feature = "controller")]
-                send_controller_event(&mut self.controller_pub, ControllerEvent::ChargingState(charging));
-
                 #[cfg(feature = "_ble")]
                 {
+                    #[cfg(feature = "controller")]
+                    send_controller_event(&mut self.controller_pub, ControllerEvent::ChargingState(charging));
+
                     if charging {
                         crate::ble::trouble::battery_service::BATTERY_LEVEL
                             .store(101, core::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
These changes aim to improve battery reporting for controllers:

* Report the battery percentage instead of the measured adc value
* Report battery instantly after boot, without waiting for `polling_interval` in `NrfAdc`