### PR TITLE
feat/rust-toml-combination

### DIFF
--- a/rmk-macro/src/bind_interrupt.rs
+++ b/rmk-macro/src/bind_interrupt.rs
@@ -27,14 +27,40 @@ pub(crate) fn expand_bind_interrupt(keyboard_config: &KeyboardTomlConfig, item_m
                 }
                 None
             })
-            .unwrap_or(bind_interrupt_default(keyboard_config))
+            .unwrap_or(bind_interrupt_default(keyboard_config, item_mod))
     } else {
-        bind_interrupt_default(keyboard_config)
+        bind_interrupt_default(keyboard_config, item_mod)
     }
 }
 
+pub(crate) fn find_extern_irqs(item_mod: &ItemMod) -> Vec<TokenStream2> {
+
+    let mut extern_irqs:Vec<TokenStream2> = Vec::new();
+    if let Some((_, items)) = &item_mod.content {
+        items
+            .iter()
+            .for_each(|item| {
+                if let syn::Item::Fn(item_fn) = &item {
+                    if let Some(attr) = item_fn.attrs.iter().find(|attr| attr.path().is_ident("add_irq")){
+                        if let syn::Meta::List(list) = &attr.meta {
+                            extern_irqs.push(list.tokens.clone());
+                        } else {
+                            panic!("Invalid attribute format for add_irq");
+                        }
+                    }
+                }
+        });
+    }
+    extern_irqs
+}
+
 /// Expand default `bind_interrupt!` for different chips and nrf-sdc config for nRF52
-pub(crate) fn bind_interrupt_default(keyboard_config: &KeyboardTomlConfig) -> TokenStream2 {
+pub(crate) fn bind_interrupt_default(keyboard_config: &KeyboardTomlConfig, item_mod: &ItemMod) -> TokenStream2 {
+    let extern_irqs_vec = find_extern_irqs(item_mod);
+    let extern_irqs = quote!{
+        #(#extern_irqs_vec);*
+    };
+
     let chip = keyboard_config.get_chip_model().unwrap();
     let board = keyboard_config.get_board_config().unwrap();
     let communication = keyboard_config.get_communication_config().unwrap();
@@ -48,10 +74,13 @@ pub(crate) fn bind_interrupt_default(keyboard_config: &KeyboardTomlConfig) -> To
                     use ::embassy_stm32::bind_interrupts;
                     bind_interrupts!(struct Irqs {
                         #interrupt_name => ::embassy_stm32::usb::InterruptHandler<::embassy_stm32::peripherals::#peripheral_name>;
+                        #extern_irqs
                     });
                 }
             } else {
-                quote! {}
+                quote! {
+                    #extern_irqs
+                }
             }
         }
         rmk_config::ChipSeries::Nrf52 => {
@@ -114,6 +143,7 @@ pub(crate) fn bind_interrupt_default(keyboard_config: &KeyboardTomlConfig) -> To
                     RADIO => ::nrf_sdc::mpsl::HighPrioInterruptHandler;
                     TIMER0 => ::nrf_sdc::mpsl::HighPrioInterruptHandler;
                     RTC0 => ::nrf_sdc::mpsl::HighPrioInterruptHandler;
+                    #extern_irqs;
                 });
 
                 #[::embassy_executor::task]

--- a/rmk-macro/src/controller/mod.rs
+++ b/rmk-macro/src/controller/mod.rs
@@ -1,12 +1,13 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use rmk_config::KeyboardTomlConfig;
+use syn::ItemMod;
 
 use crate::gpio_config::convert_gpio_str_to_output_pin;
 
 /// Expands the controller initialization code based on the keyboard configuration.
 /// Returns a tuple containing: (controller_initialization, controller names)
-pub(crate) fn expand_controller_init(keyboard_config: &KeyboardTomlConfig) -> (TokenStream, Vec<TokenStream>) {
+pub(crate) fn expand_controller_init(keyboard_config: &KeyboardTomlConfig, item_mod: &ItemMod) -> (TokenStream, Vec<TokenStream>) {
     // TODO: Check whether the `controller` feature is enabled
     let chip = keyboard_config.get_chip_model().unwrap();
 
@@ -55,5 +56,36 @@ pub(crate) fn expand_controller_init(keyboard_config: &KeyboardTomlConfig) -> (T
         controller_names.push(quote! { capslock_controller });
     }
 
+    // external controller
+    if let Some((_, items)) = &item_mod.content {
+        items.iter().for_each(|item| {
+            if let syn::Item::Fn(item_fn) = &item {
+                if item_fn.attrs.iter().any(|attr| attr.path().is_ident("controller")) {
+                    let (custom_init, custom_name) = expand_custom_controller(&item_fn);
+                    initializers.extend(custom_init);
+                    controller_names.push(custom_name);
+                }
+            }
+        });
+    }
+
     (initializers, controller_names)
+}
+
+fn expand_custom_controller(fn_item: &syn::ItemFn) -> (TokenStream, TokenStream) {
+    let attr =  &fn_item.attrs.iter().find(|attr| attr.path().is_ident("controller")).unwrap();
+    if let syn::Meta::List(meta) = &attr.meta {
+        let content = &fn_item.block.stmts;
+        let initializer = quote! {
+            #(#content)*
+        };
+
+        let task_name = meta.tokens.clone();
+
+        (initializer, task_name)
+    } else {
+        (quote! {
+            compile_error!("Invalid controller definition")
+        }, quote! {})
+    }
 }

--- a/rmk-macro/src/keyboard.rs
+++ b/rmk-macro/src/keyboard.rs
@@ -126,7 +126,7 @@ fn expand_main(
     let split_central_config = expand_split_central_config(keyboard_config);
     let (input_device_config, devices, processors) = expand_input_device_config(keyboard_config);
     let matrix_and_keyboard = expand_matrix_and_keyboard_init(keyboard_config, rmk_features);
-    let (controller_initializers, controllers) = expand_controller_init(keyboard_config);
+    let (controller_initializers, controllers) = expand_controller_init(keyboard_config, &item_mod);
     let run_rmk = expand_rmk_entry(keyboard_config, &item_mod, devices, processors, controllers);
 
     let rmk_config = if keyboard_config.get_storage_config().enabled {


### PR DESCRIPTION
- support using external controller
- support declaring extra irqs with rust using toml

use toml for quick configuring
use rust for more interesting things

the example below shows how it works using an external crate named `rmk-display`
```rust
#[rmk_central]
mod keybaord_central {
    #[add_irq(SPIM3 => ::embassy_nrf::spim::InterruptHandler<::embassy_nrf::peripherals::SPI3>)]
    fn for_spim() {}

    #[controller(display_controller)]
    fn display_controller() {
        let mut config = ::embassy_nrf::spim::Config::default();
        config.frequency = ::embassy_nrf::spim::Frequency::M1;
        let spi = ::embassy_nrf::spim::Spim::new_txonly(p.SPI3, Irqs, p.P0_06, p.P0_05, config);
        let cs = ::embassy_nrf::gpio::Output::new(
            p.P0_26,
            ::embassy_nrf::gpio::Level::High,
            ::embassy_nrf::gpio::OutputDrive::Standard
        );
        let mut display_controller = rmk_display::spec::nice_view::create_controller::<_, _, 2>(spi, cs);
    }
}
```