### PR TITLE
Feature:  new BLE option to configuring   default BLE transmit power (default_tx_power)  

### DIFF
--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -359,6 +359,7 @@ pub struct BleConfig {
     pub charge_led: Option<PinConfig>,
     pub adc_divider_measured: Option<u32>,
     pub adc_divider_total: Option<u32>,
+    pub default_tx_power: Option<i8>,
 }
 
 /// Config for lights

--- a/rmk-macro/src/bind_interrupt.rs
+++ b/rmk-macro/src/bind_interrupt.rs
@@ -66,6 +66,13 @@ pub(crate) fn bind_interrupt_default(keyboard_config: &KeyboardTomlConfig) -> To
             } else {
                 quote! { CLOCK_POWER => ::nrf_sdc::mpsl::ClockInterruptHandler; }
             };
+
+            let tx_power = if let Some(pwr) = communication.get_ble_config().unwrap().default_tx_power {
+                quote! { .default_tx_power(#pwr)?  }
+            } else {
+                quote! {}
+            };
+
             // nrf-sdc interrupt config
             let nrf_sdc_config = match board {
                 BoardConfig::Split(_) => quote! {
@@ -79,6 +86,7 @@ pub(crate) fn bind_interrupt_default(keyboard_config: &KeyboardTomlConfig) -> To
                     .support_phy_update_central()?
                     .support_phy_update_peripheral()?
                     .support_le_2m_phy()?
+                    #tx_power
                     .central_count(1)?
                     .peripheral_count(1)?
                     .buffer_cfg(L2CAP_MTU as u16, L2CAP_MTU as u16, L2CAP_TXQ, L2CAP_RXQ)?
@@ -91,6 +99,7 @@ pub(crate) fn bind_interrupt_default(keyboard_config: &KeyboardTomlConfig) -> To
                     .support_dle_peripheral()?
                     .support_phy_update_peripheral()?
                     .support_le_2m_phy()?
+                    #tx_power
                     .peripheral_count(1)?
                     .buffer_cfg(L2CAP_MTU as u16, L2CAP_MTU as u16, L2CAP_TXQ, L2CAP_RXQ)?
                     .build(p, rng, mpsl, mem)

--- a/rmk-macro/src/split/peripheral.rs
+++ b/rmk-macro/src/split/peripheral.rs
@@ -61,6 +61,12 @@ pub(crate) fn parse_split_peripheral_mod(id: usize, _attr: proc_macro::TokenStre
 fn expand_bind_interrupt_for_split_peripheral(chip: &ChipModel, communication: &CommunicationConfig) -> TokenStream2 {
     match chip.series {
         ChipSeries::Nrf52 => {
+            let tx_power = if let Some(pwr) = communication.get_ble_config().unwrap().default_tx_power {
+                quote! { .default_tx_power(#pwr)?  }
+            } else {
+                quote! {}
+            };
+
             quote! {
                 use ::embassy_nrf::bind_interrupts;
                 bind_interrupts!(struct Irqs {
@@ -98,6 +104,7 @@ fn expand_bind_interrupt_for_split_peripheral(chip: &ChipModel, communication: &
                         .support_phy_update_central()?
                         .support_phy_update_peripheral()?
                         .support_le_2m_phy()?
+                        #tx_power
                         .peripheral_count(1)?
                         .buffer_cfg(L2CAP_MTU as u16, L2CAP_MTU as u16, L2CAP_TXQ, L2CAP_RXQ)?
                         .build(p, rng, mpsl, mem)


### PR DESCRIPTION
This PR adds support for configuring the default BLE transmit power (`default_tx_power`) in **rmk** for **nRF-based devices**.

Developers can now optionally set the BLE transmit power via the TOML configuration. If specified, the value is applied during BLE stack initialization. If omitted, the default behavior remains unchanged, ensuring full backward compatibility.

### Recommended Usage (for nRF52840)

```toml
[ble]
default_tx_power = 8
```

> **Note:**
> This feature is currently implemented only for **nRF** series chips (e.g., `nrf52840`). The field is available for other platforms like **ESP32**, but support has not yet been implemented.

