### PR TITLE
real morse implementation

### DIFF
--- a/docs/en/docs/features/configuration/appendix.md
+++ b/docs/en/docs/features/configuration/appendix.md
@@ -201,11 +201,12 @@ combo_max_num = 8
 combo_max_length = 4
 # Maximum number of forks for conditional key actions
 fork_max_num = 8
-# Maximum number of tap dances keyboard can store
-# (Each tap dance is a programmable multi-tap/hold key)
+# Maximum number of tap dances keyboard can store (max 255)
 tap_dance_max_num = 8
-# Maximum number of taps per tap dance (default: 2, min: 2, max: 256)
-tap_dance_max_tap = 2
+# Maximum number of morse keys the keyboard can store (max 255)
+morse_max_num = 1
+# Maximum number of morse patterns a morse key can handle
+max_morse_patterns_per_key = 40
 # Macro space size in bytes for storing sequences
 macro_space_size = 256
 # Default debounce time in ms

--- a/docs/en/docs/features/configuration/appendix.md
+++ b/docs/en/docs/features/configuration/appendix.md
@@ -142,6 +142,33 @@ tap_dances = [
   }
 ]
 
+[[morse]]
+hold_timeout = "300ms"
+permissive_hold = false
+unilateral_tap = false
+hold_on_other_press = false
+morse.action_pairs = [ 
+  # Extended many function keys with morse
+  {pattern = ".", action = "F1"}, {pattern = "..", action = "F2"}, {pattern = "...", action = "F3"}, {pattern = "....", action = "F4"}, {pattern = ".....", action = "F5"},
+  {pattern = "-", action = "MO(1)"}, {pattern = ".-", action = "MO(2)"}, {pattern = "..-", action = "MO(3)"}, {pattern = "...-", action = "MO(4)"}, {pattern = "....-", action = "MO(5)"} 
+]
+
+# real morse ABC
+[[morse]]
+hold_timeout = "200ms"
+permissive_hold = false
+unilateral_tap = false
+hold_on_other_press = false
+[[morse.action_pairs]]
+pattern = ".-"
+action = "A"
+[[morse.action_pairs]] 
+pattern = "-..."
+action = "B"
+[[morse.action_pairs]] 
+pattern = "-.-."
+action = "C"
+
 # Fork configuration
 [behavior.fork]
 forks = [
@@ -204,9 +231,9 @@ fork_max_num = 8
 # Maximum number of tap dances keyboard can store (max 255)
 tap_dance_max_num = 8
 # Maximum number of morse keys the keyboard can store (max 255)
-morse_max_num = 1
+morse_max_num = 2
 # Maximum number of morse patterns a morse key can handle
-max_morse_patterns_per_key = 40
+max_morse_patterns_per_key = 12
 # Macro space size in bytes for storing sequences
 macro_space_size = 256
 # Default debounce time in ms

--- a/docs/en/docs/features/configuration/behavior.md
+++ b/docs/en/docs/features/configuration/behavior.md
@@ -207,19 +207,15 @@ keymap = [
 
 ### Configuration Limits
 
-The tap dance functionality is controlled by the following configuration limits in the `[rmk]` section:
+The tap dance and morse functionality is controlled by the following configuration limits in the `[rmk]` section:
 
 - `tap_dance_max_num`: Maximum number of tap dances (default: 8)
-- `tap_dance_max_tap`: Maximum number of taps per tap dance (default: 2, range: 2-256)
+- `morse_max_num`: Maximum number of morse keys (default: 8)
+- `max_morse_patterns_per_key`: Maximum number of morse patterns per morse key config (default: 8, range: 4-255)
 
-To support more taps per sequence, increase the `tap_dance_max_tap` value:
+Note that the tap_dance is limited to 2 taps in these combinations: `tap`, `hold`, `double_tap`, `hold_after_tap`, while morse supports a sequence of up to 15 tap/hold in a morse pattern.
 
-```toml
-[rmk]
-tap_dance_max_tap = 4  # Support up to 4 taps per tap dance
-```
-
-Note that the default format (using `tap`, `hold`, `hold_after_tap`, `double_tap`) is limited to 2 taps, while the extended format (using `tap_actions` and `hold_actions`) can support up to the configured `tap_dance_max_tap` value.
+To support more taps per sequence, use morse instead of tap dance, the only drawback is the lack of vial support.
 
 ## Fork
 

--- a/docs/en/docs/features/configuration/behavior.md
+++ b/docs/en/docs/features/configuration/behavior.md
@@ -156,31 +156,68 @@ Tap dance configuration includes the following parameters:
 
 :::
 
+## Morse
+In the `morse` sub-table, you can configure the keyboard's morse functionality. Morse allows you to define different actions based on various tap/hold patterns.
+It is like tap dance for experts, but unfortunately has no VIAL support. 
 
-Here is an example of tap dance configuration:
+For each morse configuration the following parameters can be set:
+ - `timeout` : The time window (in milliseconds or seconds) within which taps are considered part of the same morse sequence. 
+- `permissive_hold`: Enables permissive hold mode. When enabled, hold action will be triggered when a key is pressed and released during tap-hold decision. This option is recommended to set to true when `enable_hrm` is set to true.
+- `unilateral_tap`: (Experimental) Enables unilateral tap mode. When enabled, tap action will be triggered when a key from "same" hand is pressed. In current experimental version, the "opposite" hand is calculated [according to the number of cols/rows](https://github.com/HaoboGu/rmk/blob/c0ef95b1185c25972c62458c878ee9f1a8e1a837/rmk/src/tap_hold.rs#L111-L136). This option is recommended to set to true when `enable_hrm` is set to true.
+- `hold_on_other_press`: Enables hold-on-other-key-press mode. When enabled, hold action will be triggered immediately when any other non-tap-hold key is pressed while a tap-hold key is being held. This provides faster modifier activation without waiting for the timeout. **Priority rules**: When HRM is disabled, permissive hold takes precedence over this feature. When HRM is enabled, this feature works normally. Defaults to `false`.
+ - `morse.action_pairs`: list of patten -> action pairs. The pattern is a tap/hold sequence, its length is limited in 15. The morse pattern of `C` for example can be described like this: `"-.-."` or `"_._."` or `"1010"`. See the examples below!
+
+Here is an example of tap dance and morse configuration:
 
 ```toml
 [behavior.tap_dance]
 tap_dances = [
-  # Function key that outputs F1 on tap, F2 on double tap, layer 1 on hold
+  # td(0): Function key that outputs F1 on tap, F2 on double tap, layer 1 on hold
   { tap = "F1", hold = "MO(1)", double_tap = "F2" },
   
-  # Modifier key that outputs Ctrl on tap, Alt on double tap, Shift on hold
+  # td(1): Modifier key that outputs Ctrl on tap, Alt on double tap, Shift on hold
   { tap = "LCtrl", hold = "LShift", double_tap = "LAlt" },
   
-  # Navigation key that outputs Tab on tap, Escape on double tap, layer 2 on hold
+  # td(2): Navigation key that outputs Tab on tap, Escape on double tap, layer 2 on hold
   { tap = "Tab", hold = "MO(2)", double_tap = "Escape", timeout = "250ms" },
   
-  # Extended tap dance for function keys
+  # td(3): Extended tap dance for function keys
   {
     tap_actions = ["F1", "F2", "F3", "F4", "F5"], 
     hold_actions = ["MO(1)", "MO(2)", "MO(3)", "MO(4)", "MO(5)"],
     timeout = "300ms" 
   }
 ]
+
+# morse(0): Extended many function keys with morse - equivalent with td(3)
+[[morse]]
+timeout = "300ms"
+permissive_hold = false
+unilateral_tap = false
+hold_on_other_press = false
+morse.action_pairs = [ 
+  {pattern = ".", action = "F1"}, {pattern = "..", action = "F2"}, {pattern = "...", action = "F3"}, {pattern = "....", action = "F4"}, {pattern = ".....", action = "F5"},
+  {pattern = "-", action = "MO(1)"}, {pattern = ".-", action = "MO(2)"}, {pattern = "..-", action = "MO(3)"}, {pattern = "...-", action = "MO(4)"}, {pattern = "....-", action = "MO(5)"} 
+]
+
+# morse(1): the start of the real morse ABC
+[[morse]]
+timeout = "200ms"
+permissive_hold = false
+unilateral_tap = false
+hold_on_other_press = false
+[[morse.action_pairs]]
+pattern = ".-"
+action = "A"
+[[morse.action_pairs]] 
+pattern = "-..."
+action = "B"
+[[morse.action_pairs]] 
+pattern = "-.-."
+action = "C"
 ```
 
-### Using Tap Dance in Keymaps
+### Using Tap Dance, Morse in Keymaps
 
 To use a tap dance in your keymap, reference it by its index (starting from 0):
 
@@ -191,7 +228,7 @@ cols = 3
 layers = 2
 keymap = [
     [
-        ["A", "B", "C"],
+        ["A", "MORSE(0)", "MORSE(1)"], # use morse 0 and 1
         ["TD(0)", "TD(1)", "TD(2)"],  # Use tap dances 0, 1, and 2
         ["LCtrl", "MO(1)", "LShift"],
         ["OSL(1)", "LT(2, Kc9)", "LM(1, LShift | LGui)"]

--- a/docs/en/docs/features/configuration/layout.md
+++ b/docs/en/docs/features/configuration/layout.md
@@ -118,6 +118,10 @@ The definitions of those operations are same with QMK, you can found [here](http
 
 7. For shifted key, use `SHIFTED(key)`
 
+8. For Tap Dance, use `TD(n)`
+
+9. For morse key, use `MORSE(n)`
+
 ## Aliases
 
 The `[aliases]` section contains a table of user defined names and an associated replacement string, which can be used in the `layer.keys`:

--- a/docs/en/docs/features/configuration/rmk_config.md
+++ b/docs/en/docs/features/configuration/rmk_config.md
@@ -16,10 +16,12 @@ combo_max_num = 8
 combo_max_length = 4
 # Maximum number of forks for conditional key actions
 fork_max_num = 8
-# Maximum number of tap dances keyboard can store
+# Maximum number of tap dances keyboard can store (max 255)
 tap_dance_max_num = 8
-# Maximum number of taps per tap dance (default: 2, min: 2, max: 256)
-tap_dance_max_tap = 2
+# Maximum number of morse keys the keyboard can store (max 255)
+morse_max_num = 1
+# Maximum number of morse patterns a morse key can handle
+max_morse_patterns_per_key = 40
 # Macro space size in bytes for storing sequences. The maximum number of Macros depends on the size of each sequence: All sequences combined need to fit into macro_space_size, the number of macro sequences doesn't matter.
 macro_space_size = 256
 # Default debounce time in ms
@@ -59,7 +61,8 @@ Increasing the number of combos, forks, tap dances and macros will increase memo
 - `combo_max_length`: Maximum number of keys that can be pressed simultaneously in a combo, default value is 4.
 - `fork_max_num`: Maximum number of forks for conditional key actions, default value is 8. This value must be between 0 and 256.
 - `tap_dance_max_num`: Maximum number of tap dances that can be stored, default value is 8. This value must be between 0 and 256.
-- `tap_dance_max_tap`: Maximum number of taps per tap dance, default value is 2. This value must be between 2 and 256. If `tap_actions` or `hold_actions` in [tap-dance config](./behavior.md#tap-dance) is set, the `tap_dance_max_tap` will be automatically set to the maximum length of `tap_actions` or `hold_actions`.
+- `morse_max_num` : Maximum number of morse keys the keyboard can store, default value is 1. This value must be between 0 and 256.
+- `max_morse_patterns_per_key` : Maximum number of morse patterns a morse key can handle, default value is 40.
 - `macro_space_size`: Space size in bytes for storing macro sequences, default value is 256.
 
 ### Matrix Configuration

--- a/examples/use_config/rp2040/keyboard.toml
+++ b/examples/use_config/rp2040/keyboard.toml
@@ -48,4 +48,4 @@ keymap = [
 # enabled = false
 
 [rmk]
-tap_dance_max_tap = 4
+morse_max_num = 0

--- a/rmk-config/src/keymap.pest
+++ b/rmk-config/src/keymap.pest
@@ -98,12 +98,15 @@ shifted_action = { ^"SHIFTED" ~ "(" ~ keycode_name ~ ")" }
 // Rule 8: TD(n) - Tap Dance
 tap_dance_action = { ^"TD" ~ "(" ~ number ~ ")" }
 
+// Rule 9: MORSE(n) - Morse
+morse_action = { ^"MORSE" ~ "(" ~ number ~ ")" }
+
 // --- Top Level Rules ---
 
 // A single key action entry in the map
 // Order is important: more specific function-like rules first, then aliases/specials, then simple keycodes.
 key_action = _{ // Consume surrounding whitespace/comments implicitly
-    wm_action | osm_action | layer_action | tap_hold_action | shifted_action | tap_dance_action | no_action | transparent_action | simple_keycode
+    wm_action | osm_action | layer_action | tap_hold_action | shifted_action | tap_dance_action | morse_action | no_action | transparent_action | simple_keycode
 }
 
 // The entire key map string: Start, zero or more key actions, End.

--- a/rmk-config/src/layout.rs
+++ b/rmk-config/src/layout.rs
@@ -408,6 +408,11 @@ impl KeyboardTomlConfig {
                                     key_action_sequence.push(action);
                                 }
 
+                                Rule::morse_action => {
+                                    let action = inner_pair.as_str().to_string();
+                                    key_action_sequence.push(action);
+                                }
+
                                 Rule::EOI | Rule::WHITESPACE => {
                                     // Ignore End of input marker
                                 }

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -388,6 +388,7 @@ pub struct LayoutConfig {
 pub struct BehaviorConfig {
     pub tri_layer: Option<TriLayerConfig>,
     pub tap_hold: Option<TapHoldConfig>,
+    pub morse: Vec<Morse>,
     pub one_shot: Option<OneShotConfig>,
     pub combo: Option<CombosConfig>,
     #[serde(alias = "macro")]
@@ -406,6 +407,23 @@ pub struct TapHoldConfig {
     pub hold_on_other_press: Option<bool>,
     pub prior_idle_time: Option<DurationMillis>,
     pub hold_timeout: Option<DurationMillis>,
+}
+
+/// Configurations for morse
+#[derive(Clone, Debug, Deserialize)]
+pub struct Morse {
+    pub action_pairs: Vec<MorseActionPair>,
+    pub hold_timeout: Option<DurationMillis>,
+    pub permissive_hold: Option<bool>,
+    pub unilateral_tap: Option<bool>,
+    pub hold_on_other_press: Option<bool>,
+}
+
+/// Configurations for morse action pairs
+#[derive(Clone, Debug, Deserialize)]
+pub struct MorseActionPair {
+    pub pattern: String, // "-..."
+    pub action: String,  // "B"
 }
 
 /// Configurations for tri layer

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -50,10 +50,13 @@ pub struct RmkConstantsConfig {
     #[serde_inline_default(8)]
     #[serde(deserialize_with = "check_tap_dance_max_num")]
     pub tap_dance_max_num: usize,
-    /// Maximum number of taps per tap dance
-    #[serde_inline_default(2)]
-    #[serde(deserialize_with = "check_tap_dance_max_tap")]
-    pub tap_dance_max_tap: usize,
+    /// Maximum number of morse key configurations the keyboard can store
+    #[serde_inline_default(1)]
+    #[serde(deserialize_with = "check_morse_max_num")]
+    pub morse_max_num: usize,
+    /// Maximum number of morse patterns a morse key can handle
+    #[serde_inline_default(40)]
+    pub max_morse_patterns_per_key: usize,
     /// Macro space size in bytes for storing sequences
     #[serde_inline_default(256)]
     pub macro_space_size: usize,
@@ -117,13 +120,13 @@ where
     Ok(value)
 }
 
-fn check_tap_dance_max_tap<'de, D>(deserializer: D) -> Result<usize, D::Error>
+fn check_morse_max_num<'de, D>(deserializer: D) -> Result<usize, D::Error>
 where
     D: de::Deserializer<'de>,
 {
     let value = SerdeDeserialize::deserialize(deserializer)?;
-    if value < 2 || value > 256 {
-        panic!("❌ Parse `keyboard.toml` error: tap_dance_max_tap must be between 2 and 256, got {value}");
+    if value > 256 {
+        panic!("❌ Parse `keyboard.toml` error: morse_max_num must be between 0 and 256, got {value}");
     }
     Ok(value)
 }
@@ -149,7 +152,8 @@ impl Default for RmkConstantsConfig {
             combo_max_length: 4,
             fork_max_num: 8,
             tap_dance_max_num: 8,
-            tap_dance_max_tap: 2,
+            morse_max_num: 1,
+            max_morse_patterns_per_key: 40,
             macro_space_size: 256,
             debounce_time: 20,
             event_channel_size: 16,
@@ -230,7 +234,6 @@ impl KeyboardTomlConfig {
     }
 
     /// Auto calculate some parameters in toml:
-    /// - Update tap_dance_max_tap to fit the max length of tap_actions and hold_actions
     /// - Update peripheral number based on the number of split boards
     /// - TODO: Update controller number based on the number of split boards
     pub fn auto_calculate_parameters(&mut self) {
@@ -243,33 +246,6 @@ impl KeyboardTomlConfig {
                 //     self.rmk.split_peripherals_num
                 // );
                 self.rmk.split_peripherals_num = split.peripheral.len();
-            }
-        }
-
-        // Update tap_dance_max_tap
-        if let Some(behavior) = &self.behavior {
-            if let Some(tap_dance) = &behavior.tap_dance {
-                let mut max_required_taps = self.rmk.tap_dance_max_tap;
-
-                for td in &tap_dance.tap_dances {
-                    let tap_actions_len = td.tap_actions.as_ref().map(|v| v.len()).unwrap_or(0);
-                    let hold_actions_len = td.hold_actions.as_ref().map(|v| v.len()).unwrap_or(0);
-                    max_required_taps = max_required_taps.max(tap_actions_len).max(hold_actions_len);
-                }
-
-                if max_required_taps > 256 {
-                    panic!(
-                        "The number of taps per tap dance is too large, the max number of taps is 256, got {max_required_taps}"
-                    );
-                }
-
-                if max_required_taps > self.rmk.tap_dance_max_tap {
-                    // eprintln!(
-                    //     "The number of taps per tap dance is updated to {} from {}",
-                    //     max_required_taps, self.rmk.tap_dance_max_tap
-                    // );
-                    self.rmk.tap_dance_max_tap = max_required_taps;
-                }
             }
         }
     }

--- a/rmk-macro/src/behavior.rs
+++ b/rmk-macro/src/behavior.rs
@@ -3,8 +3,8 @@
 
 use quote::quote;
 use rmk_config::{
-    CombosConfig, ForksConfig, KeyboardTomlConfig, MacrosConfig, OneShotConfig, TapDancesConfig, TapHoldConfig,
-    TriLayerConfig,
+    CombosConfig, ForksConfig, KeyboardTomlConfig, MacrosConfig, Morse, MorseActionPair, OneShotConfig,
+    TapDancesConfig, TapHoldConfig, TriLayerConfig,
 };
 
 use crate::layout::{get_key_with_alias, parse_key};
@@ -42,39 +42,117 @@ fn expand_one_shot(one_shot: &Option<OneShotConfig>) -> proc_macro2::TokenStream
     }
 }
 
-fn expand_morse(morse_config: &Option<TapHoldConfig>) -> proc_macro2::TokenStream {
+fn expand_action_pair(action_pair: &MorseActionPair) -> proc_macro2::TokenStream {
+    let mut pattern = 0b1;
+    for ch in action_pair.pattern.chars() {
+        match ch {
+            '1' => pattern = pattern << 1 | 1,
+            '-' => pattern = pattern << 1 | 1,
+            '_' => pattern = pattern << 1 | 1,
+            '0' => pattern = pattern << 1,
+            '.' => pattern = pattern << 1,
+            _ => {}
+        }
+    }
+    let action = parse_key(action_pair.action.to_owned());
+    quote! { (::rmk::morse::MorsePattern::from_u16(#pattern), #action) }
+}
+
+fn expand_action_pairs(action_pairs: &Vec<MorseActionPair>) -> proc_macro2::TokenStream {
+    if action_pairs.len() > 0 {
+        let action_pair_def = action_pairs.iter().map(|action_pair| expand_action_pair(action_pair));
+
+        quote! {
+            actions: ::rmk::heapless::Vec::from_iter([#(#action_pair_def),*]),
+        }
+    } else {
+        quote! {}
+    }
+}
+
+fn expand_morse_key(morse: &Morse) -> proc_macro2::TokenStream {
+    //let default = quote! { ::core::default::Default::default() };
+
+    let hold_timeout = match &morse.hold_timeout {
+        Some(t) => {
+            let timeout = t.0;
+            quote! { timeout: ::embassy_time::Duration::from_millis(#timeout), }
+        }
+        None => quote! {},
+    };
+
+    let morse_mode = if let Some(true) = morse.permissive_hold {
+        quote! { mode: ::rmk::morse::MorseKeyMode::PermissiveHold, }
+    } else if let Some(true) = morse.hold_on_other_press {
+        quote! { mode: ::rmk::morse::MorseKeyMode::HoldOnOtherPress, }
+    } else {
+        quote! { mode: ::rmk::morse::MorseKeyMode::Normal,}
+    };
+
+    let unilateral_tap = match morse.unilateral_tap {
+        Some(enable) => quote! { unilateral_tap: #enable, },
+        None => quote! {},
+    };
+
+    let action_pairs_def = expand_action_pairs(&morse.action_pairs);
+
+    quote! {
+        ::rmk::morse::Morse {
+            #action_pairs_def
+            #hold_timeout
+            #morse_mode
+            #unilateral_tap
+            ..Default::default()
+        }
+    }
+}
+
+fn expand_morse_keys(morse_keys: &Vec<Morse>) -> proc_macro2::TokenStream {
+    if morse_keys.len() > 0 {
+        let morse_def = morse_keys.iter().map(|morse| expand_morse_key(morse));
+
+        quote! {
+            action_sets: ::rmk::heapless::Vec::from_iter([#(#morse_def),*]),
+        }
+    } else {
+        quote! {}
+    }
+}
+
+fn expand_morse_config(morse_config: &Option<TapHoldConfig>, morse_keys: &Vec<Morse>) -> proc_macro2::TokenStream {
     let default = quote! {::rmk::config::MorseConfig::default()};
     match morse_config {
-        Some(morse) => {
-            let enable_hrm = match morse.enable_hrm {
+        Some(morse_config) => {
+            let enable_hrm = match morse_config.enable_hrm {
                 Some(enable) => quote! { enable_hrm: #enable, },
                 None => quote! {},
             };
-            let morse_mode = if let Some(true) = morse.permissive_hold {
+            let morse_mode = if let Some(true) = morse_config.permissive_hold {
                 quote! { mode: ::rmk::morse::MorseKeyMode::PermissiveHold, }
-            } else if let Some(true) = morse.hold_on_other_press {
+            } else if let Some(true) = morse_config.hold_on_other_press {
                 quote! { mode: ::rmk::morse::MorseKeyMode::HoldOnOtherPress, }
             } else {
                 quote! { mode: ::rmk::morse::MorseKeyMode::Normal,}
             };
-            let unilateral_tap = match morse.unilateral_tap {
+            let unilateral_tap = match morse_config.unilateral_tap {
                 Some(enable) => quote! { unilateral_tap: #enable, },
                 None => quote! {},
             };
-            let prior_idle_time = match &morse.prior_idle_time {
+            let prior_idle_time = match &morse_config.prior_idle_time {
                 Some(t) => {
                     let timeout = t.0;
                     quote! { prior_idle_time: ::embassy_time::Duration::from_millis(#timeout), }
                 }
                 None => quote! {},
             };
-            let hold_timeout = match &morse.hold_timeout {
+            let hold_timeout = match &morse_config.hold_timeout {
                 Some(t) => {
                     let timeout = t.0;
                     quote! { operation_timeout: ::embassy_time::Duration::from_millis(#timeout), }
                 }
                 None => quote! {},
             };
+            let morse_keys = expand_morse_keys(morse_keys);
 
             quote! {
                 ::rmk::config::MorseConfig {
@@ -83,6 +161,7 @@ fn expand_morse(morse_config: &Option<TapHoldConfig>) -> proc_macro2::TokenStrea
                     #hold_timeout
                     #morse_mode
                     #unilateral_tap
+                    #morse_keys
                     ..Default::default()
                 }
             }
@@ -397,7 +476,7 @@ fn expand_forks(forks: &Option<ForksConfig>) -> proc_macro2::TokenStream {
 pub(crate) fn expand_behavior_config(keyboard_config: &KeyboardTomlConfig) -> proc_macro2::TokenStream {
     let behavior = keyboard_config.get_behavior_config().unwrap();
     let tri_layer = expand_tri_layer(&behavior.tri_layer);
-    let morse = expand_morse(&behavior.tap_hold);
+    let morse = expand_morse_config(&behavior.tap_hold, &behavior.morse);
     let one_shot = expand_one_shot(&behavior.one_shot);
     let combos = expand_combos(&behavior.combo);
     let macros = expand_macros(&behavior.macros);

--- a/rmk-macro/src/layout.rs
+++ b/rmk-macro/src/layout.rs
@@ -374,6 +374,12 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
                 ::rmk::td!(#index)
             }
         }
+        s if s.to_lowercase().starts_with("morse(") => {
+            let index = get_number(s.clone(), s.get(0..3).unwrap(), ")");
+            quote! {
+                ::rmk::morse!(#index)
+            }
+        }
         _ => {
             let ident = get_key_with_alias(key);
             quote! { ::rmk::k!(#ident) }
@@ -381,7 +387,7 @@ pub(crate) fn parse_key(key: String) -> TokenStream2 {
     }
 }
 
-/// Parse the string literal like `MO(1)`, `OSL(1)`, `TD(0)`, etc, get the number in it.
+/// Parse the string literal like `MO(1)`, `OSL(1)`, `TD(0)`, `MORSE(0)`, etc, get the number in it.
 /// The caller should pass the trimmed prefix and suffix
 fn get_number(key: String, prefix: &str, suffix: &str) -> u8 {
     let layer_str = key.trim_start_matches(prefix).trim_end_matches(suffix);

--- a/rmk/build.rs
+++ b/rmk/build.rs
@@ -66,7 +66,8 @@ fn get_constants_str(constants: RmkConstantsConfig) -> String {
         const_declaration!(pub(crate) NUM_BLE_PROFILE = constants.ble_profiles_num),
         const_declaration!(pub(crate) SPLIT_CENTRAL_SLEEP_TIMEOUT_MINUTES = constants.split_central_sleep_timeout_minutes),
         const_declaration!(pub(crate) TAP_DANCE_MAX_NUM = constants.tap_dance_max_num),
-        const_declaration!(pub(crate) TAP_DANCE_MAX_TAP = constants.tap_dance_max_tap),
+        const_declaration!(pub(crate) MORSE_MAX_NUM = constants.morse_max_num),
+        const_declaration!(pub(crate) MAX_MORSE_PATTERNS_PER_KEY = constants.max_morse_patterns_per_key),
         format!("pub(crate) const BUILD_HASH: u32 = {build_hash:#010x};\n"),
     ]
     .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())

--- a/rmk/src/action.rs
+++ b/rmk/src/action.rs
@@ -1,6 +1,8 @@
-use crate::TAP_DANCE_MAX_TAP;
+use embassy_time::Duration;
+
+use crate::config::BehaviorConfig;
 use crate::keycode::{KeyCode, ModifierCombination};
-use crate::morse::Morse;
+use crate::morse::{DOUBLE_TAP, HOLD, HOLD_AFTER_TAP, MorseKeyMode, MorsePattern, TAP};
 
 /// EncoderAction is the action at a encoder position, stored in encoder_map.
 #[derive(Clone, Copy, Debug)]
@@ -56,10 +58,15 @@ pub enum KeyAction {
     Single(Action),
     /// Don't wait the release of the key, auto-release after a time threshold.
     Tap(Action),
+
+    /// Tap hold action
+    TapHold(Action, Action),
+
     /// Tap dance action, references a tap dance configuration by index.
     TapDance(u8),
-    /// Morse action
-    Morse(Morse<TAP_DANCE_MAX_TAP>),
+
+    /// Morse action, references a morse configuration by index.
+    Morse(u8),
 }
 
 impl KeyAction {
@@ -69,6 +76,108 @@ impl KeyAction {
         match self {
             KeyAction::Single(a) | KeyAction::Tap(a) => a,
             _ => Action::No,
+        }
+    }
+
+    pub fn is_morse(&self) -> bool {
+        matches!(
+            self,
+            KeyAction::TapHold(_, _) | KeyAction::TapDance(_) | KeyAction::Morse(_)
+        )
+    }
+
+    pub fn action_from_pattern(&self, behavior_config: &BehaviorConfig, pattern: MorsePattern) -> Action {
+        match self {
+            KeyAction::TapHold(tap_action, hold_action) => match pattern {
+                TAP => *tap_action,
+                HOLD => *hold_action,
+                _ => Action::No,
+            },
+            KeyAction::TapDance(idx) => {
+                behavior_config
+                    .tap_dance
+                    .tap_dances
+                    .get(*idx as usize)
+                    .map_or(Action::No, |td| match pattern {
+                        TAP => td.tap_action,
+                        HOLD => td.hold_action,
+                        DOUBLE_TAP => td.double_tap_action,
+                        HOLD_AFTER_TAP => td.hold_after_tap_action,
+                        _ => Action::No,
+                    })
+            }
+
+            KeyAction::Morse(idx) => behavior_config
+                .morse
+                .action_sets
+                .get(*idx as usize)
+                .map_or(Action::No, |morse| *morse.get(pattern).unwrap_or(&Action::No)),
+            _ => Action::No,
+        }
+    }
+
+    pub fn morse_timeout(&self, behavior_config: &BehaviorConfig) -> Duration {
+        match self {
+            KeyAction::TapDance(idx) => behavior_config
+                .tap_dance
+                .tap_dances
+                .get(*idx as usize)
+                .map(|td| Duration::from_millis(td.timeout_ms as u64)),
+
+            KeyAction::Morse(idx) => behavior_config
+                .morse
+                .action_sets
+                .get(*idx as usize)
+                .map(|morse| Duration::from_millis(morse.timeout_ms as u64)),
+
+            _ => None,
+        }
+        .unwrap_or_else(|| behavior_config.morse.operation_timeout)
+    }
+
+    pub fn morse_mode(&self, behavior_config: &BehaviorConfig) -> (MorseKeyMode, bool) {
+        match self {
+            KeyAction::TapDance(idx) => behavior_config
+                .tap_dance
+                .tap_dances
+                .get(*idx as usize)
+                .map(|td| (td.mode, td.unilateral_tap)),
+
+            KeyAction::Morse(idx) => behavior_config
+                .morse
+                .action_sets
+                .get(*idx as usize)
+                .map(|morse| (morse.mode, morse.unilateral_tap)),
+
+            _ => None,
+        }
+        .unwrap_or_else(|| {
+            if behavior_config.morse.enable_hrm //TODO instead of this let the HRM keycodes configurable!
+               && let Action::Key(tap_key_code) = self.action_from_pattern(behavior_config, TAP)
+               && tap_key_code.is_home_row()
+            //&& (!let Action::Key(_) = hold_action) //the hold action in home row is not key, but modifier or layer activation
+            {
+                (MorseKeyMode::PermissiveHold, true)
+            } else {
+                (behavior_config.morse.mode, behavior_config.morse.unilateral_tap)
+            }
+        })
+    }
+
+    pub fn max_pattern_length(&self, behavior_config: &BehaviorConfig) -> usize {
+        match self {
+            KeyAction::TapHold(_, _) => 1,
+            KeyAction::TapDance(idx) => behavior_config
+                .tap_dance
+                .tap_dances
+                .get(*idx as usize)
+                .map_or(0, |td| td.max_pattern_length()),
+            KeyAction::Morse(idx) => behavior_config
+                .morse
+                .action_sets
+                .get(*idx as usize)
+                .map_or(0, |morse| morse.max_pattern_length()),
+            _ => 0,
         }
     }
 }

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -10,9 +10,9 @@ use macro_config::KeyboardMacrosConfig;
 
 use crate::combo::Combo;
 use crate::fork::Fork;
-use crate::morse::MorseKeyMode;
+use crate::morse::{Morse, MorseKeyMode};
 use crate::tap_dance::TapDance;
-use crate::{COMBO_MAX_NUM, FORK_MAX_NUM, TAP_DANCE_MAX_NUM};
+use crate::{COMBO_MAX_NUM, FORK_MAX_NUM, MAX_MORSE_PATTERNS_PER_KEY, MORSE_MAX_NUM, TAP_DANCE_MAX_NUM};
 
 /// Internal configurations for RMK keyboard.
 #[derive(Default)]
@@ -51,7 +51,7 @@ impl Default for TapDancesConfig {
 }
 
 /// Configurations for morse behavior
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct MorseConfig {
     pub enable_hrm: bool,
     pub prior_idle_time: Duration,
@@ -61,6 +61,9 @@ pub struct MorseConfig {
     pub mode: MorseKeyMode,
     /// If the previous key is on the same "hand", the current key will be determined as a tap
     pub unilateral_tap: bool,
+
+    // Morse actions for each morse key:
+    pub action_sets: Vec<Morse<MAX_MORSE_PATTERNS_PER_KEY>, MORSE_MAX_NUM>,
 }
 
 impl Default for MorseConfig {
@@ -71,6 +74,7 @@ impl Default for MorseConfig {
             mode: MorseKeyMode::Normal,
             prior_idle_time: Duration::from_millis(120),
             operation_timeout: Duration::from_millis(250),
+            action_sets: Vec::new(),
         }
     }
 }

--- a/rmk/src/keyboard/held_buffer.rs
+++ b/rmk/src/keyboard/held_buffer.rs
@@ -1,7 +1,8 @@
 use embassy_time::Instant;
 
-use crate::action::KeyAction;
+use crate::action::{Action, KeyAction};
 use crate::event::{KeyboardEvent, KeyboardEventPos};
+use crate::morse::MorsePattern;
 
 /// The buffer of held keys.
 #[derive(Debug, Default, Clone)]
@@ -89,24 +90,22 @@ impl HeldBuffer {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum KeyState {
-    /// After a press event is received.
-    /// The number represents the number of completed "tap".
-    Held(u8),
-    /// Idle state after tap n times for morse keys
-    IdleAfterTap(u8),
-    /// Idle state after hold released
-    IdleAfterHold(u8),
     /// The current key is a component of a combo, and it's waiting for other combo components
     WaitingCombo,
-    /// Tap key has been processed and sent to HID, but not yet released.
-    /// The number is used for morse keys, represents the number of completed "tap"s
-    PostTap(u8),
-    /// Key is being held, but not yet released
-    /// The number is used for morse keys, represents the number of completed "tap"s
-    PostHold(u8),
-    /// Key needs to be released but is still in the queue,
-    /// it should be cleaned up in the main loop regardless
-    Release,
+
+    /// After a press event is received.
+    /// The data represents the previously completed morse pattern
+    Pressed(MorsePattern),
+
+    /// After a release event is received for a key still kept in the HeldBuffer - so morse pattern may continue
+    /// The data represents the already completed morse pattern
+    Released(MorsePattern),
+
+    /// The corresponding action is already executed (so the Pressed HID report is sent),
+    /// but the release HID report is not sent yet (will be sent only when the corresponding
+    /// key is really released).
+    ProcessedButReleaseNotReportedYet(Action),
+    // The Idle state is represented by the removal from the HeldBuffer
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/rmk/src/keyboard/morse.rs
+++ b/rmk/src/keyboard/morse.rs
@@ -1,31 +1,38 @@
-use embassy_time::{Duration, Instant};
+use embassy_time::Instant;
 
-use crate::TAP_DANCE_MAX_TAP;
 use crate::action::KeyAction;
 use crate::event::KeyboardEvent;
 use crate::keyboard::Keyboard;
 use crate::keyboard::held_buffer::{HeldKey, KeyState};
-use crate::morse::Morse;
+use crate::morse::MorsePattern;
 
 impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_ENCODER: usize>
     Keyboard<'a, ROW, COL, NUM_LAYER, NUM_ENCODER>
 {
-    // When a morse key reaches timeout
-    // - Trigger the current key as tap or hold according to it's `KeyState`
-    // - For all non tap-hold keys pressed, trigger their tap action.
-    pub(crate) async fn handle_morse_timeout(&mut self, key: &HeldKey, morse: Morse<TAP_DANCE_MAX_TAP>) {
+    // When a morse key reaches timeout after press / release
+    pub(crate) async fn handle_morse_timeout(&mut self, key: &HeldKey) {
+        // !assert(key.action.is_morse());
+
         match key.state {
-            KeyState::Held(tap) => {
-                let a = morse.hold_action(tap as usize);
-                self.process_key_action_normal(a, key.event).await;
-                if let Some(k) = self.held_buffer.find_pos_mut(key.event.pos) {
-                    k.state = KeyState::PostHold(tap)
+            KeyState::Pressed(pattern) => {
+                // The time since the key press is longer than the timeout,
+                // if there is no possibility for longer morse patterns, trigger the action:
+                let pattern = pattern.followed_by_hold();
+                if pattern.is_full()
+                    || pattern.pattern_length() >= key.action.max_pattern_length(&self.keymap.borrow().behavior)
+                {
+                    let action = key.action.action_from_pattern(&self.keymap.borrow().behavior, pattern);
+                    self.process_key_action_normal(action, key.event).await;
+                    if let Some(k) = self.held_buffer.find_pos_mut(key.event.pos) {
+                        k.state = KeyState::ProcessedButReleaseNotReportedYet(action);
+                    }
                 }
             }
-            KeyState::IdleAfterTap(tap) => {
-                let a = morse.tap_action(tap as usize);
-                self.process_key_action_tap(a, key.event).await;
-                let _ = self.held_buffer.remove(key.event.pos);
+            KeyState::Released(pattern) => {
+                // The time since the key release is longer than the timeout, trigger the action
+                let action = key.action.action_from_pattern(&self.keymap.borrow().behavior, pattern);
+                self.process_key_action_tap(action, key.event).await;
+                let _ = self.held_buffer.remove(key.event.pos); // Removing from the held buffer is like setting to an idle state
             }
             _ => unreachable!(),
         };
@@ -35,111 +42,95 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             .held_buffer
             .keys
             .iter()
-            .filter(|k| matches!(k.action, KeyAction::Morse(_)) && matches!(k.state, KeyState::Held(0)))
-            .count()
-            > 0
+            .any(|k| k.action.is_morse() && matches!(k.state, KeyState::Pressed(_)))
         {
-            return;
+            return; //?
         }
 
         self.fire_held_non_morse_keys().await;
     }
 
-    pub(crate) async fn process_key_action_morse(&mut self, morse: Morse<TAP_DANCE_MAX_TAP>, event: KeyboardEvent) {
+    pub(crate) async fn process_key_action_morse(&mut self, key_action: KeyAction, event: KeyboardEvent) {
         debug!("Processing morse: {:?}", event);
+        // !assert(key_action.is_morse());
 
         // Process the morse key
         if event.pressed {
             // Pressed, check the held buffer, update the tap state
             let pressed_time = self.get_timer_value(event).unwrap_or(Instant::now());
+            let timeout_time = pressed_time + key_action.morse_timeout(&self.keymap.borrow().behavior);
             match self.held_buffer.find_pos_mut(event.pos) {
                 Some(k) => {
-                    // The current key is already in the buffer, update the tap state
-                    if let KeyState::IdleAfterTap(t) = k.state {
-                        let tap_len = morse.tap_actions.len().max(morse.hold_actions.len()) as u8;
-                        if t + 1 >= tap_len {
-                            // Reach maximum tapping number
-                            k.state = KeyState::Held(tap_len - 1);
-                        } else {
-                            k.state = KeyState::Held(t + 1);
-                        }
+                    // The current key is already in the buffer, update its state
+                    if let KeyState::Released(pattern) = k.state {
+                        k.state = KeyState::Pressed(pattern);
                         k.press_time = pressed_time;
-                        k.timeout_time = pressed_time + Duration::from_millis(morse.timeout_ms as u64);
+                        k.timeout_time = timeout_time;
                     }
                 }
                 None => {
                     // Add to buffer
                     self.held_buffer.push(HeldKey::new(
                         event,
-                        KeyAction::Morse(morse),
-                        KeyState::Held(0),
+                        key_action,
+                        KeyState::Pressed(MorsePattern::default()),
                         pressed_time,
-                        pressed_time + Duration::from_millis(morse.timeout_ms as u64),
+                        timeout_time,
                     ));
                 }
             }
         } else {
-            // Release a morse key
-            // 1. It's in the holding buffer
-            // 2. If it's already timeout, get the hold action to be released.
-            // 3. If it's not timeout, and the releasing action is the last tap actions, and there's no tap actions after it, trigger it immediately
-            // 4. Otherwise, update the tap state to idle, wait for the next tap or idle timeout
+            // Release a morse key, which is in the held buffer
+            // If there's no possible longer morse pattern, trigger it immediately
+            // Otherwise, update the state, wait for the either the next press event or the idle timeout
             if let Some(k) = self.held_buffer.find_pos_mut(event.pos) {
                 debug!("Releasing morse key: {:?}", k);
-                let action = match k.state {
-                    KeyState::Held(t) => {
-                        // If the current pressed key is timeout when releasing it, release the hold action
-                        if k.timeout_time < Instant::now() {
-                            // Timeout, release current hold action
-                            Some(morse.hold_action(t as usize))
+                match k.state {
+                    KeyState::Pressed(pattern) => {
+                        let pattern = if Instant::now() >= k.timeout_time {
+                            pattern.followed_by_hold()
                         } else {
-                            // Not timeout, check whether it's the last tap action
-                            if t + 1 >= morse.tap_actions.len() as u8 && t >= morse.hold_actions.len() as u8 {
-                                // It's the last tap action, trigger the tap action immediately
-                                let action = morse.tap_action(t as usize);
-                                debug!("Last tap action, trigger tap action {:?} immediately", action);
-                                // Trigger the tap action immediately
-                                k.state = KeyState::PostTap(t);
-                                let mut press_event = event;
-                                press_event.pressed = true;
-                                self.process_key_action_tap(action, press_event).await;
-                                self.held_buffer.remove(event.pos);
-                                None
-                            } else {
-                                // It's not the last tap action, update the tap state to idle
-                                k.state = KeyState::IdleAfterTap(t);
-                                // Use current release time for `IdleAfterTap` state
-                                k.press_time = Instant::now(); // Use release time as the "press_time"
-                                k.timeout_time = k.press_time + Duration::from_millis(morse.timeout_ms as u64);
-                                None
-                            }
+                            pattern.followed_by_tap()
+                        };
+
+                        if pattern.is_full()
+                            || pattern.pattern_length() >= k.action.max_pattern_length(&self.keymap.borrow().behavior)
+                        {
+                            // Reached the longest configured morse pattern, trigger the corresponding action immediately
+                            let action = k.action.action_from_pattern(&self.keymap.borrow().behavior, pattern);
+
+                            self.held_buffer.remove(event.pos); // Remove the key from the held buffer, is like setting to an idle state
+
+                            debug!(
+                                "Reached the longest configured morse pattern, trigger corresponding action {:?} immediately",
+                                action
+                            );
+
+                            // Trigger the morse action immediately
+                            let mut press_event = event;
+                            press_event.pressed = true;
+                            self.process_key_action_tap(action, press_event).await;
+                            self.held_buffer.remove(event.pos); // Remove the key from the held buffer, is like setting to an idle state
+                        } else {
+                            // Expect a possible longer morse pattern (or idle timeout), update the state
+                            k.state = KeyState::Released(pattern);
+                            // Use current release time for `IdleAfterTap` state
+                            k.press_time = Instant::now(); // Use release time as the "press_time"
+                            k.timeout_time = k.press_time + k.action.morse_timeout(&self.keymap.borrow().behavior);
                         }
                     }
-                    KeyState::PostHold(t) => {
-                        // Releasing a tap-hold action whose hold action is already triggered
-                        info!("Releasing a tap-hold action whose hold action is already triggered");
-                        Some(morse.hold_action(t as usize))
+                    KeyState::ProcessedButReleaseNotReportedYet(action) => {
+                        // Releasing a tap-hold action whose pressed HID report is already sent
+                        info!("Releasing a morse action whose pressed action is already triggered");
+                        let _ = self.held_buffer.remove(event.pos);
+                        // Process the release action
+                        debug!("[morse] Releasing morse key: {:?}", event);
+                        self.process_key_action_normal(action, event).await;
+                        // Clear timer
+                        self.set_timer_value(event, None);
                     }
-                    KeyState::PostTap(t) => {
-                        // Releasing a tap-hold action whose tap action is already triggered
-                        info!("Releasing a tap-hold action whose tap action is already triggered");
-                        Some(morse.tap_action(t as usize))
-                    }
-                    _ => {
-                        // Release when tap-dance key is in other state, ignore
-                        None
-                    }
+                    _ => {}
                 };
-
-                // If there's an action determined to be triggered, process it
-                if let Some(action) = action {
-                    debug!("[morse] Releasing tap-hold key: {:?}", event);
-                    let _ = self.held_buffer.remove(event.pos);
-                    // Process the action
-                    self.process_key_action_normal(action, event).await;
-                    // Clear timer
-                    self.set_timer_value(event, None);
-                }
             }
         }
     }
@@ -148,7 +139,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
         self.held_buffer.keys.sort_unstable_by_key(|k| k.press_time);
 
         // Trigger all non-morse keys in the buffer
-        while let Some(key) = self.held_buffer.remove_if(|k| !matches!(k.action, KeyAction::Morse(_))) {
+        while let Some(key) = self.held_buffer.remove_if(|k| !k.action.is_morse()) {
             debug!("Trigger non-morse key: {:?}", key);
             let action = self.keymap.borrow_mut().get_action_with_layer_cache(key.event);
             match action {

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -53,10 +53,10 @@ macro_rules! lm {
 #[macro_export]
 macro_rules! lt {
     ($x: literal, $k: ident) => {
-        $crate::action::KeyAction::Morse($crate::morse::Morse::new_layer_tap_hold(
+        $crate::action::KeyAction::TapHold(
             $crate::action::Action::Key($crate::keycode::KeyCode::$k),
-            $x,
-        ))
+            $crate::action::Action::LayerOn($x),
+        )
     };
 }
 
@@ -64,21 +64,21 @@ macro_rules! lt {
 #[macro_export]
 macro_rules! mt {
     ($k: ident, $m: expr) => {
-        $crate::action::KeyAction::Morse($crate::morse::Morse::new_modifier_tap_hold(
+        $crate::action::KeyAction::TapHold(
             $crate::action::Action::Key($crate::keycode::KeyCode::$k),
-            $m,
-        ))
+            $crate::action::Action::Modifier($m),
+        )
     };
 }
 
-/// Create a modifier-tap-hold action which is on the home row.
+// TODO: remove this, implement HRM key config somewhere else!
 #[macro_export]
 macro_rules! hrm {
     ($k: ident, $m: expr) => {
-        $crate::action::KeyAction::Morse($crate::morse::Morse::new_hrm(
+        $crate::action::KeyAction::TapHold(
             $crate::action::Action::Key($crate::keycode::KeyCode::$k),
-            $m,
-        ))
+            $crate::action::Action::Modifier($m),
+        )
     };
 }
 
@@ -86,10 +86,10 @@ macro_rules! hrm {
 #[macro_export]
 macro_rules! th {
     ($t: ident, $h: ident) => {
-        $crate::action::KeyAction::Morse($crate::morse::Morse::new_tap_hold(
+        $crate::action::KeyAction::TapHold(
             $crate::action::Action::Key($crate::keycode::KeyCode::$t),
             $crate::action::Action::Key($crate::keycode::KeyCode::$h),
-        ))
+        )
     };
 }
 
@@ -121,10 +121,10 @@ macro_rules! tg {
 #[macro_export]
 macro_rules! tt {
     ($x: literal) => {
-        $crate::action::KeyAction::Morse($crate::morse::Morse::new_layer_tap_hold(
+        $crate::action::KeyAction::TapHold(
             $crate::action::Action::LayerToggle($x),
-            $x,
-        ))
+            $crate::action::Action::LayerOn($x),
+        )
     };
 }
 
@@ -168,5 +168,13 @@ macro_rules! encoder {
 macro_rules! td {
     ($index: literal) => {
         $crate::action::KeyAction::TapDance($index)
+    };
+}
+
+/// Create a morse action (which is an advanced tap-dance action)
+#[macro_export]
+macro_rules! morse {
+    ($index: literal) => {
+        $crate::action::KeyAction::Morse($index)
     };
 }

--- a/rmk/src/morse.rs
+++ b/rmk/src/morse.rs
@@ -1,26 +1,66 @@
 use crate::action::Action;
-use crate::keycode::ModifierCombination;
+
+/// a sequence of maximum 15 tap or hold can be encoded on an u16:
+/// 0x1 when empty, then 0 for tap or 1 for hold shifted from the right
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MorsePattern(u16);
+
+pub const TAP: MorsePattern = MorsePattern(0b10);
+pub const HOLD: MorsePattern = MorsePattern(0b11);
+pub const DOUBLE_TAP: MorsePattern = MorsePattern(0b100);
+pub const HOLD_AFTER_TAP: MorsePattern = MorsePattern(0b101);
+
+impl MorsePattern {
+    pub fn max_taps() -> usize {
+        15 // 15 taps can be encoded on u16 bits (1 bit used to mark the start position)
+    }
+
+    pub fn default() -> Self {
+        MorsePattern(0b1) // 0b1 means empty
+    }
+
+    pub fn from_u16(value: u16) -> Self {
+        MorsePattern(value)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0 == 0b1
+    }
+
+    pub fn is_full(&self) -> bool {
+        (self.0 & 0b1000_0000_0000_0000) != 0
+    }
+
+    pub fn pattern_length(&self) -> usize {
+        15 - self.0.leading_zeros() as usize
+    }
+
+    pub fn followed_by_tap(&self) -> Self {
+        // Shift the bits to the left and set the last bit to 0 (tap)
+        MorsePattern((self.0 << 1) | 0b0)
+    }
+
+    pub fn followed_by_hold(&self) -> Self {
+        // Shift the bits to the left and set the last bit to 1 (hold)
+        MorsePattern((self.0 << 1) | 0b1)
+    }
+}
 
 /// Definition of a morse key.
 ///
-/// A morse key is a key that behaves differently according to the number of taps and current action.
-/// It's morse code, but supports only holding after a certain number of taps.
+/// A morse key is a key that behaves differently according to the pattern of a tap/hold sequence.
 ///
-/// There are two lists of actions in a morse key:
-/// - tap actions: actions triggered by tapping the key n times
-/// - hold actions: actions triggered by tapping the key n times then holding the key
-///
-/// The maximum number of taps is defined by the `TAP_N` parameter.
-///
-/// The morse key is actually a superset of tap-hold key and tap-dance key.
-/// When `TAP_N` is 1, the morse key becomes a tap-hold key, and when `hold_actions` is empty, it becomes a tap-dance key.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+/// There is a lists of (morse pattern, corresponding action) pairs for each morse key:
+/// The number of pairs is limited by N, which is a const generic parameter.
+/// The maximum number of taps is limited to 15 by the internal u16 representation of MorsePattern.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Morse<const TAP_N: usize> {
-    /// The actions triggered by tapping the key
-    pub(crate) tap_actions: MorseActions<TAP_N>,
-    /// The actions triggered by tapping and holding the key
-    pub(crate) hold_actions: MorseActions<TAP_N>,
+pub struct Morse<const N: usize> {
+    /// The list of pattern -> action pairs, which can be triggered
+    pub(crate) actions: heapless::Vec<(MorsePattern, Action), N>,
+
     /// The timeout time for each operation in milliseconds
     pub timeout_ms: u16,
     /// The decision mode of the morse key
@@ -29,113 +69,36 @@ pub struct Morse<const TAP_N: usize> {
     pub unilateral_tap: bool,
 }
 
-impl<const TAP_N: usize> Default for Morse<TAP_N> {
+impl<const N: usize> Default for Morse<N> {
     fn default() -> Self {
         Self {
-            tap_actions: MorseActions::default(),
-            hold_actions: MorseActions::default(),
+            actions: heapless::Vec::default(),
             timeout_ms: 250,
-            mode: MorseKeyMode::Normal,
+            mode: MorseKeyMode::HoldOnOtherPress,
             unilateral_tap: false,
         }
     }
 }
 
-impl<const TAP_N: usize> Morse<TAP_N> {
-    pub const fn new_tap_hold(tap_action: Action, hold_action: Action) -> Self {
-        let tap_actions = MorseActions::new_single(tap_action);
-        let hold_actions = MorseActions::new_single(hold_action);
-        Self {
-            tap_actions,
-            hold_actions,
-            timeout_ms: 250,
-            mode: MorseKeyMode::Normal,
-            unilateral_tap: false,
+impl<const N: usize> Morse<N> {
+    pub fn max_pattern_length(&self) -> usize {
+        let mut max_length = 0;
+        for pair in self.actions.iter() {
+            let pattern_length = pair.0.pattern_length();
+            if pattern_length > max_length {
+                max_length = pattern_length;
+            }
         }
+        max_length
     }
 
-    pub const fn new_layer_tap_hold(tap_action: Action, layer: u8) -> Self {
-        let tap_actions = MorseActions::new_single(tap_action);
-        let hold_actions = MorseActions::new_single(Action::LayerOn(layer));
-        Self {
-            tap_actions,
-            hold_actions,
-            timeout_ms: 250,
-            mode: MorseKeyMode::HoldOnOtherPress,
-            unilateral_tap: false,
+    pub fn get(&self, pattern: MorsePattern) -> Option<&Action> {
+        for pair in self.actions.iter() {
+            if pair.0 == pattern {
+                return Some(&pair.1);
+            }
         }
-    }
-
-    pub const fn new_modifier_tap_hold(tap_action: Action, modifier: ModifierCombination) -> Self {
-        let tap_actions = MorseActions::new_single(tap_action);
-        let hold_actions = MorseActions::new_single(Action::Modifier(modifier));
-        Self {
-            tap_actions,
-            hold_actions,
-            timeout_ms: 250,
-            mode: MorseKeyMode::HoldOnOtherPress,
-            unilateral_tap: false,
-        }
-    }
-
-    pub const fn new_hrm(tap_action: Action, modifier: ModifierCombination) -> Self {
-        let tap_actions = MorseActions::new_single(tap_action);
-        let hold_actions = MorseActions::new_single(Action::Modifier(modifier));
-        Self {
-            tap_actions,
-            hold_actions,
-            timeout_ms: 250,
-            mode: MorseKeyMode::PermissiveHold,
-            unilateral_tap: true,
-        }
-    }
-
-    pub fn new_tap_dance(tap_action: [Action; TAP_N], hold_action: [Action; TAP_N], timeout_ms: u16) -> Self {
-        let tap_actions = MorseActions::new(tap_action);
-        let hold_actions = MorseActions::new(hold_action);
-        Self {
-            tap_actions,
-            hold_actions,
-            timeout_ms,
-            mode: MorseKeyMode::HoldOnOtherPress,
-            unilateral_tap: false,
-        }
-    }
-
-    pub const fn new_tap_hold_with_config(
-        tap_action: Action,
-        hold_action: Action,
-        timeout_ms: u16,
-        mode: MorseKeyMode,
-        unilateral_tap: bool,
-    ) -> Self {
-        let tap_actions = MorseActions::new_single(tap_action);
-        let hold_actions = MorseActions::new_single(hold_action);
-        Self {
-            tap_actions,
-            hold_actions,
-            timeout_ms,
-            mode,
-            unilateral_tap,
-        }
-    }
-
-    // TODO: Remove the global setting
-    pub fn get_timeout(&self, global_timeout_time: u16) -> u16 {
-        if self.timeout_ms == 250 && global_timeout_time != 250 {
-            // Global setting overrides the default setting
-            global_timeout_time
-        } else {
-            self.timeout_ms
-        }
-    }
-
-    pub fn tap_action(&self, index: usize) -> Action {
-        *self.tap_actions.get(index).unwrap_or(&Action::No)
-    }
-
-    pub fn hold_action(&self, index: usize) -> Action {
-        *self.hold_actions.get(index).unwrap_or(&Action::No)
+        None
     }
 }
 
@@ -151,80 +114,4 @@ pub enum MorseKeyMode {
     PermissiveHold,
     /// Trigger hold immediately if any other non-morse key is pressed when the current morse key is held
     HoldOnOtherPress,
-}
-
-/// The list of actions for a morse key.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct MorseActions<const N: usize> {
-    /// The actions list, use `Action::No` to represent an empty slot
-    actions: [Action; N],
-    /// The number of saved actions
-    len: u8,
-}
-
-impl<const N: usize> Default for MorseActions<N> {
-    fn default() -> Self {
-        Self {
-            actions: [Action::No; N],
-            len: 0,
-        }
-    }
-}
-
-impl<const N: usize> MorseActions<N> {
-    pub fn empty() -> Self {
-        Self {
-            actions: [Action::No; N],
-            len: 0,
-        }
-    }
-
-    pub fn new(actions: [Action; N]) -> Self {
-        let mut len = 0;
-        for action in actions {
-            if action != Action::No {
-                len += 1;
-            }
-        }
-        Self { actions, len }
-    }
-
-    pub const fn new_from_list(actions: [Action; N], len: u8) -> Self {
-        Self { actions, len }
-    }
-
-    pub const fn new_single(action: Action) -> Self {
-        Self {
-            actions: [action; N],
-            len: 1,
-        }
-    }
-
-    pub fn push(&mut self, action: Action) {
-        if self.len < N as u8 {
-            // Find first empty slot
-            for i in 0..N {
-                if self.actions[i] == Action::No {
-                    self.actions[i] = action;
-                    self.len += 1;
-                    break;
-                }
-            }
-        } else {
-            warn!("MorseAction list is full");
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        self.len as usize
-    }
-
-    pub fn get(&self, index: usize) -> Option<&Action> {
-        self.actions.get(index)
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len == 0
-    }
 }

--- a/rmk/src/morse.rs
+++ b/rmk/src/morse.rs
@@ -24,6 +24,10 @@ impl MorsePattern {
         MorsePattern(value)
     }
 
+    pub fn to_u16(&self) -> u16 {
+        self.0
+    }
+
     pub fn is_empty(&self) -> bool {
         self.0 == 0b1
     }

--- a/rmk/src/morse.rs
+++ b/rmk/src/morse.rs
@@ -1,3 +1,5 @@
+use heapless::Vec;
+
 use crate::action::Action;
 
 /// a sequence of maximum 15 tap or hold can be encoded on an u16:
@@ -63,7 +65,7 @@ impl MorsePattern {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Morse<const N: usize> {
     /// The list of pattern -> action pairs, which can be triggered
-    pub(crate) actions: heapless::Vec<(MorsePattern, Action), N>,
+    pub(crate) actions: Vec<(MorsePattern, Action), N>,
 
     /// The timeout time for each operation in milliseconds
     pub timeout_ms: u16,
@@ -76,7 +78,7 @@ pub struct Morse<const N: usize> {
 impl<const N: usize> Default for Morse<N> {
     fn default() -> Self {
         Self {
-            actions: heapless::Vec::default(),
+            actions: Vec::default(),
             timeout_ms: 250,
             mode: MorseKeyMode::HoldOnOtherPress,
             unilateral_tap: false,

--- a/rmk/src/tap_dance.rs
+++ b/rmk/src/tap_dance.rs
@@ -1,58 +1,62 @@
-use heapless::Vec;
-
-use crate::TAP_DANCE_MAX_TAP;
 use crate::action::Action;
-use crate::morse::{Morse, MorseActions};
+use crate::morse::MorseKeyMode;
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TapDance(pub(crate) Morse<TAP_DANCE_MAX_TAP>);
+pub struct TapDance {
+    /// if more complex pattens are needed than these below, use `Morse` instead:
+    pub tap_action: Action,
+    pub hold_action: Action,
+    pub double_tap_action: Action,
+    pub hold_after_tap_action: Action,
+    /// The timeout time for each operation in milliseconds
+    pub timeout_ms: u16,
+    /// The decision mode of the morse key
+    pub mode: MorseKeyMode,
+    /// If the unilateral tap is enabled
+    pub unilateral_tap: bool,
+}
 
 impl Default for TapDance {
     fn default() -> Self {
-        Self(Morse {
-            tap_actions: MorseActions::empty(),
-            hold_actions: MorseActions::empty(),
+        Self {
+            tap_action: Action::No,
+            hold_action: Action::No,
+            double_tap_action: Action::No,
+            hold_after_tap_action: Action::No,
             timeout_ms: 200,
             mode: crate::morse::MorseKeyMode::HoldOnOtherPress,
             unilateral_tap: false,
-        })
+        }
     }
 }
 
 impl TapDance {
     pub fn new_from_vial(tap: Action, hold: Action, hold_after_tap: Action, double_tap: Action, timeout: u16) -> Self {
-        assert!(TAP_DANCE_MAX_TAP >= 2, "TAP_DANCE_MAX_TAP must be at least 2");
-        let mut tap_actions = [Action::No; TAP_DANCE_MAX_TAP];
-        let mut hold_actions = [Action::No; TAP_DANCE_MAX_TAP];
-        tap_actions[0] = tap;
-        tap_actions[1] = double_tap;
-        hold_actions[0] = hold;
-        hold_actions[1] = hold_after_tap;
-        Self(Morse::new_tap_dance(tap_actions, hold_actions, timeout))
-    }
-
-    /// Create a new tap dance with custom actions for each tap count
-    /// This allows for more flexible tap dance configurations
-    pub fn new_with_actions(
-        tap_actions: Vec<Action, TAP_DANCE_MAX_TAP>,
-        hold_actions: Vec<Action, TAP_DANCE_MAX_TAP>,
-        timeout: u16,
-    ) -> Self {
-        assert!(TAP_DANCE_MAX_TAP >= 2, "TAP_DANCE_MAX_TAP must be at least 2");
-        let mut tap_actions_slice = [Action::No; TAP_DANCE_MAX_TAP];
-        let mut hold_actions_slice = [Action::No; TAP_DANCE_MAX_TAP];
-        for (i, item) in tap_actions.iter().enumerate() {
-            tap_actions_slice[i] = *item;
+        Self {
+            tap_action: tap,
+            hold_action: hold,
+            double_tap_action: double_tap,
+            hold_after_tap_action: hold_after_tap,
+            timeout_ms: timeout,
+            mode: crate::morse::MorseKeyMode::HoldOnOtherPress,
+            unilateral_tap: false,
         }
-        for (i, item) in hold_actions.iter().enumerate() {
-            hold_actions_slice[i] = *item;
-        }
-        Self(Morse::new_tap_dance(tap_actions_slice, hold_actions_slice, timeout))
     }
 
     /// Check if this tap dance has any actions defined
     pub fn has_actions(&self) -> bool {
-        !self.0.tap_actions.is_empty() || !self.0.hold_actions.is_empty()
+        self.tap_action != Action::No
+            || self.hold_action != Action::No
+            || self.double_tap_action != Action::No
+            || self.hold_after_tap_action != Action::No
+    }
+
+    pub fn max_pattern_length(&self) -> usize {
+        if self.double_tap_action != Action::No || self.hold_after_tap_action != Action::No {
+            2
+        } else {
+            1
+        }
     }
 }

--- a/rmk/src/via/keycode_convert.rs
+++ b/rmk/src/via/keycode_convert.rs
@@ -2,7 +2,6 @@ use num_enum::FromPrimitive;
 
 use crate::action::{Action, KeyAction};
 use crate::keycode::{KeyCode, ModifierCombination};
-use crate::morse::Morse;
 
 pub(crate) fn to_via_keycode(key_action: KeyAction) -> u16 {
     match key_action {
@@ -52,27 +51,30 @@ pub(crate) fn to_via_keycode(key_action: KeyAction) -> u16 {
             warn!("Tap action is not supported by via");
             0
         }
-        KeyAction::Morse(m) => {
-            if m.tap_actions.len() == 1 && m.hold_actions.len() == m.tap_actions.len() {
-                // It a tap-hold behavior
-                let tap_code = match m.tap_action(0) {
-                    Action::Key(key_code) => key_code as u16,
+        KeyAction::TapHold(tap, hold) => match hold {
+            Action::LayerOn(l) => {
+                if l > 16 {
+                    0
+                } else {
+                    let keycode = match tap {
+                        Action::Key(k) => k as u16,
+                        _ => 0,
+                    };
+                    0x4000 | ((l as u16) << 8) | keycode
+                }
+            }
+            Action::Modifier(m) => {
+                let keycode = match tap {
+                    Action::Key(k) => k as u16,
                     _ => 0,
                 };
-                match m.hold_action(0) {
-                    Action::Modifier(m) => 0x2000 | ((m.into_bits() as u16) << 8) | tap_code,
-                    Action::LayerOn(l) => {
-                        if l > 16 {
-                            0
-                        } else {
-                            0x4000 | ((l as u16) << 8) | tap_code
-                        }
-                    }
-                    _ => 0,
-                }
-            } else {
-                0
+                0x2000 | ((m.into_bits() as u16) << 8) | keycode
             }
+            _ => 0x0000,
+        },
+        KeyAction::Morse(_) => {
+            warn!("Morse is not supported by via");
+            0
         }
         KeyAction::TapDance(index) => {
             // Tap dance keycodes: 0x5700..=0x57FF
@@ -99,18 +101,14 @@ pub(crate) fn from_via_keycode(via_keycode: u16) -> KeyAction {
             // HRMs is in permissive hold mode, while other modifier tap-hold is in hold on other key press mode
             let keycode = KeyCode::from_primitive(via_keycode & 0x00FF);
             let modifier = ModifierCombination::from_bits(((via_keycode >> 8) & 0b11111) as u8);
-            if keycode.is_home_row() {
-                KeyAction::Morse(Morse::new_hrm(Action::Key(keycode), modifier))
-            } else {
-                KeyAction::Morse(Morse::new_modifier_tap_hold(Action::Key(keycode), modifier))
-            }
+            KeyAction::TapHold(Action::Key(keycode), Action::Modifier(modifier))
         }
         0x4000..=0x4FFF => {
             // Layer tap-hold.
             // Layer tap-hold is in hold on other key press mode by default
             let layer = (via_keycode >> 8) & 0xF;
             let keycode = KeyCode::from_primitive(via_keycode & 0x00FF);
-            KeyAction::Morse(Morse::new_layer_tap_hold(Action::Key(keycode), layer as u8))
+            KeyAction::TapHold(Action::Key(keycode), Action::LayerOn(layer as u8))
         }
         0x5200..=0x521F => {
             // Activate layer X and deactivate other layers(except default layer)
@@ -502,54 +500,54 @@ mod test {
         // LT0(A) -> LayerTapHold(A, 0)
         let via_keycode = 0x4004;
         assert_eq!(
-            KeyAction::Morse(Morse::new_layer_tap_hold(Action::Key(KeyCode::A), 0)),
+            KeyAction::TapHold(Action::Key(KeyCode::A), Action::LayerOn(0)),
             from_via_keycode(via_keycode)
         );
 
         // LT3(A) -> LayerTapHold(A, 3)
         let via_keycode = 0x4304;
         assert_eq!(
-            KeyAction::Morse(Morse::new_layer_tap_hold(Action::Key(KeyCode::A), 3)),
+            KeyAction::TapHold(Action::Key(KeyCode::A), Action::LayerOn(3)),
             from_via_keycode(via_keycode)
         );
 
         // LSA_T(A) ->
         let via_keycode = 0x2604;
         assert_eq!(
-            KeyAction::Morse(Morse::new_hrm(
+            KeyAction::TapHold(
                 Action::Key(KeyCode::A),
-                ModifierCombination::new_from(false, false, true, true, false)
-            )),
+                Action::Modifier(ModifierCombination::new_from(false, false, true, true, false))
+            ), //hrm
             from_via_keycode(via_keycode)
         );
 
         // RCAG_T(B) ->
         let via_keycode = 0x3D05;
         assert_eq!(
-            KeyAction::Morse(Morse::new_modifier_tap_hold(
+            KeyAction::TapHold(
                 Action::Key(KeyCode::B),
-                ModifierCombination::new_from(true, true, true, false, true)
-            )),
+                Action::Modifier(ModifierCombination::new_from(true, true, true, false, true))
+            ),
             from_via_keycode(via_keycode)
         );
 
         // ALL_T(A) ->
         let via_keycode: u16 = 0x2F04;
         assert_eq!(
-            KeyAction::Morse(Morse::new_hrm(
+            KeyAction::TapHold(
                 Action::Key(KeyCode::A),
-                ModifierCombination::new_from(false, true, true, true, true)
-            )),
+                Action::Modifier(ModifierCombination::new_from(false, true, true, true, true))
+            ), //hrm
             from_via_keycode(via_keycode)
         );
 
         // Meh_T(B) ->
         let via_keycode = 0x2705;
         assert_eq!(
-            KeyAction::Morse(Morse::new_modifier_tap_hold(
+            KeyAction::TapHold(
                 Action::Key(KeyCode::B),
-                ModifierCombination::new_from(false, false, true, true, true)
-            )),
+                Action::Modifier(ModifierCombination::new_from(false, false, true, true, true))
+            ),
             from_via_keycode(via_keycode)
         );
 
@@ -640,39 +638,39 @@ mod test {
         assert_eq!(0xF04, to_via_keycode(a));
 
         // LT0(A) -> LayerTapHold(A, 0)
-        let a = KeyAction::Morse(Morse::new_layer_tap_hold(Action::Key(KeyCode::A), 0));
+        let a = KeyAction::TapHold(Action::Key(KeyCode::A), Action::LayerOn(0));
         assert_eq!(0x4004, to_via_keycode(a));
 
         // LT3(A) -> LayerTapHold(A, 3)
-        let a = KeyAction::Morse(Morse::new_layer_tap_hold(Action::Key(KeyCode::A), 3));
+        let a = KeyAction::TapHold(Action::Key(KeyCode::A), Action::LayerOn(3));
         assert_eq!(0x4304, to_via_keycode(a));
 
         // LSA_T(A) ->
-        let a = KeyAction::Morse(Morse::new_modifier_tap_hold(
+        let a = KeyAction::TapHold(
             Action::Key(KeyCode::A),
-            ModifierCombination::new_from(false, false, true, true, false),
-        ));
+            Action::Modifier(ModifierCombination::new_from(false, false, true, true, false)),
+        );
         assert_eq!(0x2604, to_via_keycode(a));
 
         // RCAG_T(A) ->
-        let a = KeyAction::Morse(Morse::new_modifier_tap_hold(
+        let a = KeyAction::TapHold(
             Action::Key(KeyCode::A),
-            ModifierCombination::new_from(true, true, true, false, true),
-        ));
+            Action::Modifier(ModifierCombination::new_from(true, true, true, false, true)),
+        );
         assert_eq!(0x3D04, to_via_keycode(a));
 
         // ALL_T(A) ->
-        let a = KeyAction::Morse(Morse::new_modifier_tap_hold(
+        let a = KeyAction::TapHold(
             Action::Key(KeyCode::A),
-            ModifierCombination::new_from(false, true, true, true, true),
-        ));
+            Action::Modifier(ModifierCombination::new_from(false, true, true, true, true)),
+        );
         assert_eq!(0x2F04, to_via_keycode(a));
 
         // Meh_T(A) ->
-        let a = KeyAction::Morse(Morse::new_modifier_tap_hold(
+        let a = KeyAction::TapHold(
             Action::Key(KeyCode::A),
-            ModifierCombination::new_from(false, false, true, true, true),
-        ));
+            Action::Modifier(ModifierCombination::new_from(false, false, true, true, true)),
+        );
         assert_eq!(0x2704, to_via_keycode(a));
 
         // ComboOff

--- a/rmk/src/via/vial.rs
+++ b/rmk/src/via/vial.rs
@@ -175,21 +175,21 @@ pub(crate) async fn process_vial<
                         // Pack tap dance data into report
                         LittleEndian::write_u16(
                             &mut report.input_data[1..3],
-                            to_via_keycode(KeyAction::Single(tap_dance.0.tap_action(0))),
+                            to_via_keycode(KeyAction::Single(tap_dance.tap_action)),
                         );
                         LittleEndian::write_u16(
                             &mut report.input_data[3..5],
-                            to_via_keycode(KeyAction::Single(tap_dance.0.hold_action(0))),
+                            to_via_keycode(KeyAction::Single(tap_dance.hold_action)),
                         );
                         LittleEndian::write_u16(
                             &mut report.input_data[5..7],
-                            to_via_keycode(KeyAction::Single(tap_dance.0.tap_action(1))),
+                            to_via_keycode(KeyAction::Single(tap_dance.double_tap_action)),
                         );
                         LittleEndian::write_u16(
                             &mut report.input_data[7..9],
-                            to_via_keycode(KeyAction::Single(tap_dance.0.hold_action(1))),
+                            to_via_keycode(KeyAction::Single(tap_dance.hold_after_tap_action)),
                         );
-                        LittleEndian::write_u16(&mut report.input_data[9..11], tap_dance.0.timeout_ms);
+                        LittleEndian::write_u16(&mut report.input_data[9..11], tap_dance.timeout_ms);
                     } else {
                         report.input_data[1..11].fill(0);
                     }

--- a/rmk/tests/common/morse.rs
+++ b/rmk/tests/common/morse.rs
@@ -1,4 +1,3 @@
-use rmk::action::KeyAction;
 use rmk::config::BehaviorConfig;
 use rmk::keyboard::Keyboard;
 use rmk::keycode::ModifierCombination;
@@ -7,7 +6,7 @@ use rmk::{k, lt, mt};
 use crate::common::wrap_keymap;
 
 pub fn create_simple_morse_keyboard(behavior_config: BehaviorConfig) -> Keyboard<'static, 1, 4, 2> {
-    let mut keymap = [
+    let keymap = [
         [[
             k!(A),
             mt!(B, ModifierCombination::SHIFT),
@@ -16,20 +15,6 @@ pub fn create_simple_morse_keyboard(behavior_config: BehaviorConfig) -> Keyboard
         ]],
         [[k!(Kp1), k!(Kp2), k!(Kp3), k!(Kp4)]],
     ];
-
-    // Update all keys according to behavior config
-    for layer in keymap.iter_mut() {
-        for row in layer {
-            for key in row {
-                if let KeyAction::Morse(morse) = key {
-                    if behavior_config.morse.unilateral_tap {
-                        morse.unilateral_tap = true;
-                    }
-                    morse.mode = behavior_config.morse.mode;
-                }
-            }
-        }
-    }
 
     Keyboard::new(wrap_keymap(keymap, behavior_config))
 }

--- a/rmk/tests/keyboard_morse_hold_on_other_press_test.rs
+++ b/rmk/tests/keyboard_morse_hold_on_other_press_test.rs
@@ -7,7 +7,7 @@ use rmk::config::{BehaviorConfig, CombosConfig, MorseConfig};
 use rmk::k;
 use rmk::keyboard::Keyboard;
 use rmk::keycode::{KeyCode, ModifierCombination};
-use rmk::morse::{Morse, MorseKeyMode};
+use rmk::morse::MorseKeyMode;
 use rusty_fork::rusty_fork_test;
 
 use crate::common::morse::create_simple_morse_keyboard;
@@ -26,27 +26,9 @@ fn create_hold_on_other_key_press_keyboard() -> Keyboard<'static, 1, 4, 2> {
 }
 
 fn create_hold_on_other_key_press_keyboard_with_combo() -> Keyboard<'static, 1, 4, 2> {
-    let combo_key = KeyAction::Morse(Morse::new_tap_hold_with_config(
-        Action::Key(KeyCode::B),
-        Action::Modifier(ModifierCombination::SHIFT),
-        250,
-        MorseKeyMode::HoldOnOtherPress,
-        false,
-    ));
-    let combo_key_2 = KeyAction::Morse(Morse::new_tap_hold_with_config(
-        Action::Key(KeyCode::C),
-        Action::Modifier(ModifierCombination::GUI),
-        250,
-        MorseKeyMode::HoldOnOtherPress,
-        false,
-    ));
-    let combo_key_3 = KeyAction::Morse(Morse::new_tap_hold_with_config(
-        Action::Key(KeyCode::D),
-        Action::LayerOn(1),
-        250,
-        MorseKeyMode::HoldOnOtherPress,
-        false,
-    ));
+    let combo_key = KeyAction::TapHold(Action::Key(KeyCode::B), Action::Modifier(ModifierCombination::SHIFT)); //TODO MorseKeyMode::HoldOnOtherPress, false
+    let combo_key_2 = KeyAction::TapHold(Action::Key(KeyCode::C), Action::Modifier(ModifierCombination::GUI)); //TODO MorseKeyMode::HoldOnOtherPress, false
+    let combo_key_3 = KeyAction::TapHold(Action::Key(KeyCode::D), Action::LayerOn(1)); //TODO MorseKeyMode::HoldOnOtherPress, false
     create_simple_morse_keyboard(BehaviorConfig {
         morse: MorseConfig {
             enable_hrm: false,

--- a/rmk/tests/keyboard_morse_hrm_test.rs
+++ b/rmk/tests/keyboard_morse_hrm_test.rs
@@ -10,7 +10,7 @@ use rmk::config::{BehaviorConfig, CombosConfig, MorseConfig};
 use rmk::k;
 use rmk::keyboard::Keyboard;
 use rmk::keycode::{KeyCode, ModifierCombination};
-use rmk::morse::{Morse, MorseKeyMode};
+use rmk::morse::MorseKeyMode;
 use rusty_fork::rusty_fork_test;
 
 use crate::common::morse::create_simple_morse_keyboard;
@@ -29,15 +29,10 @@ fn create_hrm_keyboard() -> Keyboard<'static, 1, 4, 2> {
 }
 
 fn create_hrm_keyboard_with_combo() -> Keyboard<'static, 1, 4, 2> {
-    let combo_key = KeyAction::Morse(Morse::new_hrm(Action::Key(KeyCode::B), ModifierCombination::SHIFT));
-    let combo_key_2 = KeyAction::Morse(Morse::new_hrm(Action::Key(KeyCode::C), ModifierCombination::GUI));
-    let combo_key_3 = KeyAction::Morse(Morse::new_tap_hold_with_config(
-        Action::Key(KeyCode::D),
-        Action::LayerOn(1),
-        250,
-        MorseKeyMode::PermissiveHold,
-        true,
-    ));
+    let combo_key = KeyAction::TapHold(Action::Key(KeyCode::B), Action::Modifier(ModifierCombination::SHIFT)); //TODO hrm = MorseKeyMode::PermissiveHold, true
+    let combo_key_2 = KeyAction::TapHold(Action::Key(KeyCode::C), Action::Modifier(ModifierCombination::GUI)); //TODO hrm = MorseKeyMode::PermissiveHold, true
+    let combo_key_3 = KeyAction::TapHold(Action::Key(KeyCode::D), Action::LayerOn(1)); //TODO hrm = MorseKeyMode::PermissiveHold, true
+
     create_simple_morse_keyboard(BehaviorConfig {
         morse: MorseConfig {
             enable_hrm: true,

--- a/rmk/tests/keyboard_morse_permissive_hold_test.rs
+++ b/rmk/tests/keyboard_morse_permissive_hold_test.rs
@@ -7,7 +7,7 @@ use rmk::config::{BehaviorConfig, CombosConfig, MorseConfig};
 use rmk::k;
 use rmk::keyboard::Keyboard;
 use rmk::keycode::{KeyCode, ModifierCombination};
-use rmk::morse::{Morse, MorseKeyMode};
+use rmk::morse::MorseKeyMode;
 use rusty_fork::rusty_fork_test;
 
 use crate::common::morse::create_simple_morse_keyboard;
@@ -26,27 +26,9 @@ fn create_permissive_hold_keyboard() -> Keyboard<'static, 1, 4, 2> {
 }
 
 fn create_permissive_hold_keyboard_with_combo() -> Keyboard<'static, 1, 4, 2> {
-    let combo_key = KeyAction::Morse(Morse::new_tap_hold_with_config(
-        Action::Key(KeyCode::B),
-        Action::Modifier(ModifierCombination::SHIFT),
-        250,
-        MorseKeyMode::PermissiveHold,
-        false,
-    ));
-    let combo_key_2 = KeyAction::Morse(Morse::new_tap_hold_with_config(
-        Action::Key(KeyCode::C),
-        Action::Modifier(ModifierCombination::GUI),
-        250,
-        MorseKeyMode::PermissiveHold,
-        false,
-    ));
-    let combo_key_3 = KeyAction::Morse(Morse::new_tap_hold_with_config(
-        Action::Key(KeyCode::D),
-        Action::LayerOn(1),
-        250,
-        MorseKeyMode::PermissiveHold,
-        false,
-    ));
+    let combo_key = KeyAction::TapHold(Action::Key(KeyCode::B), Action::Modifier(ModifierCombination::SHIFT)); //TODO MorseKeyMode::PermissiveHold, false    
+    let combo_key_2 = KeyAction::TapHold(Action::Key(KeyCode::C), Action::Modifier(ModifierCombination::GUI)); //TODO MorseKeyMode::PermissiveHold, false    
+    let combo_key_3 = KeyAction::TapHold(Action::Key(KeyCode::D), Action::LayerOn(1)); //TODO MorseKeyMode::PermissiveHold, false
     create_simple_morse_keyboard(BehaviorConfig {
         morse: MorseConfig {
             enable_hrm: false,

--- a/rmk/tests/keyboard_morse_tap_dance_test.rs
+++ b/rmk/tests/keyboard_morse_tap_dance_test.rs
@@ -248,14 +248,35 @@ rusty_fork_test! {
                 [0, 0, true, 150], // Press td!(0)
                 [0, 0, false, 10], // Release td!(0)
                 [0, 0, true, 150], // Press td!(0)
-                [0, 1, true, 260], // Press td!(1) -> td!(0) timeout
-                [0, 0, false, 260], // Release td!(0) -> td!(1) timeout
+                [0, 1, true, 260], // Press td!(1) -> td!(0) timeout: tap-hold
+                [0, 0, false, 260], // Release td!(0) -> td!(1) hold, waiting for longer pattern
                 [0, 1, false, 10], // Release td!(1)
             ],
             expected_reports: [
                 [0, [kc_to_u8!(C), 0, 0, 0, 0, 0]],
+                [0, [0, 0, 0, 0, 0, 0]],//changed because td!(1) waiting for possible longer patten
+                [0, [kc_to_u8!(Y), 0, 0, 0, 0, 0]],
+                [0, [0, 0, 0, 0, 0, 0]],
+            ]
+        };
+    }
+
+    #[test]
+    fn test_rolling_3() {
+        key_sequence_test! {
+            keyboard: create_tap_dance_test_keyboard(),
+            sequence: [
+                [0, 0, true, 150], // Press td!(0)
+                [0, 0, false, 10], // Release td!(0)
+                [0, 0, true, 150], // Press td!(0)
+                [0, 1, true, 260], // Press td!(1) -> td!(0) timeout (tap-hold)
+                [0, 1, false, 260], // Release td!(1)
+                [0, 0, false, 260], // Release td!(0) -> td!(1) timeout (hold)
+            ],
+            expected_reports: [
+                [0, [kc_to_u8!(C), 0, 0, 0, 0, 0]],
                 [0, [kc_to_u8!(C), kc_to_u8!(Y), 0, 0, 0, 0]],
-                [0, [0, kc_to_u8!(Y), 0, 0, 0, 0]],
+                [0, [kc_to_u8!(C), 0, 0, 0, 0, 0]],
                 [0, [0, 0, 0, 0, 0, 0]],
             ]
         };
@@ -313,8 +334,8 @@ rusty_fork_test! {
                 [0, 0, false, 10], // Release td!(0)
                 [0, 0, true, 150], // Press td!(0)
                 [0, 1, true, 10], // Press td!(1) -> Trigger hold-after-tap of td!(0)
-                [0, 1, false, 310], // Release td!(1) -> td!(1) Timeout!
-                [0, 0, false, 10], // Release td!(0)
+                [0, 1, false, 310], // Release td!(1) -> hold
+                [0, 0, false, 260], // td!(1) Timeout after release, Release td!(0)
             ],
             expected_reports: [
                 [0, [kc_to_u8!(C), 0, 0, 0, 0, 0]],

--- a/rmk/tests/keyboard_morse_test.rs
+++ b/rmk/tests/keyboard_morse_test.rs
@@ -6,7 +6,6 @@ use rmk::combo::Combo;
 use rmk::config::{BehaviorConfig, CombosConfig};
 use rmk::k;
 use rmk::keycode::{KeyCode, ModifierCombination};
-use rmk::morse::Morse;
 use rusty_fork::rusty_fork_test;
 
 use crate::common::morse::create_simple_morse_keyboard;
@@ -729,7 +728,8 @@ rusty_fork_test! {
                     combo: CombosConfig {
                         combos: heapless::Vec::from_iter([
                             Combo::new(
-                                [KeyAction::Morse(Morse::new_tap_hold(Action::Key(KeyCode::B), Action::Modifier(ModifierCombination::SHIFT))), KeyAction::Morse(Morse::new_tap_hold(Action::Key(KeyCode::C), Action::Modifier(ModifierCombination::GUI)))],
+                                [KeyAction::TapHold(Action::Key(KeyCode::B), Action::Modifier(ModifierCombination::SHIFT)),
+                                 KeyAction::TapHold(Action::Key(KeyCode::C), Action::Modifier(ModifierCombination::GUI))],
                                 k!(X),
                                 None,
                             )
@@ -760,7 +760,8 @@ rusty_fork_test! {
                     combo: CombosConfig {
                         combos: heapless::Vec::from_iter([
                             Combo::new(
-                                [KeyAction::Morse(Morse::new_tap_hold(Action::Key(KeyCode::B), Action::Modifier(ModifierCombination::SHIFT))), KeyAction::Morse(Morse::new_tap_hold(Action::Key(KeyCode::C), Action::Modifier(ModifierCombination::GUI)))],
+                                [KeyAction::TapHold(Action::Key(KeyCode::B), Action::Modifier(ModifierCombination::SHIFT)),
+                                 KeyAction::TapHold(Action::Key(KeyCode::C), Action::Modifier(ModifierCombination::GUI))],
                                 k!(X),
                                 None,
                             )


### PR DESCRIPTION
Ability to handle real morse codes

The tap_hold, tap_dance kept unchanged in the config to be recognizable by forks, non-positional combos, etc.
Morse configs can be indexed the same way as tap dances, but they do not have vial support.

Remaining work:
Config from keyboard.toml, add some unit tests

Example:
(".", E) //tap
("-", T) //hold
("..", I) //double tap
(".-", A) //tap hold
("-...", B) //hold tap tap tap

