### PR TITLE
Macros config support

### DIFF
--- a/rmk-config/src/keymap.pest
+++ b/rmk-config/src/keymap.pest
@@ -98,12 +98,15 @@ shifted_action = { ^"SHIFTED" ~ "(" ~ keycode_name ~ ")" }
 // Rule 8: TD(n) - Tap Dance
 tap_dance_action = { ^"TD" ~ "(" ~ number ~ ")" }
 
+// Rule 9: M(n) - Trigger Macro
+trigger_macro_action = { ^"M" ~ "(" ~ number ~ ")" }
+
 // --- Top Level Rules ---
 
 // A single key action entry in the map
 // Order is important: more specific function-like rules first, then aliases/specials, then simple keycodes.
 key_action = _{ // Consume surrounding whitespace/comments implicitly
-    wm_action | osm_action | layer_action | tap_hold_action | shifted_action | tap_dance_action | no_action | transparent_action | simple_keycode
+    wm_action | osm_action | layer_action | tap_hold_action | shifted_action | tap_dance_action | trigger_macro_action | no_action | transparent_action | simple_keycode
 }
 
 // The entire key map string: Start, zero or more key actions, End.

--- a/rmk-config/src/layout.rs
+++ b/rmk-config/src/layout.rs
@@ -408,6 +408,11 @@ impl KeyboardTomlConfig {
                                     key_action_sequence.push(action);
                                 }
 
+                                Rule::trigger_macro_action => {
+                                    let action = inner_pair.as_str().to_string();
+                                    key_action_sequence.push(action);
+                                }
+
                                 Rule::EOI | Rule::WHITESPACE => {
                                     // Ignore End of input marker
                                 }
@@ -539,6 +544,20 @@ mod tests {
         assert!(result.is_ok());
         let actions = result.unwrap();
         assert_eq!(actions, vec!["A", "TD(0)", "B", "TD(1)", "C", "TD(255)"]);
+    }
+
+    #[test]
+    fn test_macro_trigger_action_parsing() {
+        let aliases = std::collections::HashMap::new();
+        let layer_names = std::collections::HashMap::new();
+
+        // Test parsing a keymap string with macro trigger actions
+        let keymap = "A M(0) B M(1) C M(255)";
+        let result = KeyboardTomlConfig::keymap_parser(keymap, &aliases, &layer_names);
+
+        assert!(result.is_ok());
+        let actions = result.unwrap();
+        assert_eq!(actions, vec!["A", "M(0)", "B", "M(1)", "C", "M(255)"]);
     }
 
     #[test]

--- a/rmk-macro/src/layout.rs
+++ b/rmk-macro/src/layout.rs
@@ -374,6 +374,12 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
                 ::rmk::td!(#index)
             }
         }
+        s if s.to_lowercase().starts_with("m(") => {
+            let index = get_number(s.clone(), s.get(0..2).unwrap(), ")");
+            quote! {
+                ::rmk::m!(#index)
+            }
+        }
         _ => {
             let ident = get_key_with_alias(key);
             quote! { ::rmk::k!(#ident) }

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -170,3 +170,11 @@ macro_rules! td {
         $crate::action::KeyAction::TapDance($index)
     };
 }
+
+// Create a macro trigger action
+#[macro_export]
+macro_rules! m {
+    ($index: literal) => {
+        $crate::action::KeyAction::Single($crate::action::Action::TriggerMacro($index))
+    };
+}


### PR DESCRIPTION
# Macro config support

This PR enables users to map keys to macro triggers directly through keyboard.toml keymap

## Tasks

- [x] Add m! rust macro for creating a macro trigger action
- [x] Add M(n) to keymap parser to trigger macros
- [ ] Update documentation

## Example

```
[[behavior.macro.macros]]
operations = [
  { operation = "down", keycode = "RAlt" }, 
  { operation = "tap", keycode = "Quote" },
  { operation = "up", keycode = "RAlt" },
]


[[layer]]
name = "base_layer"
keys = """
M(0)
"""
```