### PR TITLE
Rename `TapDance` to `Morse`

### DIFF
--- a/docs/en/docs/features/configuration/appendix.md
+++ b/docs/en/docs/features/configuration/appendix.md
@@ -130,15 +130,15 @@ operations = [
     { operation = "text", text = "Hello" }
 ]
 
-[behavior.tap_dance]
-tap_dances = [
+[behavior.morse]
+morses = [
   # TD(0) Function key that outputs F1 on tap, F2 on double tap, layer 1 on hold
   { tap = "F1", hold = "MO(1)", double_tap = "F2" },
 
-  # TD(1) Extended tap dance for function keys  
+  # TD(1) Extended tap dance representation for function keys  
   { tap_actions = ["F1", "F2", "F3", "F4", "F5"], hold_actions = ["MO(1)", "MO(2)", "MO(3)", "MO(4)", "MO(5)"], timeout = "300ms" }
 
-  # TD(2) Morse like tap dance
+  # TD(2) Morse code like representation
   { timeout = "300ms", morse_actions = [
       {pattern = ".-", action = "A"}, 
       {pattern = "-...", action = "B"}, 
@@ -238,10 +238,10 @@ combo_max_num = 8
 combo_max_length = 4
 # Maximum number of forks for conditional key actions
 fork_max_num = 8
-# Maximum number of tap dances keyboard can store (max 256)
-# (Each tap dance is a programmable multi-tap/hold key)
-tap_dance_max_num = 8
-# Maximum number of patterns a tap dance key can handle
+# Maximum number of morse keys keyboard can store (max 256)
+# (Each morse key is a programmable multi-tap/hold key)
+morse_max_num = 8
+# Maximum number of patterns a morse key can handle
 max_patterns_per_key = 36
 # Macro space size in bytes for storing sequences
 macro_space_size = 256

--- a/docs/en/docs/features/configuration/behavior.md
+++ b/docs/en/docs/features/configuration/behavior.md
@@ -147,10 +147,10 @@ RMK provides three methods for defining a Morse key.
 
 This method is fully compatible with Vial's Tap Dance, it defines four specific actions:
 
-1 `tap`: The action to be triggered on the first tap within the tapping term. This is the default action when the key is tapped once.
-2 `hold`: The action to be triggered when the key is held down (not tapped) beyond the tapping term.
-3 `hold_after_tap`: The action to be triggered when the key is held down after being tapped once.
-4 `double_tap`: The action to be triggered when the key is tapped twice within the tapping term.
+1. `tap`: The action to be triggered on the first tap. This is the default action when the key is tapped once.
+2. `hold`: The action to be triggered when the key is held down (not tapped) beyond the tapping term.
+3. `hold_after_tap`: The action to be triggered when the key is held down after being tapped once.
+4. `double_tap`: The action to be triggered when the key is tapped twice within the tapping term.
 
 Example:
 
@@ -166,8 +166,8 @@ morses = [
 
 This is an extended version of tap dance. It allows you to define sequences of actions for multiple taps and for holds that occur after a specific number of taps.
 
-- `tap_actions`: An array of actions triggered by sequential taps. Each tap within the tapping term increments the tap count and triggers the corresponding action from the `tap_actions` array. For example, `tap_actions = ["F1", "F2", "F3"]` means a single tap triggers "F1", double tap triggers "F2", triple tap triggers "F3", and so on. Tapping 5 times will trigger the 5th item in the `tap_actions` (`tap_actions[4]`). If the tap count exceeds the length of the array, the last action is used.
-- `hold_actions`: An array of actions triggered when the key is held *after* a certain number of taps. When a key is held after multiple taps, the corresponding action from the `hold_actions` array is triggered. For example, `hold_actions = ["MO(1)", "MO(2)", "MO(3)"]` means holding after one tap triggers "MO(1)", holding after two taps triggers "MO(2)", and so on. Holding the key after tapping 5 times will trigger 6th item in the `hold_actions` list (`hold_actions[5]`).
+- `tap_actions`: An array of actions triggered by sequential taps. Each tap within the tapping term increments the tap count and triggers the corresponding action from the `tap_actions` array. For example, `tap_actions = ["F1", "F2", "F3"]` means a single tap triggers "F1", double tap triggers "F2", triple tap triggers "F3", and so on. If the tap count exceeds the length of the array, the last action is used.
+- `hold_actions`: An array of actions triggered when the key is held *after* a certain number of taps. When a key is held after multiple taps, the corresponding action from the `hold_actions` array is triggered. For example, `hold_actions = ["MO(1)", "MO(2)", "MO(3)"]` means holding after one tap triggers "MO(1)", holding after two taps triggers "MO(2)", and so on.
 
 Example:
 

--- a/docs/en/docs/features/configuration/behavior.md
+++ b/docs/en/docs/features/configuration/behavior.md
@@ -123,55 +123,103 @@ operations = [
 ]
 ```
 
-## Tap Dance
+## Morse(Tap Dance)
 
-In the `tap_dance` sub-table, you can configure the keyboard's tap dance functionality. Tap dance allows you to define different actions based on the number of times a key is tapped within a specific time window.
+In the `morse` sub-table, you can configure the keyboard's morse functionality. Morse is a superset of well-known [tap dance](https://docs.qmk.fm/features/tap_dance), which allows you to define different actions based on the different combinations of taps and holds within a specific time window.
 
-The basic tap dance(with 2 taps) works as follows:
+You can define a list of morse keys as the following: 
 
-1. **Single Tap**: When a key is pressed and released within the tapping term, the `tap` action is triggered.
-2. **Hold**: When a key is pressed and held beyond the tapping term, the `hold` action is triggered.
-3. **Hold After Tap**: When a key is tapped once and then held down, the `hold_after_tap` action is triggered.
-4. **Double Tap**: When a key is tapped twice within the tapping term, the `double_tap` action is triggered.
+```toml
+[behavior.morse]
+morses = [
+  ... # Morse keys
+]
+```
 
-In RMK, tap dance behavior also supports multiple taps and hold-after-multiple-taps:
+There are three ways to define a morse key in RMK:
 
-- **Multiple Taps**: Each tap within the tapping term increments the tap count and triggers the corresponding action from the `tap_actions` array, for example, tapping 5 times will trigger the 5th item in the `tap_actions` (`tap_actions[4]`).
-- **Hold After Multiple Taps**: When a key is held after multiple taps, the corresponding action from the `hold_actions` array is triggered, for example, hold the key after tapping 5 times will trigger 6th item in the `hold_actions` list (`hold_actions[5]`).
+### Define a morse key
 
-In RMK, tap dance behavior also supports morse code like patterns:
+#### 1. Define the vial-like tap dance:
 
-- **Morse code**: Each tap/hold within the tapping term registered in a pattern, then the corresponding action looked up in the `morse_actions` array.
+This type is fully compatible with TapDance in Vial, only four actions are defined:
 
-Tap dance configuration includes the following parameters:
+1 `tap`: The action to be triggered on the first tap within the tapping term. This is the default action when the key is tapped once.
+2 `hold`: The action to be triggered when the key is held down (not tapped) beyond the tapping term.
+3 `hold_after_tap`: The action to be triggered when the key is held down after being tapped once.
+4 `double_tap`: The action to be triggered when the key is tapped twice within the tapping term.
 
-- `tap_dances`: An array containing all defined tap dances. Each tap dance configuration is an object containing the following attributes:
-  - `tap`: The action to be triggered on the first tap. This is the default action when the key is tapped once.
-  - `hold`: The action to be triggered when the key is held down (not tapped).
-  - `hold_after_tap`: The action to be triggered when the key is held down after being tapped once.
-  - `double_tap`: The action to be triggered when the key is tapped twice within the tapping term.
-  - `timeout`: The time window (in milliseconds or seconds) within which taps are considered part of the same tap dance sequence. Defaults to 200ms if not specified.
-  - `tap_actions`: An array of actions, each corresponding to the number of taps. For example, `tap_actions = ["F1", "F2", "F3"]` means a single tap triggers "F1", double tap triggers "F2", triple tap triggers "F3", and so on. If the tap count exceeds the length of the array, the last action is used.
-  - `hold_actions`: An array of actions, each corresponding to holding the key after a certain number of taps. For example, `hold_actions = ["MO(1)", "MO(2)", "MO(3)"]` means holding after one tap triggers "MO(1)", holding after two taps triggers "MO(2)", and so on. If the tap count exceeds the length of the array, the last action is used.
-  - `morse_actions`: list of patten -> action pairs. The pattern is a tap/hold sequence, its length is limited in 15. The morse pattern of `C` for example can be described like this: `"-.-."` or `"_._."` or `"1010"`. See the examples below!
+The following is an example:
+
+```toml
+[behavior.morse]
+morses = [
+  # A vial-like tap dance
+  { tap = "F1", hold = "MO(1)", hold_after_tap = "MO(2)", double_tap = "F2" }
+]
+```
+
+#### 2. Define taps and hold-after-tap actions
+
+This is a slightly extended version of tap dance, you can define multiple taps(just like tap dance) in `tap_actions`, and you can also define a `hold_actions` list which represents hold-after-multiple-taps:
+
+- `tap_actions`: Each tap within the tapping term increments the tap count and triggers the corresponding action from the `tap_actions` array. For example, `tap_actions = ["F1", "F2", "F3"]` means a single tap triggers "F1", double tap triggers "F2", triple tap triggers "F3", and so on. Tapping 5 times will trigger the 5th item in the `tap_actions` (`tap_actions[4]`). If the tap count exceeds the length of the array, the last action is used.
+- `hold_actions`: When a key is held after multiple taps, the corresponding action from the `hold_actions` array is triggered. For example, `hold_actions = ["MO(1)", "MO(2)", "MO(3)"]` means holding after one tap triggers "MO(1)", holding after two taps triggers "MO(2)", and so on. Holding the key after tapping 5 times will trigger 6th item in the `hold_actions` list (`hold_actions[5]`).
+
+The following is an example:
+
+```toml
+[behavior.morse]
+morses = [
+  # A taps & hold-after-tap morse key
+  { tap_actions = ["F1", "F2", "F3", "F4", "F5"], hold_actions = ["MO(1)", "MO(2)", "MO(3)", "MO(4)", "MO(5)"] }
+]
+```
+
+#### 3. Define the full-morse behavior
+
+This is the most powerful way, you can just define a morse code like patterns, use a single key to represent many many actions, just like [morse code](https://en.wikipedia.org/wiki/Morse_code).
+
+- `morse_actions`: list of patten -> action pairs. The pattern is a tap/hold sequence, its length is limited in 15. For example, the morse pattern of `C` can be described like this: `"-.-."` or `"_._."` or `"1010"`.
+
+The following is an example:
+
+```toml
+[behavior.morse]
+morses = [
+  # A morse key defined using morse_actions
+  { morse_actions = [
+        { pattern = ".-", action = "A" },
+        { pattern = "-...", action = "B" },
+        { pattern = "-.-.", action = "C" },
+        { pattern = "-..", action = "D" },
+    ] },
+]
+```
+
+### Common configuration for morse keys
+
+This is also common configurations for both three representations of morse keys:
+
+  - `timeout`: The time window (in milliseconds or seconds) within which taps are considered part of the same morse sequence. Defaults to 200ms if not specified.
 
 ::: warning
 
-`morse_actions` cannot be used together with `tap_actions` and `hold_actions` and they also cannot be used together with `tap`, `hold`, `hold_after_tap`, or `double_tap`. For each tap dance configuration, please choose either the morse style (`morse_actions`) or array style (`tap_actions`/`hold_actions`) or the individual fields (`tap`/`hold`/`hold_after_tap`/`double_tap`).
+`morse_actions` cannot be used together with `tap_actions` and `hold_actions` and they also cannot be used together with `tap`, `hold`, `hold_after_tap`, or `double_tap`. For each morse configuration, please choose either the morse style (`morse_actions`) or array style (`tap_actions`/`hold_actions`) or the individual fields (`tap`/`hold`/`hold_after_tap`/`double_tap`).
 
 :::
 
-Here is an example of tap dance configuration:
+Here is a composite example of morse configuration:
 
 ```toml
 [rmk]
-# Maximum number of tap dances keyboard can store (max 256)
-tap_dance_max_num = 9
-# Maximum number of patterns a tap dance key can handle
+# Maximum number of morses keyboard can store (max 256)
+morse_max_num = 9
+# Maximum number of patterns a morse key can handle
 max_patterns_per_key = 36
 
-[behavior.tap_dance]
-tap_dances = [
+[behavior.morse]
+morses = [
   # td(0): Function key that outputs F1 on tap, F2 on double tap, layer 1 on hold
   { tap = "F1", hold = "MO(1)", double_tap = "F2" },
   
@@ -181,54 +229,54 @@ tap_dances = [
   # td(2): Navigation key that outputs Tab on tap, Escape on double tap, layer 2 on hold
   { tap = "Tab", hold = "MO(2)", double_tap = "Escape", timeout = "250ms" },
   
-  # td(3): Extended tap dance for function keys
+  # td(3): Extended morse for function keys
   { tap_actions = ["F1", "F2", "F3", "F4", "F5"], hold_actions = ["MO(1)", "MO(2)", "MO(3)", "MO(4)", "MO(5)"], timeout = "300ms" }
 
   # td(4): the morse ABC
   { timeout = "250ms", morse_actions = [
-      {pattern = ".-", action = "A"}, 
-      {pattern = "-...", action = "B"}, 
-      {pattern = "-.-.", action = "C"}, 
-      {pattern = "-..", action = "D"}, 
-      {pattern = ".", action = "E"}, 
-      {pattern = "..-.", action = "F"}, 
-      {pattern = "--.", action = "G"}, 
-      {pattern = "....", action = "H"}, 
-      {pattern = "..", action = "I"}, 
-      {pattern = ".---", action = "J"}, 
-      {pattern = "-.-", action = "K"}, 
-      {pattern = ".-..", action = "L"}, 
-      {pattern = "--", action = "M"}, 
-      {pattern = "-.", action = "N"}, 
-      {pattern = "---", action = "O"}, 
-      {pattern = ".--.", action = "P"}, 
-      {pattern = "--.-", action = "Q"}, 
-      {pattern = ".-.", action = "R"}, 
-      {pattern = "...", action = "S"}, 
-      {pattern = "-", action = "T"}, 
-      {pattern = "..-", action = "U"}, 
-      {pattern = "...-", action = "V"}, 
-      {pattern = ".--", action = "W"}, 
-      {pattern = "-..-", action = "X"}, 
-      {pattern = "-.--", action = "Y"}, 
-      {pattern = "--..", action = "Z"}, 
-      {pattern = ".----", action = "Kc1"}, 
-      {pattern = "..---", action = "Kc2"}, 
-      {pattern = "...--", action = "Kc3"}, 
-      {pattern = "....-", action = "Kc4"}, 
-      {pattern = ".....", action = "Kc5"}, 
-      {pattern = "-....", action = "Kc6"}, 
-      {pattern = "--...", action = "Kc7"}, 
-      {pattern = "---..", action = "Kc8"}, 
-      {pattern = "----.", action = "Kc9"}, 
-      {pattern = "-----", action = "Kc0"}
+      { pattern = ".-", action = "A" }, 
+      { pattern = "-...", action = "B" }, 
+      { pattern = "-.-.", action = "C" }, 
+      { pattern = "-..", action = "D" }, 
+      { pattern = ".", action = "E" }, 
+      { pattern = "..-.", action = "F" }, 
+      { pattern = "--.", action = "G" }, 
+      { pattern = "....", action = "H" }, 
+      { pattern = "..", action = "I" }, 
+      { pattern = ".---", action = "J" }, 
+      { pattern = "-.-", action = "K" }, 
+      { pattern = ".-..", action = "L" }, 
+      { pattern = "--", action = "M" }, 
+      { pattern = "-.", action = "N" }, 
+      { pattern = "---", action = "O"}, 
+      { pattern = ".--.", action = "P" }, 
+      { pattern = "--.-", action = "Q" }, 
+      { pattern = ".-.", action = "R" }, 
+      { pattern = "...", action = "S" }, 
+      { pattern = "-", action = "T" }, 
+      { pattern = "..-", action = "U" }, 
+      { pattern = "...-", action = "V" }, 
+      { pattern = ".--", action = "W" }, 
+      { pattern = "-..-", action = "X" }, 
+      { pattern = "-.--", action = "Y" }, 
+      { pattern = "--..", action = "Z" }, 
+      { pattern = ".----", action = "Kc1" }, 
+      { pattern = "..---", action = "Kc2" }, 
+      { pattern = "...--", action = "Kc3" }, 
+      { pattern = "....-", action = "Kc4" }, 
+      { pattern = ".....", action = "Kc5" }, 
+      { pattern = "-....", action = "Kc6" }, 
+      { pattern = "--...", action = "Kc7" }, 
+      { pattern = "---..", action = "Kc8" }, 
+      { pattern = "----.", action = "Kc9" }, 
+      { pattern = "-----", action = "Kc0" }
     ] }
 ]
 ```
 
-### Using Tap Dance in Keymaps
+### Using Morse(Tap Dance) in Keymaps
 
-To use a tap dance in your keymap, reference it by its index (starting from 0):
+You can use both `Morse` and `TD` to represent a morse key in your keymap, you can reference it by its index (starting from 0):
 
 ```toml
 [layout]
@@ -238,7 +286,7 @@ layers = 2
 keymap = [
     [
         ["A", "B", "C"], 
-        ["TD(0)", "TD(1)", "TD(2)"],  # Use tap dances 0, 1, and 2
+        ["TD(0)", "TD(1)", "TD(2)"],  # Use morse dances 0, 1, and 2
         ["LCtrl", "MO(1)", "LShift"],
         ["OSL(1)", "LT(2, Kc9)", "LM(1, LShift | LGui)"]
     ],
@@ -251,20 +299,20 @@ keymap = [
 ]
 ```
 
-### Configuration Limits
+### Limits
 
-The tap dance functionality is controlled by the following configuration limits in the `[rmk]` section:
+The morse functionality is controlled by the following configuration limits in the `[rmk]` section:
 
-- `tap_dance_max_num`: Maximum number of tap dances (default: 8, range: 0-256)
-- `max_patterns_per_key`: Maximum number of patterns per tap dance key config (default: 8, range: 4-65536)
+- `morse_max_num`: Maximum number of morses (default: 8, range: 0-256)
+- `max_patterns_per_key`: Maximum number of patterns per morse key config (default: 8, range: 4-65536)
 
 ```toml
 [rmk]
-tap_dance_max_num = 10  # To support up to 10 tap dances
-max_patterns_per_key = 36  # To support up to 36 morse patterns per tap dance key
+morse_max_num = 10  # To support up to 10 morses
+max_patterns_per_key = 36  # To support up to 36 morse patterns per morse key
 ```
 
-Note that the default format (using `tap`, `hold`, `hold_after_tap`, `double_tap`) needs at least 4 patterns, the  the extended format (using `tap_actions` + `hold_actions` together) can support up to the configured `max_patterns_per_key` value, then number of `morse_actions` is also limited by `max_patterns_per_key`. 
+Note that the default format (using `tap`, `hold`, `hold_after_tap`, `double_tap`) needs at least 4 patterns, the extended format (using `tap_actions` + `hold_actions` together) can support up to the configured `max_patterns_per_key` value, then number of `morse_actions` is also limited by `max_patterns_per_key`. 
 
 ::: warning 
 Also Vial is only able to edit the ".", "-", "..", ".-" patterns as tap, hold, double tap, hold after tap, the rest is not visible.

--- a/docs/en/docs/features/configuration/behavior.md
+++ b/docs/en/docs/features/configuration/behavior.md
@@ -10,9 +10,11 @@ one_shot = { timeout = "1s" }
 
 ## Tap Hold
 
-In the `tap_hold` sub-table, you can configure the following parameters:
+In the `tap_hold` sub-table you can configure tap-hold behavior which performs one action when tapped and another action when held.
 
-- `enable_hrm`: Enables or disables HRM (Home Row Mod) mode. When enabled, the `prior_idle_time` setting becomes functional. Defaults to `false`.
+Available fields:
+
+- `enable_hrm`: Enables HRM (Home Row Mod) mode. When enabled, the `prior_idle_time` setting becomes functional. Defaults to `false`.
 - `permissive_hold`: Enables permissive hold mode. When enabled, hold action will be triggered when a key is pressed and released during tap-hold decision. This option is recommended to set to true when `enable_hrm` is set to true.
 - `unilateral_tap`: (Experimental) Enables unilateral tap mode. When enabled, tap action will be triggered when a key from "same" hand is pressed. In current experimental version, the "opposite" hand is calculated [according to the number of cols/rows](https://github.com/HaoboGu/rmk/blob/c0ef95b1185c25972c62458c878ee9f1a8e1a837/rmk/src/tap_hold.rs#L111-L136). This option is recommended to set to true when `enable_hrm` is set to true.
 - `hold_on_other_press`: Enables hold-on-other-key-press mode. When enabled, hold action will be triggered immediately when any other non-tap-hold key is pressed while a tap-hold key is being held. This provides faster modifier activation without waiting for the timeout. **Priority rules**: When HRM is disabled, permissive hold takes precedence over this feature. When HRM is enabled, this feature works normally. Defaults to `false`.
@@ -26,17 +28,19 @@ The following are the typical configurations:
 [behavior]
 # Enable HRM with all tap-hold features
 tap_hold = { enable_hrm = true, permissive_hold = true, unilateral_tap = true, hold_on_other_press = true, prior_idle_time = "120ms", hold_timeout = "250ms" }
-# Fast modifier usage without HRM
+
+# Fast modifiers without HRM
 tap_hold = { enable_hrm = false, hold_on_other_press = true, hold_timeout = "200ms" }
-# Disable HRM, you can safely ignore any fields if you don't want to change them
+
+# HRM disabled; unspecified fields keep their defaults
 tap_hold = { enable_hrm = false, hold_timeout = "200ms" }
 ```
 
 ## Tri Layer
 
-`Tri Layer` works by enabling a layer (called `adjust`) when other two layers (`upper` and `lower`) are both enabled.
+Tri-layer enables a third layer (often called `adjust`) automatically when two other layers(`upper` and `lower`) are both active.
 
-You can enable Tri Layer by specifying the `upper`, `lower` and `adjust` layers in the `tri_layer` sub-table:
+You can enable Tri-Layer by specifying the `upper`, `lower` and `adjust` layers in the `tri_layer` sub-table:
 
 ```toml
 [behavior.tri_layer]
@@ -50,8 +54,7 @@ In this example, when both layers 1 (`upper`) and 2 (`lower`) are active, layer 
 Note that `"#layer_name"` could also be used in place of layer numbers.
 
 ## One Shot
-
-In the `one_shot` sub-table you can define how long OSM or OSL will wait before releasing the modifier/layer with the `timeout` option, default is one second. `timeout` is a string with a suffix of either "s" or "ms".
+The `one_shot` sub-table configures one-shot modifiers or one-shot layers (OSM/OSL). Use `timeout` to specify how long the modifier/layer remains active. The value is a string suffixed with `s` or `ms` (default: `1s`).
 
 ```toml
 [behavior.one_shot]
@@ -125,69 +128,69 @@ operations = [
 
 ## Morse(Tap Dance)
 
-In the `morse` sub-table, you can configure the keyboard's morse functionality. Morse is a superset of well-known [tap dance](https://docs.qmk.fm/features/tap_dance), which allows you to define different actions based on the different combinations of taps and holds within a specific time window.
+In the `morse` sub-table, you can configure the keyboard's morse functionality. Morse is a superset of the well-known [tap dance](https://docs.qmk.fm/features/tap_dance), enabling you to assign different actions to various combinations of taps and holds performed within a specific time window.
 
-You can define a list of morse keys as the following: 
+Morse keys are defined as a list under the `[behavior.morse]` section:
 
 ```toml
 [behavior.morse]
 morses = [
-  ... # Morse keys
+  # ... morse entries ...
 ]
 ```
 
-There are three ways to define a morse key in RMK:
+RMK provides three methods for defining a Morse key.
 
 ### Define a morse key
 
-#### 1. Define the vial-like tap dance:
+#### 1. Vial-style Tap Dance
 
-This type is fully compatible with TapDance in Vial, only four actions are defined:
+This method is fully compatible with Vial's Tap Dance, it defines four specific actions:
 
 1 `tap`: The action to be triggered on the first tap within the tapping term. This is the default action when the key is tapped once.
 2 `hold`: The action to be triggered when the key is held down (not tapped) beyond the tapping term.
 3 `hold_after_tap`: The action to be triggered when the key is held down after being tapped once.
 4 `double_tap`: The action to be triggered when the key is tapped twice within the tapping term.
 
-The following is an example:
+Example:
 
 ```toml
 [behavior.morse]
 morses = [
-  # A vial-like tap dance
+  # A Vial-style tap dance key
   { tap = "F1", hold = "MO(1)", hold_after_tap = "MO(2)", double_tap = "F2" }
 ]
 ```
 
-#### 2. Define taps and hold-after-tap actions
+#### 2. Tap and Hold Arrays
 
-This is a slightly extended version of tap dance, you can define multiple taps(just like tap dance) in `tap_actions`, and you can also define a `hold_actions` list which represents hold-after-multiple-taps:
+This is an extended version of tap dance. It allows you to define sequences of actions for multiple taps and for holds that occur after a specific number of taps.
 
-- `tap_actions`: Each tap within the tapping term increments the tap count and triggers the corresponding action from the `tap_actions` array. For example, `tap_actions = ["F1", "F2", "F3"]` means a single tap triggers "F1", double tap triggers "F2", triple tap triggers "F3", and so on. Tapping 5 times will trigger the 5th item in the `tap_actions` (`tap_actions[4]`). If the tap count exceeds the length of the array, the last action is used.
-- `hold_actions`: When a key is held after multiple taps, the corresponding action from the `hold_actions` array is triggered. For example, `hold_actions = ["MO(1)", "MO(2)", "MO(3)"]` means holding after one tap triggers "MO(1)", holding after two taps triggers "MO(2)", and so on. Holding the key after tapping 5 times will trigger 6th item in the `hold_actions` list (`hold_actions[5]`).
+- `tap_actions`: An array of actions triggered by sequential taps. Each tap within the tapping term increments the tap count and triggers the corresponding action from the `tap_actions` array. For example, `tap_actions = ["F1", "F2", "F3"]` means a single tap triggers "F1", double tap triggers "F2", triple tap triggers "F3", and so on. Tapping 5 times will trigger the 5th item in the `tap_actions` (`tap_actions[4]`). If the tap count exceeds the length of the array, the last action is used.
+- `hold_actions`: An array of actions triggered when the key is held *after* a certain number of taps. When a key is held after multiple taps, the corresponding action from the `hold_actions` array is triggered. For example, `hold_actions = ["MO(1)", "MO(2)", "MO(3)"]` means holding after one tap triggers "MO(1)", holding after two taps triggers "MO(2)", and so on. Holding the key after tapping 5 times will trigger 6th item in the `hold_actions` list (`hold_actions[5]`).
 
-The following is an example:
+Example:
 
 ```toml
 [behavior.morse]
 morses = [
-  # A taps & hold-after-tap morse key
+  # A morse key defined with tap and hold-after-tap actions array
   { tap_actions = ["F1", "F2", "F3", "F4", "F5"], hold_actions = ["MO(1)", "MO(2)", "MO(3)", "MO(4)", "MO(5)"] }
 ]
 ```
 
-#### 3. Define the full-morse behavior
+#### 3. Full Morse Patterns
 
-This is the most powerful way, you can just define a morse code like patterns, use a single key to represent many many actions, just like [morse code](https://en.wikipedia.org/wiki/Morse_code).
+This is the most powerful method, allowing you to define actions based on [Morse code](https://en.wikipedia.org/wiki/Morse_code)-like patterns of taps and holds. This lets you assign a large number of actions to a single key
 
-- `morse_actions`: list of patten -> action pairs. The pattern is a tap/hold sequence, its length is limited in 15. For example, the morse pattern of `C` can be described like this: `"-.-."` or `"_._."` or `"1010"`.
+- `morse_actions`: A list of pattern-to-action mappings. The pattern is a tap/hold sequence, a tap is represented by a `.` or `0`, a hold is represented by a `_`, `-` or `1`. For example, the morse pattern of `C` can be described like this: `"-.-."` or `"_._."` or `"1010"`. The maximum length of the pattern is 15.
 
-The following is an example:
+Example:
 
 ```toml
 [behavior.morse]
 morses = [
-  # A morse key defined using morse_actions
+  # A morse key defined using full Morse patterns
   { morse_actions = [
         { pattern = ".-", action = "A" },
         { pattern = "-...", action = "B" },
@@ -197,19 +200,46 @@ morses = [
 ]
 ```
 
-### Common configuration for morse keys
-
-This is also common configurations for both three representations of morse keys:
-
-  - `timeout`: The time window (in milliseconds or seconds) within which taps are considered part of the same morse sequence. Defaults to 200ms if not specified.
-
 ::: warning
 
-`morse_actions` cannot be used together with `tap_actions` and `hold_actions` and they also cannot be used together with `tap`, `hold`, `hold_after_tap`, or `double_tap`. For each morse configuration, please choose either the morse style (`morse_actions`) or array style (`tap_actions`/`hold_actions`) or the individual fields (`tap`/`hold`/`hold_after_tap`/`double_tap`).
+The three definition methods are mutually exclusive. For any single Morse key definition, you must choose only one of the following approaches:
+
+- Full Morse: `morse_actions`
+- Tap and Hold Arrays: `tap_actions` and/or `hold_actions`
+- Vial-style: `tap`, `hold`, `hold_after_tap`, `double_tap`.
+
+Mixing fields from different methods in the same definition is not allowed.
 
 :::
 
-Here is a composite example of morse configuration:
+### Common configuration
+
+The following setting applies to all three definition methods:
+
+  - `timeout`: The time window (in milliseconds or seconds) within which taps are considered part of the same morse sequence. Defaults to 200ms if not specified.
+
+### Global Configuration Limits
+
+The following parameters in the `[rmk]` section control the resource allocation for the Morse feature:
+
+- `morse_max_num`: The maximum number of Morse key you can create. (Default: 8, Range: 0-256)
+- `max_patterns_per_key`: The maximum number of individual patterns (like ".-") or actions that a single Morse key can contain. (Default: 8, Range: 4-65536)
+
+```toml
+[rmk]
+morse_max_num = 10  # To support up to 10 morse keys
+max_patterns_per_key = 36  # To support up to 36 morse patterns per morse key
+```
+
+Note that the Vial-style method (using `tap`, `hold`, `hold_after_tap`, `double_tap`) needs at least 4 patterns. If you create a key with a long `tap_actions`/`hold_actions` array or many `morse_actions`, you might need to increase `max_patterns_per_key` accordingly.
+
+::: warning Vial Compatibility
+Please note that while the firmware can handle all Morse configurations, Vial can only recognize and edit the four basic Vial-style actions. These correspond to the patterns for single tap (.), hold (-), double tap (..), and hold-after-tap (.-). More complex patterns defined using morse_actions or extended tap_actions will not be visible or editable in Vial.
+:::
+
+### Comprehensive Example
+
+Here is a comprehensive example of morse configuration:
 
 ```toml
 [rmk]
@@ -298,25 +328,6 @@ keymap = [
     ],
 ]
 ```
-
-### Limits
-
-The morse functionality is controlled by the following configuration limits in the `[rmk]` section:
-
-- `morse_max_num`: Maximum number of morses (default: 8, range: 0-256)
-- `max_patterns_per_key`: Maximum number of patterns per morse key config (default: 8, range: 4-65536)
-
-```toml
-[rmk]
-morse_max_num = 10  # To support up to 10 morses
-max_patterns_per_key = 36  # To support up to 36 morse patterns per morse key
-```
-
-Note that the default format (using `tap`, `hold`, `hold_after_tap`, `double_tap`) needs at least 4 patterns, the extended format (using `tap_actions` + `hold_actions` together) can support up to the configured `max_patterns_per_key` value, then number of `morse_actions` is also limited by `max_patterns_per_key`. 
-
-::: warning 
-Also Vial is only able to edit the ".", "-", "..", ".-" patterns as tap, hold, double tap, hold after tap, the rest is not visible.
-:::
 
 ## Fork
 

--- a/docs/en/docs/features/configuration/layout.md
+++ b/docs/en/docs/features/configuration/layout.md
@@ -118,7 +118,9 @@ The definitions of those operations are same with QMK, you can found [here](http
 
 7. For shifted key, use `SHIFTED(key)`
 
-8. For Morse/Tap Dance, use `TD(n)`
+8. For Morse/Tap Dance, use `TD(n)` or `Morse(n)`, they are same
+
+9. For keyboard macros, use `Macro(n)`
 
 ## Aliases
 

--- a/docs/en/docs/features/configuration/layout.md
+++ b/docs/en/docs/features/configuration/layout.md
@@ -118,7 +118,7 @@ The definitions of those operations are same with QMK, you can found [here](http
 
 7. For shifted key, use `SHIFTED(key)`
 
-8. For Tap Dance, use `TD(n)`
+8. For Morse/Tap Dance, use `TD(n)`
 
 ## Aliases
 

--- a/docs/en/docs/features/configuration/rmk_config.md
+++ b/docs/en/docs/features/configuration/rmk_config.md
@@ -16,9 +16,9 @@ combo_max_num = 8
 combo_max_length = 4
 # Maximum number of forks for conditional key actions
 fork_max_num = 8
-# Maximum number of tap dances keyboard can store (max 256)
-tap_dance_max_num = 8
-# Maximum number of patterns a tap dance key can handle (default: 8, min: 2, max 65536)
+# Maximum number of morse keys keyboard can store (max 256)
+morse_max_num = 8
+# Maximum number of patterns a morse key can handle (default: 8, min: 2, max 65536)
 max_patterns_per_key = 8
 # Macro space size in bytes for storing sequences. The maximum number of Macros depends on the size of each sequence: All sequences combined need to fit into macro_space_size, the number of macro sequences doesn't matter.
 macro_space_size = 256
@@ -51,15 +51,15 @@ ble_profiles_num = 3
 
 ::: info
 
-Increasing the number of combos, forks, tap dances and macros will increase memory usage.
+Increasing the number of combos, forks, morses(tap dances) and macros will increase memory usage.
 
 :::
 
 - `combo_max_num`: Maximum number of combos that the keyboard can store, default value is 8. This value must be between 0 and 256.
 - `combo_max_length`: Maximum number of keys that can be pressed simultaneously in a combo, default value is 4.
 - `fork_max_num`: Maximum number of forks for conditional key actions, default value is 8. This value must be between 0 and 256.
-- `tap_dance_max_num`: Maximum number of tap dances that can be stored, default value is 8. This value must be between 0 and 256.
-- `max_patterns_per_key` : Maximum number of tap/hold patterns a tap dance key can handle, default value is 8. This value must be between 4 and 65536. (Will be automatically set to the maximum length of `tap_actions` + `hold_actions` or `morse_actions`.)
+- `morse_max_num`: Maximum number of morses that can be stored, default value is 8. This value must be between 0 and 256.
+- `max_patterns_per_key` : Maximum number of tap/hold patterns a morse key can handle, default value is 8. This value must be between 4 and 65536. (Will be automatically set to the maximum length of `tap_actions` + `hold_actions` or `morse_actions`.)
 - `macro_space_size`: Space size in bytes for storing macro sequences, default value is 256.
 
 ### Matrix Configuration

--- a/examples/use_config/nrf52840_ble_split/keyboard.toml
+++ b/examples/use_config/nrf52840_ble_split/keyboard.toml
@@ -40,23 +40,23 @@ numslock.low_active = false
 [behavior]
 tap_hold = { enable_hrm = true, prior_idle_time = "120ms", hold_timeout = "250ms" }
 
-[[behavior.tap_dance.tap_dances]]
+[[behavior.morse.morses]]
 tap = "A"
 hold = "WM(A, LShift)"
 double_tap = "CapsLock"
 hold_after_tap = "A"
 timeout = "150ms"
 
-[[behavior.tap_dance.tap_dances]]
+[[behavior.morse.morses]]
 tap = "Space"
 hold = "LCtrl"
 
-[[behavior.tap_dance.tap_dances]]
+[[behavior.morse.morses]]
 tap_actions = ["F1", "F2", "F3", "F4"]  # 1 tap = F1, 2 taps = F2, 3 taps = F3, 4 taps = F4
 hold_actions = ["MO(1)", "MO(2)", "MO(3)", "MO(4)"]  # Hold after 1 tap = layer 1, etc.
 timeout = "200ms"
 
-[[behavior.tap_dance.tap_dances]]
+[[behavior.morse.morses]]
 tap_actions = ["Tab", "Escape", "CapsLock"]  # 1 tap = Tab, 2 taps = Escape, 3 taps = CapsLock
 hold_actions = ["LCtrl", "LAlt", "LShift"]  # Hold after 1 tap = Ctrl, etc.
 timeout = "250ms"

--- a/examples/use_config/rp2040/keyboard.toml
+++ b/examples/use_config/rp2040/keyboard.toml
@@ -20,16 +20,48 @@ cols = 3
 layers = 2
 keymap = [
     [
-        ["A", "B", "C"],
-        ["Kc1", "Kc2", "Kc3"],
-        ["LCtrl", "MO(1)", "LShift"],
-        ["OSL(1)", "LT(2, Kc9)", "LM(1, LShift | LGui)"]
+        [
+            "A",
+            "B",
+            "C",
+        ],
+        [
+            "Kc1",
+            "Kc2",
+            "Kc3",
+        ],
+        [
+            "LCtrl",
+            "MO(1)",
+            "LShift",
+        ],
+        [
+            "OSL(1)",
+            "LT(2, Kc9)",
+            "LM(1, LShift | LGui)",
+        ],
     ],
     [
-        ["_", "TT(1)", "TG(2)"],
-        ["_", "_", "_"],
-        ["_", "_", "_"],
-        ["_", "_", "_"]
+        [
+            "_",
+            "TT(1)",
+            "TG(2)",
+        ],
+        [
+            "_",
+            "_",
+            "_",
+        ],
+        [
+            "_",
+            "_",
+            "_",
+        ],
+        [
+            "_",
+            "_",
+            "_",
+        ],
     ],
 ]
 
@@ -48,5 +80,5 @@ keymap = [
 # enabled = false
 
 [rmk]
-tap_dance_max_num = 8
+morse_max_num = 8
 max_patterns_per_key = 8

--- a/rmk-config/src/behavior.rs
+++ b/rmk-config/src/behavior.rs
@@ -75,10 +75,10 @@ impl crate::KeyboardTomlConfig {
                         return Err("keyboard.toml: number of forks is greater than fork_max_num configured under [rmk] section".to_string());
                     }
                 }
-                behavior.tap_dance = behavior.tap_dance.or(default.tap_dance);
-                if let Some(tap_dance) = &behavior.tap_dance {
-                    if tap_dance.tap_dances.len() > self.rmk.tap_dance_max_num {
-                        return Err("keyboard.toml: number of tap dances is greater than tap_dance_max_num configured under [rmk] section".to_string());
+                behavior.morse = behavior.morse.or(default.morse);
+                if let Some(morse) = &behavior.morse {
+                    if morse.morses.len() > self.rmk.morse_max_num {
+                        return Err("keyboard.toml: number of morses is greater than morse_max_num configured under [rmk] section".to_string());
                     }
                 }
                 Ok(behavior)

--- a/rmk-config/src/keymap.pest
+++ b/rmk-config/src/keymap.pest
@@ -95,15 +95,15 @@ tap_hold_action = _{ mt_action | th_action }
 // Rule 7: SHIFTED(key)
 shifted_action = { ^"SHIFTED" ~ "(" ~ keycode_name ~ ")" }
 
-// Rule 8: TD(n) - Tap Dance index
-tap_dance_action = { ^"TD" ~ "(" ~ number ~ ")" }
+// Rule 8: TD(n) - Morse(Tap Dance) index
+morse_action = { ^"TD" ~ "(" ~ number ~ ")" }
 
 // --- Top Level Rules ---
 
 // A single key action entry in the map
 // Order is important: more specific function-like rules first, then aliases/specials, then simple keycodes.
 key_action = _{ // Consume surrounding whitespace/comments implicitly
-    wm_action | osm_action | layer_action | tap_hold_action | shifted_action | tap_dance_action | no_action | transparent_action | simple_keycode
+    wm_action | osm_action | layer_action | tap_hold_action | shifted_action | morse_action | no_action | transparent_action | simple_keycode
 }
 
 // The entire key map string: Start, zero or more key actions, End.

--- a/rmk-config/src/keymap.pest
+++ b/rmk-config/src/keymap.pest
@@ -22,7 +22,7 @@ number = @{ ASCII_DIGIT+ }
 layer_number = @{ number }
 layer_name = @{ loose_identifier }
 
-//the order is important here, as we want to match the number first 
+// The order is important here, as we want to match the number first 
 layer_reference = _{ layer_number | layer_name }
 
 // Modifier Names
@@ -95,8 +95,11 @@ tap_hold_action = _{ mt_action | th_action }
 // Rule 7: SHIFTED(key)
 shifted_action = { ^"SHIFTED" ~ "(" ~ keycode_name ~ ")" }
 
-// Rule 8: TD(n) - Morse(Tap Dance) index
-morse_action = { ^"TD" ~ "(" ~ number ~ ")" }
+// Rule 8: TD(n)/MORSE(n) - Morse index (in Vial its simplest form is known as "Tap Dance", so the TD name is used)
+morse_name = @{
+    ^"TD" | ^"MORSE"
+}
+morse_action = { morse_name ~ "(" ~ number ~ ")" }
 
 // --- Top Level Rules ---
 

--- a/rmk-config/src/layout.rs
+++ b/rmk-config/src/layout.rs
@@ -550,6 +550,11 @@ mod tests {
             ("TD(255)", Rule::morse_action),
             ("td(0)", Rule::morse_action), // Case insensitive
             ("td(1)", Rule::morse_action),
+            ("MORSE(0)", Rule::morse_action),
+            ("MORSE(1)", Rule::morse_action),
+            ("MORSE(255)", Rule::morse_action),
+            ("Morse(0)", Rule::morse_action), // Case insensitive
+            ("morse(1)", Rule::morse_action),
         ];
 
         for (input, expected_rule) in test_cases {

--- a/rmk-config/src/layout.rs
+++ b/rmk-config/src/layout.rs
@@ -403,7 +403,7 @@ impl KeyboardTomlConfig {
                                     key_action_sequence.push(action);
                                 }
 
-                                Rule::tap_dance_action => {
+                                Rule::morse_action => {
                                     let action = inner_pair.as_str().to_string();
                                     key_action_sequence.push(action);
                                 }
@@ -528,7 +528,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tap_dance_action_parsing() {
+    fn test_morse_action_parsing() {
         let aliases = HashMap::new();
         let layer_names = HashMap::new();
 
@@ -542,14 +542,14 @@ mod tests {
     }
 
     #[test]
-    fn test_tap_dance_action_grammar() {
+    fn test_morse_action_grammar() {
         // Test that TD actions are parsed correctly by the grammar
         let test_cases = vec![
-            ("TD(0)", Rule::tap_dance_action),
-            ("TD(1)", Rule::tap_dance_action),
-            ("TD(255)", Rule::tap_dance_action),
-            ("td(0)", Rule::tap_dance_action), // Case insensitive
-            ("td(1)", Rule::tap_dance_action),
+            ("TD(0)", Rule::morse_action),
+            ("TD(1)", Rule::morse_action),
+            ("TD(255)", Rule::morse_action),
+            ("td(0)", Rule::morse_action), // Case insensitive
+            ("td(1)", Rule::morse_action),
         ];
 
         for (input, expected_rule) in test_cases {
@@ -561,7 +561,7 @@ mod tests {
                 if pair.as_rule() == Rule::key_map {
                     for inner_pair in pair.into_inner() {
                         match inner_pair.as_rule() {
-                            Rule::tap_dance_action => {
+                            Rule::morse_action => {
                                 found_rule = Some(inner_pair.as_rule());
                             }
                             _ => {}

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -46,11 +46,11 @@ pub struct RmkConstantsConfig {
     #[serde_inline_default(8)]
     #[serde(deserialize_with = "check_fork_max_num")]
     pub fork_max_num: usize,
-    /// Maximum number of tap dances keyboard can store
+    /// Maximum number of morses keyboard can store
     #[serde_inline_default(8)]
-    #[serde(deserialize_with = "check_tap_dance_max_num")]
-    pub tap_dance_max_num: usize,
-    /// Maximum number of patterns a tap dance key can handle
+    #[serde(deserialize_with = "check_morse_max_num")]
+    pub morse_max_num: usize,
+    /// Maximum number of patterns a morse key can handle
     #[serde_inline_default(8)]
     #[serde(deserialize_with = "check_max_patterns_per_key")]
     pub max_patterns_per_key: usize,
@@ -106,13 +106,13 @@ where
     Ok(value)
 }
 
-fn check_tap_dance_max_num<'de, D>(deserializer: D) -> Result<usize, D::Error>
+fn check_morse_max_num<'de, D>(deserializer: D) -> Result<usize, D::Error>
 where
     D: de::Deserializer<'de>,
 {
     let value = SerdeDeserialize::deserialize(deserializer)?;
     if value > 256 {
-        panic!("❌ Parse `keyboard.toml` error: tap_dance_max_num must be between 0 and 256, got {value}");
+        panic!("❌ Parse `keyboard.toml` error: morse_max_num must be between 0 and 256, got {value}");
     }
     Ok(value)
 }
@@ -148,7 +148,7 @@ impl Default for RmkConstantsConfig {
             combo_max_num: 8,
             combo_max_length: 4,
             fork_max_num: 8,
-            tap_dance_max_num: 8,
+            morse_max_num: 8,
             max_patterns_per_key: 8,
             macro_space_size: 256,
             debounce_time: 20,
@@ -230,8 +230,8 @@ impl KeyboardTomlConfig {
     }
 
     /// Auto calculate some parameters in toml:
-    /// - Update tap_dance_max_num to fit all configured tap dances
-    /// - Update max_patterns_per_key to fit the max number of configured (pattern, action) pairs per tap dance key
+    /// - Update morse_max_num to fit all configured morses
+    /// - Update max_patterns_per_key to fit the max number of configured (pattern, action) pairs per morse key
     /// - Update peripheral number based on the number of split boards
     /// - TODO: Update controller number based on the number of split boards
     pub fn auto_calculate_parameters(&mut self) {
@@ -249,27 +249,27 @@ impl KeyboardTomlConfig {
 
         if let Some(behavior) = &self.behavior {
             // Update the max_patterns_per_key
-            if let Some(tap_dance) = &behavior.tap_dance {
+            if let Some(morse) = &behavior.morse {
                 let mut max_required_patterns = self.rmk.max_patterns_per_key;
 
-                for tap_dance in &tap_dance.tap_dances {
-                    let tap_actions_len = tap_dance.tap_actions.as_ref().map(|v| v.len()).unwrap_or(0);
-                    let hold_actions_len = tap_dance.hold_actions.as_ref().map(|v| v.len()).unwrap_or(0);
+                for morse in &morse.morses {
+                    let tap_actions_len = morse.tap_actions.as_ref().map(|v| v.len()).unwrap_or(0);
+                    let hold_actions_len = morse.hold_actions.as_ref().map(|v| v.len()).unwrap_or(0);
 
                     let n = tap_actions_len.max(hold_actions_len);
                     if n > 15 {
-                        panic!("The number of taps per tap dance is too large, the max number of taps is 15, got {n}");
+                        panic!("The number of taps per morse is too large, the max number of taps is 15, got {n}");
                     }
 
-                    let morse_actions_len = tap_dance.morse_actions.as_ref().map(|v| v.len()).unwrap_or(0);
+                    let morse_actions_len = morse.morse_actions.as_ref().map(|v| v.len()).unwrap_or(0);
 
                     max_required_patterns =
                         max_required_patterns.max(tap_actions_len + hold_actions_len + morse_actions_len);
                 }
                 self.rmk.max_patterns_per_key = max_required_patterns;
 
-                // Update the tap_dance_max_num
-                self.rmk.tap_dance_max_num = self.rmk.tap_dance_max_num.max(tap_dance.tap_dances.len());
+                // Update the morse_max_num
+                self.rmk.morse_max_num = self.rmk.morse_max_num.max(morse.morses.len());
             }
         }
     }
@@ -417,7 +417,7 @@ pub struct BehaviorConfig {
     #[serde(alias = "macro")]
     pub macros: Option<MacrosConfig>,
     pub fork: Option<ForksConfig>,
-    pub tap_dance: Option<TapDancesConfig>,
+    pub morse: Option<MorsesConfig>,
 }
 
 /// Configurations for tap hold
@@ -507,16 +507,16 @@ pub struct ForkConfig {
     pub bindable: Option<bool>,
 }
 
-/// Configurations for tap dances
+/// Configurations for morse keys
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct TapDancesConfig {
-    pub tap_dances: Vec<TapDanceConfig>,
+pub struct MorsesConfig {
+    pub morses: Vec<MorseConfig>,
 }
 
-/// Configurations for tap dance
+/// Configurations for morse
 #[derive(Clone, Debug, Deserialize)]
-pub struct TapDanceConfig {
+pub struct MorseConfig {
     pub tap: Option<String>,
     pub hold: Option<String>,
     pub hold_after_tap: Option<String>,

--- a/rmk-macro/src/behavior.rs
+++ b/rmk-macro/src/behavior.rs
@@ -3,7 +3,7 @@
 
 use quote::quote;
 use rmk_config::{
-    CombosConfig, ForksConfig, KeyboardTomlConfig, MacrosConfig, MorseActionPair, OneShotConfig, TapDancesConfig,
+    CombosConfig, ForksConfig, KeyboardTomlConfig, MacrosConfig, MorseActionPair, MorsesConfig, OneShotConfig,
     TapHoldConfig, TriLayerConfig,
 };
 
@@ -55,7 +55,7 @@ fn expand_morse_action_pair(action_pair: &MorseActionPair) -> proc_macro2::Token
         }
     }
     let action = parse_key(action_pair.action.to_owned());
-    quote! { (rmk::tap_dance::MorsePattern::from_u16(#pattern), #action.to_action()) }
+    quote! { (rmk::morse::MorsePattern::from_u16(#pattern), #action.to_action()) }
 }
 
 fn expand_morse_actions(actions: &Vec<MorseActionPair>) -> proc_macro2::TokenStream {
@@ -78,11 +78,11 @@ fn expand_tap_hold_config(tap_hold_config: &Option<TapHoldConfig>) -> proc_macro
                 None => quote! {},
             };
             let tap_hold_mode = if let Some(true) = tap_hold_config.permissive_hold {
-                quote! { mode: ::rmk::tap_dance::TapHoldMode::PermissiveHold, }
+                quote! { mode: ::rmk::morse::MorseMode::PermissiveHold, }
             } else if let Some(true) = tap_hold_config.hold_on_other_press {
-                quote! { mode: ::rmk::tap_dance::TapHoldMode::HoldOnOtherPress, }
+                quote! { mode: ::rmk::morse::MorseMode::HoldOnOtherPress, }
             } else {
-                quote! { mode: ::rmk::tap_dance::TapHoldMode::Normal,}
+                quote! { mode: ::rmk::morse::MorseMode::Normal,}
             };
             let unilateral_tap = match tap_hold_config.unilateral_tap {
                 Some(enable) => quote! { unilateral_tap: #enable, },
@@ -189,11 +189,11 @@ fn expand_macros(macros: &Option<MacrosConfig>) -> proc_macro2::TokenStream {
     }
 }
 
-fn expand_tap_dance(tap_dance: &Option<TapDancesConfig>) -> proc_macro2::TokenStream {
+fn expand_morse(morse: &Option<MorsesConfig>) -> proc_macro2::TokenStream {
     let default = quote! { ::core::default::Default::default() };
-    match tap_dance {
-        Some(tap_dance) => {
-            let tap_dances_def = tap_dance.tap_dances.iter().map(|td| {
+    match morse {
+        Some(morse) => {
+            let morses_def = morse.morses.iter().map(|td| {
                 // Parse tapping term, default to 200ms if not specified
                 let timeout = match &td.timeout {
                     Some(duration) => {
@@ -205,13 +205,13 @@ fn expand_tap_dance(tap_dance: &Option<TapDancesConfig>) -> proc_macro2::TokenSt
 
                 if let Some(morse_actions) = &td.morse_actions {
                     if td.tap.is_some() || td.hold.is_some() || td.hold_after_tap.is_some() || td.double_tap.is_some() || td.tap_actions.is_some() || td.hold_actions.is_some() {
-                        panic!("\n❌ keyboard.toml: `morse_actions` cannot be used together with `tap_actions`, `hold_actions`, `tap`, `hold`, `hold_after_tap`, or `double_tap`. Please check the documentation: https://rmk.rs/docs/features/configuration/behavior.html#tap-dance");
+                        panic!("\n❌ keyboard.toml: `morse_actions` cannot be used together with `tap_actions`, `hold_actions`, `tap`, `hold`, `hold_after_tap`, or `double_tap`. Please check the documentation: https://rmk.rs/docs/features/configuration/behavior.html#morse");
                     }
 
                     let actions_def = expand_morse_actions(&morse_actions);
 
                     quote! {
-                        ::rmk::tap_dance::TapDance {
+                        ::rmk::morse::Morse {
                             timeout_ms: #timeout,
                             #actions_def
                             ..Default::default()
@@ -221,7 +221,7 @@ fn expand_tap_dance(tap_dance: &Option<TapDancesConfig>) -> proc_macro2::TokenSt
                 } else if td.tap_actions.is_some() || td.hold_actions.is_some() {
                     // Check first
                     if td.tap.is_some() || td.hold.is_some() || td.hold_after_tap.is_some() || td.double_tap.is_some() {
-                        panic!("\n❌ keyboard.toml: `tap_actions` and `hold_actions` cannot be used together with `tap`, `hold`, `hold_after_tap`, or `double_tap`. Please check the documentation: https://rmk.rs/docs/features/configuration/behavior.html#tap-dance");
+                        panic!("\n❌ keyboard.toml: `tap_actions` and `hold_actions` cannot be used together with `tap`, `hold`, `hold_after_tap`, or `double_tap`. Please check the documentation: https://rmk.rs/docs/features/configuration/behavior.html#morse");
                     }
 
                     let tap_actions_def = match &td.tap_actions {
@@ -247,7 +247,7 @@ fn expand_tap_dance(tap_dance: &Option<TapDancesConfig>) -> proc_macro2::TokenSt
                     };
 
                     quote! {
-                        ::rmk::tap_dance::TapDance::new_with_actions(
+                        ::rmk::morse::Morse::new_with_actions(
                             #tap_actions_def,
                             #hold_actions_def,
                             #timeout,
@@ -260,7 +260,7 @@ fn expand_tap_dance(tap_dance: &Option<TapDancesConfig>) -> proc_macro2::TokenSt
                     let double_tap = parse_key(td.double_tap.clone().unwrap_or_else(|| "No".to_string()));
 
                     quote! {
-                        ::rmk::tap_dance::TapDance::new_from_vial(
+                        ::rmk::morse::Morse::new_from_vial(
                             #tap.to_action(),
                             #hold.to_action(),
                             #hold_after_tap.to_action(),
@@ -272,8 +272,8 @@ fn expand_tap_dance(tap_dance: &Option<TapDancesConfig>) -> proc_macro2::TokenSt
             });
 
             quote! {
-                ::rmk::config::TapDancesConfig {
-                    tap_dances: ::rmk::heapless::Vec::from_iter([#(#tap_dances_def),*]),
+                ::rmk::config::MorsesConfig {
+                    morses: ::rmk::heapless::Vec::from_iter([#(#morses_def),*]),
                 }
             }
         }
@@ -445,7 +445,7 @@ pub(crate) fn expand_behavior_config(keyboard_config: &KeyboardTomlConfig) -> pr
     let combos = expand_combos(&behavior.combo);
     let macros = expand_macros(&behavior.macros);
     let forks = expand_forks(&behavior.fork);
-    let tap_dance = expand_tap_dance(&behavior.tap_dance);
+    let morse = expand_morse(&behavior.morse);
 
     quote! {
         let mut behavior_config = ::rmk::config::BehaviorConfig {
@@ -454,7 +454,7 @@ pub(crate) fn expand_behavior_config(keyboard_config: &KeyboardTomlConfig) -> pr
             one_shot: #one_shot,
             combo: #combos,
             fork: #forks,
-            tap_dance: #tap_dance,
+            morse: #morse,
             keyboard_macros: #macros,
             // keyboard_macros: ::rmk::config::macro_config::KeyboardMacrosConfig::default(),
             mouse_key: ::rmk::config::MouseKeyConfig::default(),

--- a/rmk/build.rs
+++ b/rmk/build.rs
@@ -65,7 +65,7 @@ fn get_constants_str(constants: RmkConstantsConfig) -> String {
         const_declaration!(pub(crate) SPLIT_MESSAGE_CHANNEL_SIZE = constants.split_message_channel_size),
         const_declaration!(pub(crate) NUM_BLE_PROFILE = constants.ble_profiles_num),
         const_declaration!(pub(crate) SPLIT_CENTRAL_SLEEP_TIMEOUT_MINUTES = constants.split_central_sleep_timeout_minutes),
-        const_declaration!(pub(crate) TAP_DANCE_MAX_NUM = constants.tap_dance_max_num),
+        const_declaration!(pub(crate) MORSE_MAX_NUM = constants.morse_max_num),
         const_declaration!(pub(crate) MAX_PATTERNS_PER_KEY = constants.max_patterns_per_key),
         format!("pub(crate) const BUILD_HASH: u32 = {build_hash:#010x};\n"),
     ]

--- a/rmk/src/action.rs
+++ b/rmk/src/action.rs
@@ -56,8 +56,8 @@ pub enum KeyAction {
     Tap(Action),
     /// Tap hold action
     TapHold(Action, Action),
-    /// Tap dance action, references a tap dance configuration by index.
-    TapDance(u8),
+    /// Morse action, references a morse configuration by index.
+    Morse(u8),
 }
 
 impl KeyAction {
@@ -73,7 +73,7 @@ impl KeyAction {
     /// 'morse' is an alias for the superset of tap dance and tap hold keys,
     /// since their handling have many similarities
     pub fn is_morse(&self) -> bool {
-        matches!(self, KeyAction::TapHold(_, _) | KeyAction::TapDance(_))
+        matches!(self, KeyAction::TapHold(_, _) | KeyAction::Morse(_))
     }
 }
 

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -10,8 +10,8 @@ use macro_config::KeyboardMacrosConfig;
 
 use crate::combo::Combo;
 use crate::fork::Fork;
-use crate::tap_dance::{TapDance, TapHoldMode};
-use crate::{COMBO_MAX_NUM, FORK_MAX_NUM, TAP_DANCE_MAX_NUM};
+use crate::morse::{Morse, MorseMode};
+use crate::{COMBO_MAX_NUM, FORK_MAX_NUM, MORSE_MAX_NUM};
 
 /// Internal configurations for RMK keyboard.
 #[derive(Default)]
@@ -33,7 +33,7 @@ pub struct BehaviorConfig {
     pub one_shot: OneShotConfig,
     pub combo: CombosConfig,
     pub fork: ForksConfig,
-    pub tap_dance: TapDancesConfig,
+    pub morse: MorsesConfig,
     pub keyboard_macros: KeyboardMacrosConfig,
     pub mouse_key: MouseKeyConfig,
 }
@@ -55,15 +55,15 @@ impl Default for TapConfig {
     }
 }
 
-/// Configuration for tap dance behavior
+/// Configuration for morse behavior
 #[derive(Clone, Debug)]
-pub struct TapDancesConfig {
-    pub tap_dances: Vec<TapDance, TAP_DANCE_MAX_NUM>,
+pub struct MorsesConfig {
+    pub morses: Vec<Morse, MORSE_MAX_NUM>,
 }
 
-impl Default for TapDancesConfig {
+impl Default for MorsesConfig {
     fn default() -> Self {
-        Self { tap_dances: Vec::new() }
+        Self { morses: Vec::new() }
     }
 }
 
@@ -75,7 +75,7 @@ pub struct TapHoldConfig {
     /// Default timeout time for tap or hold
     pub timeout: Duration,
     /// Default mode
-    pub mode: TapHoldMode,
+    pub mode: MorseMode,
     /// If the previous key is on the same "hand", the current key will be determined as a tap
     pub unilateral_tap: bool,
 }
@@ -85,7 +85,7 @@ impl Default for TapHoldConfig {
         Self {
             enable_hrm: false,
             unilateral_tap: false,
-            mode: TapHoldMode::Normal,
+            mode: MorseMode::Normal,
             prior_idle_time: Duration::from_millis(120),
             timeout: Duration::from_millis(250),
         }

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -29,9 +29,9 @@ use crate::keyboard_macros::MacroOperation;
 use crate::keycode::{KeyCode, ModifierCombination};
 use crate::keymap::KeyMap;
 use crate::light::LedIndicator;
+use crate::morse::{MorseMode, MorsePattern, TAP};
 #[cfg(all(feature = "split", feature = "_ble"))]
 use crate::split::ble::central::update_activity_time;
-use crate::tap_dance::{MorsePattern, TAP, TapHoldMode};
 use crate::{FORK_MAX_NUM, boot};
 
 pub(crate) mod combo;
@@ -582,7 +582,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
                                         held_key.state = KeyState::ProcessedButReleaseNotReportedYet(action);
                                     }
                                 }
-                                _ => {} // For tap-dance, the releasing will not be processed immediately, so just ignore it
+                                _ => {} // For morse, the releasing will not be processed immediately, so just ignore it
                             }
                             // Push back after triggered hold
                             self.held_buffer.push_without_sort(held_key);
@@ -679,11 +679,11 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
 
                         // Check morse key mode
                         match tap_hold_mode {
-                            TapHoldMode::PermissiveHold => {
+                            MorseMode::PermissiveHold => {
                                 // Permissive hold mode checks key releases, so push current key press into buffer.
                                 decision_for_current_key = KeyBehaviorDecision::Buffer;
                             }
-                            TapHoldMode::HoldOnOtherPress => {
+                            MorseMode::HoldOnOtherPress => {
                                 debug!(
                                     "Trigger morse key due to hold on other key press: {:?}",
                                     held_key.action
@@ -709,7 +709,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
 
                         // The current key is being released, check only the held key in permissive hold mode
                         if decision_for_current_key != KeyBehaviorDecision::Release
-                            && tap_hold_mode == TapHoldMode::PermissiveHold
+                            && tap_hold_mode == MorseMode::PermissiveHold
                         {
                             debug!("Permissive hold!");
                             // Check first current releasing key is in the buffer, AND after the current key

--- a/rmk/src/keyboard/held_buffer.rs
+++ b/rmk/src/keyboard/held_buffer.rs
@@ -2,7 +2,7 @@ use embassy_time::Instant;
 
 use crate::action::{Action, KeyAction};
 use crate::event::{KeyboardEvent, KeyboardEventPos};
-use crate::tap_dance::MorsePattern;
+use crate::morse::MorsePattern;
 
 /// The buffer of held keys.
 #[derive(Debug, Default, Clone)]

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -73,7 +73,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
         _reorder_combos(&mut behavior.combo.combos);
 
         fill_vec(&mut behavior.fork.forks); // Is this needed? (has no Vial support)
-        fill_vec(&mut behavior.tap_dance.tap_dances);
+        fill_vec(&mut behavior.morse.morses);
 
         KeyMap {
             layers: action_map,
@@ -99,7 +99,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
         // If the storage is initialized, read keymap from storage
         fill_vec(&mut behavior.combo.combos);
         fill_vec(&mut behavior.fork.forks); // Is this needed? (has no Vial support)
-        fill_vec(&mut behavior.tap_dance.tap_dances);
+        fill_vec(&mut behavior.morse.morses);
 
         if let Some(storage) = storage {
             if {
@@ -118,8 +118,8 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
                     .and(storage.read_combos(&mut behavior.combo.combos).await)
                     // Read fork cache
                     .and(storage.read_forks(&mut behavior.fork.forks).await)
-                    // Read tap dance cache
-                    .and(storage.read_tap_dances(&mut behavior.tap_dance.tap_dances).await)
+                    // Read morse cache
+                    .and(storage.read_morses(&mut behavior.morse.morses).await)
             }
             .is_err()
             {

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -163,10 +163,18 @@ macro_rules! encoder {
     };
 }
 
-/// Create a tap dance action
+/// Create a morse(tap dance) action
 #[macro_export]
 macro_rules! td {
     ($index: literal) => {
-        $crate::action::KeyAction::TapDance($index)
+        $crate::action::KeyAction::Morse($index)
+    };
+}
+
+/// Create a morse(tap dance) action
+#[macro_export]
+macro_rules! morse {
+    ($index: literal) => {
+        $crate::action::KeyAction::Morse($index)
     };
 }

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -163,7 +163,7 @@ macro_rules! encoder {
     };
 }
 
-/// Create a morse(tap dance) action
+/// Create a Morse(index) action (in Vial its simplest form is known as "Tap Dance", so `td` name is used)
 #[macro_export]
 macro_rules! td {
     ($index: literal) => {
@@ -171,7 +171,7 @@ macro_rules! td {
     };
 }
 
-/// Create a morse(tap dance) action
+/// Create a Morse(index) action (in Vial it will appear as "Tap Dance")
 #[macro_export]
 macro_rules! morse {
     ($index: literal) => {

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -95,12 +95,12 @@ pub mod keymap;
 pub mod layout_macro;
 pub mod light;
 pub mod matrix;
+pub mod morse;
 #[cfg(feature = "split")]
 pub mod split;
 pub mod state;
 #[cfg(feature = "storage")]
 pub mod storage;
-pub mod tap_dance;
 #[cfg(not(feature = "_no_usb"))]
 pub mod usb;
 pub mod via;

--- a/rmk/src/morse.rs
+++ b/rmk/src/morse.rs
@@ -65,39 +65,38 @@ impl MorsePattern {
     }
 }
 
-/// Definition of a tap dance key.
+/// Definition of a morse key.
 ///
-/// A tap dance key is a key that behaves differently according to the pattern of a tap/hold sequence.
+/// A morse key is a key that behaves differently according to the pattern of a tap/hold sequence.
 /// The maximum number of taps is limited to 15 by the internal u16 representation of MorsePattern.
-/// There is a lists of (pattern, corresponding action) pairs for each tap_dance key:
+/// There is a lists of (pattern, corresponding action) pairs for each morse key:
 /// The number of pairs is limited by MAX_PATTERNS_PER_KEY, which is a const generic parameter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TapDance {
+pub struct Morse {
     /// The timeout time for each operation in milliseconds
     pub timeout_ms: u16,
     /// The decision mode of the morse key
-    pub mode: TapHoldMode,
+    pub mode: MorseMode,
     /// If the unilateral tap is enabled
     pub unilateral_tap: bool,
-
     /// The list of pattern -> action pairs, which can be triggered
     pub actions: Vec<(MorsePattern, Action), MAX_PATTERNS_PER_KEY>,
     //TODO: introduce settings to set gap and hold timeout separately
 }
 
-impl Default for TapDance {
+impl Default for Morse {
     fn default() -> Self {
         Self {
             timeout_ms: 250,
-            mode: TapHoldMode::HoldOnOtherPress,
+            mode: MorseMode::HoldOnOtherPress,
             unilateral_tap: false,
             actions: Vec::default(),
         }
     }
 }
 
-impl TapDance {
+impl Morse {
     pub fn new_from_vial(tap: Action, hold: Action, hold_after_tap: Action, double_tap: Action, timeout: u16) -> Self {
         let mut result = Self::default();
         if tap != Action::No {
@@ -116,8 +115,8 @@ impl TapDance {
         result
     }
 
-    /// Create a new tap dance with custom actions for each tap count
-    /// This allows for more flexible tap dance configurations
+    /// Create a new morse with custom actions for each tap count
+    /// This allows for more flexible morse configurations
     pub fn new_with_actions(
         tap_actions: Vec<Action, MAX_PATTERNS_PER_KEY>,
         hold_actions: Vec<Action, MAX_PATTERNS_PER_KEY>,
@@ -221,7 +220,7 @@ impl TapDance {
 /// Mode for morse key behavior
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum TapHoldMode {
+pub enum MorseMode {
     /// Normal mode, the decision is made when timeout
     Normal,
     /// Same as QMK's permissive hold: https://docs.qmk.fm/tap_hold#tap-or-hold-decision-modes

--- a/rmk/src/storage/mod.rs
+++ b/rmk/src/storage/mod.rs
@@ -27,11 +27,11 @@ use crate::config::{self, StorageConfig};
 use crate::fork::{Fork, StateBits};
 use crate::hid_state::{HidModifiers, HidMouseButtons};
 use crate::light::LedIndicator;
+use crate::morse::{Morse, MorseMode, MorsePattern};
 #[cfg(all(feature = "_ble", feature = "split"))]
 use crate::split::ble::PeerAddress;
-use crate::tap_dance::{MorsePattern, TapDance, TapHoldMode};
 use crate::via::keycode_convert::{from_via_keycode, to_via_keycode};
-use crate::{BUILD_HASH, COMBO_MAX_LENGTH, COMBO_MAX_NUM, FORK_MAX_NUM, MACRO_SPACE_SIZE, TAP_DANCE_MAX_NUM};
+use crate::{BUILD_HASH, COMBO_MAX_LENGTH, COMBO_MAX_NUM, FORK_MAX_NUM, MACRO_SPACE_SIZE, MORSE_MAX_NUM};
 
 /// Signal to synchronize the flash operation status, usually used outside of the flash task.
 /// True if the flash operation is finished correctly, false if the flash operation is finished with error.
@@ -79,8 +79,8 @@ pub(crate) enum FlashOperationMessage {
     WriteCombo(ComboData),
     // Write fork
     WriteFork(ForkData),
-    // Write tap dance config
-    WriteTapDance(u8, TapDance),
+    // Write morse config
+    WriteMorse(u8, Morse),
     // Timeout time for morse keys
     MorseTimeout(u16),
     // Timeout time for combos
@@ -112,7 +112,7 @@ pub(crate) enum StorageKeys {
     ConnectionType = 6,
     EncoderKeys = 7,
     ForkData = 8,
-    TapDanceData = 9,
+    MorseData = 9,
     #[cfg(all(feature = "_ble", feature = "split"))]
     PeerAddress = 0xED,
     #[cfg(feature = "_ble")]
@@ -133,7 +133,7 @@ impl StorageKeys {
             6 => Some(StorageKeys::ConnectionType),
             7 => Some(StorageKeys::EncoderKeys),
             8 => Some(StorageKeys::ForkData),
-            9 => Some(StorageKeys::TapDanceData),
+            9 => Some(StorageKeys::MorseData),
             #[cfg(all(feature = "_ble", feature = "split"))]
             0xED => Some(StorageKeys::PeerAddress),
             #[cfg(feature = "_ble")]
@@ -157,7 +157,7 @@ pub(crate) enum StorageData {
     ComboData(ComboData),
     ConnectionType(u8),
     ForkData(ForkData),
-    TapDanceData(TapDance),
+    MorseData(Morse),
     #[cfg(all(feature = "_ble", feature = "split"))]
     PeerAddress(PeerAddress),
     #[cfg(feature = "_ble")]
@@ -199,8 +199,8 @@ pub(crate) fn get_peer_address_key(peer_id: u8) -> u32 {
     0x6000 + peer_id as u32
 }
 
-/// Get the key to retrieve the tap dance from the storage.
-pub(crate) fn get_tap_dance_key(idx: u8) -> u32 {
+/// Get the key to retrieve the morse key from the storage.
+pub(crate) fn get_morse_key(idx: u8) -> u32 {
     0x7000 + idx as u32
 }
 
@@ -320,27 +320,27 @@ impl Value<'_> for StorageData {
                 );
                 Ok(15)
             }
-            StorageData::TapDanceData(tap_dance) => {
-                let total_size = 6 + 4 * tap_dance.actions.len();
+            StorageData::MorseData(morse) => {
+                let total_size = 6 + 4 * morse.actions.len();
                 if buffer.len() < total_size {
                     return Err(SerializationError::BufferTooSmall);
                 }
-                buffer[0] = StorageKeys::TapDanceData as u8;
-                BigEndian::write_u16(&mut buffer[1..3], tap_dance.actions.len() as u16);
-                BigEndian::write_u16(&mut buffer[3..5], tap_dance.timeout_ms);
+                buffer[0] = StorageKeys::MorseData as u8;
+                BigEndian::write_u16(&mut buffer[1..3], morse.actions.len() as u16);
+                BigEndian::write_u16(&mut buffer[3..5], morse.timeout_ms);
 
-                let mut flags = match tap_dance.mode {
-                    TapHoldMode::Normal => 0,
-                    TapHoldMode::PermissiveHold => 1,
-                    TapHoldMode::HoldOnOtherPress => 2,
+                let mut flags = match morse.mode {
+                    MorseMode::Normal => 0,
+                    MorseMode::PermissiveHold => 1,
+                    MorseMode::HoldOnOtherPress => 2,
                 };
-                if tap_dance.unilateral_tap {
+                if morse.unilateral_tap {
                     flags |= 0x10;
                 }
                 buffer[5] = flags;
 
                 let mut i = 6;
-                for (pattern, action) in &tap_dance.actions {
+                for (pattern, action) in &morse.actions {
                     BigEndian::write_u16(
                         &mut buffer[i..i + 2],
                         pattern.to_u16(), //pattern
@@ -557,7 +557,7 @@ impl Value<'_> for StorageData {
                         ),
                     }))
                 }
-                StorageKeys::TapDanceData => {
+                StorageKeys::MorseData => {
                     if buffer.len() < 6 {
                         return Err(SerializationError::InvalidData);
                     }
@@ -567,27 +567,27 @@ impl Value<'_> for StorageData {
                         return Err(SerializationError::InvalidData);
                     }
 
-                    let mut tap_dance = TapDance::default();
-                    tap_dance.timeout_ms = BigEndian::read_u16(&buffer[3..5]);
+                    let mut morse = Morse::default();
+                    morse.timeout_ms = BigEndian::read_u16(&buffer[3..5]);
 
                     let flags = buffer[5];
                     match flags & 0x0F {
-                        0 => tap_dance.mode = TapHoldMode::Normal,
-                        1 => tap_dance.mode = TapHoldMode::PermissiveHold,
-                        2 => tap_dance.mode = TapHoldMode::HoldOnOtherPress,
+                        0 => morse.mode = MorseMode::Normal,
+                        1 => morse.mode = MorseMode::PermissiveHold,
+                        2 => morse.mode = MorseMode::HoldOnOtherPress,
                         _ => {}
                     }
-                    tap_dance.unilateral_tap = flags & 0x10 != 0;
+                    morse.unilateral_tap = flags & 0x10 != 0;
 
                     let mut i = 6;
                     for _ in 0..count {
                         let pattern = MorsePattern::from_u16(BigEndian::read_u16(&buffer[i..i + 2]));
                         let key_action = from_via_keycode(BigEndian::read_u16(&buffer[i + 2..i + 4]));
-                        _ = tap_dance.actions.push((pattern, key_action.to_action()));
+                        _ = morse.actions.push((pattern, key_action.to_action()));
                         i += 4;
                     }
 
-                    Ok(StorageData::TapDanceData(tap_dance))
+                    Ok(StorageData::MorseData(morse))
                 }
                 #[cfg(all(feature = "_ble", feature = "split"))]
                 StorageKeys::PeerAddress => {
@@ -679,8 +679,8 @@ impl StorageData {
             StorageData::ForkData(_) => {
                 panic!("To get fork key for ForkData, use `get_fork_key` instead");
             }
-            StorageData::TapDanceData(_) => {
-                panic!("To get tap dance key for TapDanceData, use `get_tap_dance_key` instead");
+            StorageData::MorseData(_) => {
+                panic!("To get morse key for MorseData, use `get_morse_key` instead");
             }
             #[cfg(all(feature = "_ble", feature = "split"))]
             StorageData::PeerAddress(p) => get_peer_address_key(p.peer_id),
@@ -1010,15 +1010,15 @@ impl<F: AsyncNorFlash, const ROW: usize, const COL: usize, const NUM_LAYER: usiz
                     )
                     .await
                 }
-                FlashOperationMessage::WriteTapDance(id, tap_dance) => {
-                    let key = get_tap_dance_key(id);
+                FlashOperationMessage::WriteMorse(id, morse) => {
+                    let key = get_morse_key(id);
                     store_item(
                         &mut self.flash,
                         self.storage_range.clone(),
                         &mut storage_cache,
                         &mut self.buffer,
                         &key,
-                        &StorageData::TapDanceData(tap_dance),
+                        &StorageData::MorseData(morse),
                     )
                     .await
                 }
@@ -1258,12 +1258,9 @@ impl<F: AsyncNorFlash, const ROW: usize, const COL: usize, const NUM_LAYER: usiz
         Ok(())
     }
 
-    pub(crate) async fn read_tap_dances(
-        &mut self,
-        tap_dances: &mut Vec<TapDance, TAP_DANCE_MAX_NUM>,
-    ) -> Result<(), ()> {
-        for (i, item) in tap_dances.iter_mut().enumerate() {
-            let key = get_tap_dance_key(i as u8);
+    pub(crate) async fn read_morses(&mut self, morses: &mut Vec<Morse, MORSE_MAX_NUM>) -> Result<(), ()> {
+        for (i, item) in morses.iter_mut().enumerate() {
+            let key = get_morse_key(i as u8);
             let read_data = fetch_item::<u32, StorageData, _>(
                 &mut self.flash,
                 self.storage_range.clone(),
@@ -1274,8 +1271,8 @@ impl<F: AsyncNorFlash, const ROW: usize, const COL: usize, const NUM_LAYER: usiz
             .await
             .map_err(|e| print_storage_error::<F>(e))?;
 
-            if let Some(StorageData::TapDanceData(tap_dance)) = read_data {
-                *item = tap_dance;
+            if let Some(StorageData::MorseData(morse)) = read_data {
+                *item = morse;
             }
         }
 
@@ -1550,11 +1547,11 @@ mod tests {
     use super::*;
     use crate::action::Action;
     use crate::keycode::KeyCode;
-    use crate::tap_dance::{HOLD, TAP, TapHoldMode};
+    use crate::morse::{HOLD, MorseMode, TAP};
 
     #[test]
-    fn test_tap_dance_serialization_deserialization() {
-        let tap_dance = TapDance::new_from_vial(
+    fn test_morse_serialization_deserialization() {
+        let morse = Morse::new_from_vial(
             Action::Key(KeyCode::A),
             Action::Key(KeyCode::B),
             Action::Key(KeyCode::C),
@@ -1564,7 +1561,7 @@ mod tests {
 
         // Serialization
         let mut buffer = [0u8; 6 + 4 * 4];
-        let storage_data = StorageData::TapDanceData(tap_dance.clone());
+        let storage_data = StorageData::MorseData(morse.clone());
         let serialized_size = Value::serialize_into(&storage_data, &mut buffer).unwrap();
 
         // Deserialization
@@ -1572,34 +1569,34 @@ mod tests {
 
         // Validation
         match deserialized_data {
-            StorageData::TapDanceData(deserialized_tap_dance) => {
-                assert_eq!(deserialized_tap_dance.timeout_ms, tap_dance.timeout_ms);
-                assert_eq!(deserialized_tap_dance.mode, tap_dance.mode);
-                assert_eq!(deserialized_tap_dance.unilateral_tap, tap_dance.unilateral_tap);
+            StorageData::MorseData(deserialized_morse) => {
+                assert_eq!(deserialized_morse.timeout_ms, morse.timeout_ms);
+                assert_eq!(deserialized_morse.mode, morse.mode);
+                assert_eq!(deserialized_morse.unilateral_tap, morse.unilateral_tap);
 
                 // actions
-                assert_eq!(deserialized_tap_dance.actions.len(), tap_dance.actions.len());
-                for (original, deserialized) in tap_dance.actions.iter().zip(deserialized_tap_dance.actions.iter()) {
+                assert_eq!(deserialized_morse.actions.len(), morse.actions.len());
+                for (original, deserialized) in morse.actions.iter().zip(deserialized_morse.actions.iter()) {
                     assert_eq!(original, deserialized);
                 }
             }
-            _ => panic!("Expected TapDanceData"),
+            _ => panic!("Expected MorseData"),
         }
     }
 
     #[test]
-    fn test_tap_dance_with_partial_actions() {
-        // Create a TapDance with partial actions
-        let mut tap_dance: TapDance = TapDance::default();
-        _ = tap_dance.put(TAP, Action::Key(KeyCode::A));
-        _ = tap_dance.put(HOLD, Action::Key(KeyCode::B));
-        tap_dance.timeout_ms = 150;
-        tap_dance.unilateral_tap = true;
-        tap_dance.mode = TapHoldMode::PermissiveHold;
+    fn test_morse_with_partial_actions() {
+        // Create a Morse with partial actions
+        let mut morse: Morse = Morse::default();
+        _ = morse.put(TAP, Action::Key(KeyCode::A));
+        _ = morse.put(HOLD, Action::Key(KeyCode::B));
+        morse.timeout_ms = 150;
+        morse.unilateral_tap = true;
+        morse.mode = MorseMode::PermissiveHold;
 
         // Serialization
         let mut buffer = [0u8; 6 + 4 * 4];
-        let storage_data = StorageData::TapDanceData(tap_dance.clone());
+        let storage_data = StorageData::MorseData(morse.clone());
         let serialized_size = Value::serialize_into(&storage_data, &mut buffer).unwrap();
 
         // Deserialization
@@ -1607,45 +1604,45 @@ mod tests {
 
         // Validation
         match deserialized_data {
-            StorageData::TapDanceData(deserialized_tap_dance) => {
-                assert_eq!(deserialized_tap_dance.timeout_ms, tap_dance.timeout_ms);
-                assert_eq!(deserialized_tap_dance.mode, tap_dance.mode);
-                assert_eq!(deserialized_tap_dance.unilateral_tap, tap_dance.unilateral_tap);
+            StorageData::MorseData(deserialized_morse) => {
+                assert_eq!(deserialized_morse.timeout_ms, morse.timeout_ms);
+                assert_eq!(deserialized_morse.mode, morse.mode);
+                assert_eq!(deserialized_morse.unilateral_tap, morse.unilateral_tap);
 
                 // actions
-                assert_eq!(deserialized_tap_dance.actions.len(), tap_dance.actions.len());
-                for (original, deserialized) in tap_dance.actions.iter().zip(deserialized_tap_dance.actions.iter()) {
+                assert_eq!(deserialized_morse.actions.len(), morse.actions.len());
+                for (original, deserialized) in morse.actions.iter().zip(deserialized_morse.actions.iter()) {
                     assert_eq!(original, deserialized);
                 }
             }
-            _ => panic!("Expected TapDanceData"),
+            _ => panic!("Expected MorseData"),
         }
     }
 
     #[test]
-    fn test_tap_dance_with_morse_serialization_deserialization() {
-        let mut tap_dance = TapDance {
+    fn test_morse_with_morse_serialization_deserialization() {
+        let mut morse = Morse {
             timeout_ms: 200,
-            mode: TapHoldMode::Normal,
+            mode: MorseMode::Normal,
             unilateral_tap: true,
             actions: Vec::default(),
         };
-        tap_dance
+        morse
             .actions
             .push((MorsePattern::from_u16(0b1_01), Action::Key(KeyCode::A)))
             .ok();
-        tap_dance
+        morse
             .actions
             .push((MorsePattern::from_u16(0b1_1000), Action::Key(KeyCode::B)))
             .ok();
-        tap_dance
+        morse
             .actions
             .push((MorsePattern::from_u16(0b1_1010), Action::Key(KeyCode::C)))
             .ok();
 
         // Serialization
         let mut buffer = [0u8; 6 + 3 * 4];
-        let storage_data = StorageData::TapDanceData(tap_dance.clone());
+        let storage_data = StorageData::MorseData(morse.clone());
         let serialized_size = Value::serialize_into(&storage_data, &mut buffer).unwrap();
 
         // Deserialization
@@ -1653,18 +1650,18 @@ mod tests {
 
         // Validation
         match deserialized_data {
-            StorageData::TapDanceData(deserialized_tap_dance) => {
-                assert_eq!(deserialized_tap_dance.timeout_ms, tap_dance.timeout_ms);
-                assert_eq!(deserialized_tap_dance.mode, tap_dance.mode);
-                assert_eq!(deserialized_tap_dance.unilateral_tap, tap_dance.unilateral_tap);
+            StorageData::MorseData(deserialized_morse) => {
+                assert_eq!(deserialized_morse.timeout_ms, morse.timeout_ms);
+                assert_eq!(deserialized_morse.mode, morse.mode);
+                assert_eq!(deserialized_morse.unilateral_tap, morse.unilateral_tap);
 
                 // actions
-                assert_eq!(deserialized_tap_dance.actions.len(), tap_dance.actions.len());
-                for (original, deserialized) in tap_dance.actions.iter().zip(deserialized_tap_dance.actions.iter()) {
+                assert_eq!(deserialized_morse.actions.len(), morse.actions.len());
+                for (original, deserialized) in morse.actions.iter().zip(deserialized_morse.actions.iter()) {
                     assert_eq!(original, deserialized);
                 }
             }
-            _ => panic!("Expected TapDanceData"),
+            _ => panic!("Expected MorseData"),
         }
     }
 }

--- a/rmk/src/via/keycode_convert.rs
+++ b/rmk/src/via/keycode_convert.rs
@@ -72,7 +72,7 @@ pub(crate) fn to_via_keycode(key_action: KeyAction) -> u16 {
             }
             _ => 0x0000,
         },
-        KeyAction::TapDance(index) => {
+        KeyAction::Morse(index) => {
             // Tap dance keycodes: 0x5700..=0x57FF
             0x5700 | (index as u16)
         }
@@ -144,7 +144,7 @@ pub(crate) fn from_via_keycode(via_keycode: u16) -> KeyAction {
         0x5700..=0x57FF => {
             // Tap dance
             let index = (via_keycode & 0xFF) as u8;
-            KeyAction::TapDance(index)
+            KeyAction::Morse(index)
         }
         0x7000..=0x701F => {
             // TODO: QMK functions, such as swap ctrl/caps, gui on, haptic, music, clicky, combo, RGB, etc
@@ -568,17 +568,17 @@ mod test {
             from_via_keycode(via_keycode)
         );
 
-        // TapDance(0)
+        // Morse(0)
         let via_keycode = 0x5700;
-        assert_eq!(KeyAction::TapDance(0), from_via_keycode(via_keycode));
+        assert_eq!(KeyAction::Morse(0), from_via_keycode(via_keycode));
 
-        // TapDance(5)
+        // Morse(5)
         let via_keycode = 0x5705;
-        assert_eq!(KeyAction::TapDance(5), from_via_keycode(via_keycode));
+        assert_eq!(KeyAction::Morse(5), from_via_keycode(via_keycode));
 
-        // TapDance(255)
+        // Morse(255)
         let via_keycode = 0x57FF;
-        assert_eq!(KeyAction::TapDance(255), from_via_keycode(via_keycode));
+        assert_eq!(KeyAction::Morse(255), from_via_keycode(via_keycode));
     }
 
     #[test]
@@ -681,14 +681,14 @@ mod test {
         let a = KeyAction::Single(Action::Key(KeyCode::RepeatKey));
         assert_eq!(0x7C79, to_via_keycode(a));
 
-        // TapDance
-        let a = KeyAction::TapDance(0);
+        // Morse
+        let a = KeyAction::Morse(0);
         assert_eq!(0x5700, to_via_keycode(a));
 
-        let a = KeyAction::TapDance(5);
+        let a = KeyAction::Morse(5);
         assert_eq!(0x5705, to_via_keycode(a));
 
-        let a = KeyAction::TapDance(255);
+        let a = KeyAction::Morse(255);
         assert_eq!(0x57FF, to_via_keycode(a));
     }
 

--- a/rmk/src/via/vial.rs
+++ b/rmk/src/via/vial.rs
@@ -344,7 +344,7 @@ pub(crate) async fn process_vial<
                     if morse_idx < morses.len() {
                         // Update the morse in keymap
                         if let Some(morse) = morses.get_mut(morse_idx) {
-                            // Extract morse(tap dance) data from report
+                            // Extract morse (also known as "tap dance" in vial)
                             let tap = from_via_keycode(LittleEndian::read_u16(&report.output_data[4..6]));
                             let hold = from_via_keycode(LittleEndian::read_u16(&report.output_data[6..8]));
                             let double_tap = from_via_keycode(LittleEndian::read_u16(&report.output_data[8..10]));

--- a/rmk/src/via/vial.rs
+++ b/rmk/src/via/vial.rs
@@ -9,7 +9,7 @@ use crate::combo::Combo;
 use crate::config::VialConfig;
 use crate::descriptor::ViaReport;
 use crate::keymap::KeyMap;
-use crate::tap_dance::{DOUBLE_TAP, HOLD, HOLD_AFTER_TAP, TAP};
+use crate::morse::{DOUBLE_TAP, HOLD, HOLD_AFTER_TAP, TAP};
 use crate::via::keycode_convert::{from_via_keycode, to_via_keycode};
 #[cfg(feature = "storage")]
 use crate::{
@@ -17,7 +17,7 @@ use crate::{
     channel::FLASH_CHANNEL,
     storage::{ComboData, FlashOperationMessage},
 };
-use crate::{COMBO_MAX_NUM, TAP_DANCE_MAX_NUM};
+use crate::{COMBO_MAX_NUM, MORSE_MAX_NUM};
 
 /// Vial communication commands.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, FromPrimitive)]
@@ -63,8 +63,8 @@ pub(crate) enum SettingKey {
 #[repr(u8)]
 pub(crate) enum VialDynamic {
     DynamicVialGetNumberOfEntries = 0x00,
-    DynamicVialTapDanceGet = 0x01,
-    DynamicVialTapDanceSet = 0x02,
+    DynamicVialMorseGet = 0x01,
+    DynamicVialMorseSet = 0x02,
     DynamicVialComboGet = 0x03,
     DynamicVialComboSet = 0x04,
     DynamicVialKeyOverrideGet = 0x05,
@@ -295,80 +295,73 @@ pub(crate) async fn process_vial<
             match vial_dynamic {
                 VialDynamic::DynamicVialGetNumberOfEntries => {
                     debug!("DynamicEntryOp - DynamicVialGetNumberOfEntries");
-                    report.input_data[0] = core::cmp::min(TAP_DANCE_MAX_NUM, 255) as u8; // Tap dance entries
+                    report.input_data[0] = core::cmp::min(MORSE_MAX_NUM, 255) as u8; // Tap dance entries
                     report.input_data[1] = core::cmp::min(COMBO_MAX_NUM, 255) as u8; // Combo entries
                     // TODO: Support dynamic key override
                     report.input_data[2] = 0; // Key override entries
                     report.input_data[31] = 1 // Enable caps word
                 }
-                VialDynamic::DynamicVialTapDanceGet => {
-                    debug!("DynamicEntryOp - DynamicVialTapDanceGet");
+                VialDynamic::DynamicVialMorseGet => {
+                    debug!("DynamicEntryOp - DynamicVialMorseGet");
                     report.input_data[0] = 0; // Index 0 is the return code, 0 means success
 
-                    let tap_dance_idx = report.output_data[3] as usize;
-                    let tap_dances = &keymap.borrow().behavior.tap_dance.tap_dances;
-                    if let Some(tap_dance) = tap_dances.get(tap_dance_idx) {
-                        // Pack tap dance data into report
+                    let morse_idx = report.output_data[3] as usize;
+                    let morses = &keymap.borrow().behavior.morse.morses;
+                    if let Some(morse) = morses.get(morse_idx) {
+                        // Pack morse data into report
                         LittleEndian::write_u16(
                             &mut report.input_data[1..3],
-                            to_via_keycode(tap_dance.get(TAP).map_or(KeyAction::No, |a| KeyAction::Single(a))),
+                            to_via_keycode(morse.get(TAP).map_or(KeyAction::No, |a| KeyAction::Single(a))),
                         );
                         LittleEndian::write_u16(
                             &mut report.input_data[3..5],
-                            to_via_keycode(
-                                tap_dance
-                                    .get(DOUBLE_TAP)
-                                    .map_or(KeyAction::No, |a| KeyAction::Single(a)),
-                            ),
+                            to_via_keycode(morse.get(DOUBLE_TAP).map_or(KeyAction::No, |a| KeyAction::Single(a))),
                         );
                         LittleEndian::write_u16(
                             &mut report.input_data[5..7],
-                            to_via_keycode(tap_dance.get(HOLD).map_or(KeyAction::No, |a| KeyAction::Single(a))),
+                            to_via_keycode(morse.get(HOLD).map_or(KeyAction::No, |a| KeyAction::Single(a))),
                         );
                         LittleEndian::write_u16(
                             &mut report.input_data[7..9],
                             to_via_keycode(
-                                tap_dance
+                                morse
                                     .get(HOLD_AFTER_TAP)
                                     .map_or(KeyAction::No, |a| KeyAction::Single(a)),
                             ),
                         );
-                        LittleEndian::write_u16(&mut report.input_data[9..11], tap_dance.timeout_ms);
+                        LittleEndian::write_u16(&mut report.input_data[9..11], morse.timeout_ms);
                     } else {
                         report.input_data[1..11].fill(0);
                     }
                 }
-                VialDynamic::DynamicVialTapDanceSet => {
-                    debug!("DynamicEntryOp - DynamicVialTapDanceSet");
+                VialDynamic::DynamicVialMorseSet => {
+                    debug!("DynamicEntryOp - DynamicVialMorseSet");
                     report.input_data[0] = 0; // Index 0 is the return code, 0 means success
 
-                    let tap_dance_idx = report.output_data[3] as usize;
-                    let tap_dances = &mut keymap.borrow_mut().behavior.tap_dance.tap_dances;
+                    let morse_idx = report.output_data[3] as usize;
+                    let morses = &mut keymap.borrow_mut().behavior.morse.morses;
 
-                    if tap_dance_idx < tap_dances.len() {
-                        // Update the tap dance in keymap
-                        if let Some(tap_dance) = tap_dances.get_mut(tap_dance_idx) {
-                            // Extract tap dance data from report
+                    if morse_idx < morses.len() {
+                        // Update the morse in keymap
+                        if let Some(morse) = morses.get_mut(morse_idx) {
+                            // Extract morse(tap dance) data from report
                             let tap = from_via_keycode(LittleEndian::read_u16(&report.output_data[4..6]));
                             let hold = from_via_keycode(LittleEndian::read_u16(&report.output_data[6..8]));
                             let double_tap = from_via_keycode(LittleEndian::read_u16(&report.output_data[8..10]));
                             let hold_after_tap = from_via_keycode(LittleEndian::read_u16(&report.output_data[10..12]));
                             let timeout_ms = LittleEndian::read_u16(&report.output_data[12..14]);
 
-                            tap_dance.put(TAP, tap.to_action());
-                            tap_dance.put(DOUBLE_TAP, double_tap.to_action());
-                            tap_dance.put(HOLD, hold.to_action());
-                            tap_dance.put(HOLD_AFTER_TAP, hold_after_tap.to_action());
-                            tap_dance.timeout_ms = timeout_ms;
+                            morse.put(TAP, tap.to_action());
+                            morse.put(DOUBLE_TAP, double_tap.to_action());
+                            morse.put(HOLD, hold.to_action());
+                            morse.put(HOLD_AFTER_TAP, hold_after_tap.to_action());
+                            morse.timeout_ms = timeout_ms;
 
                             #[cfg(feature = "storage")]
                             {
                                 // Save to storage
                                 FLASH_CHANNEL
-                                    .send(FlashOperationMessage::WriteTapDance(
-                                        tap_dance_idx as u8,
-                                        tap_dance.clone(),
-                                    ))
+                                    .send(FlashOperationMessage::WriteMorse(morse_idx as u8, morse.clone()))
                                     .await;
                             }
                         }

--- a/rmk/tests/common/morse.rs
+++ b/rmk/tests/common/morse.rs
@@ -1,9 +1,9 @@
 use heapless::Vec;
 use rmk::action::Action;
-use rmk::config::{BehaviorConfig, TapDancesConfig};
+use rmk::config::{BehaviorConfig, MorsesConfig};
 use rmk::keyboard::Keyboard;
 use rmk::keycode::{KeyCode, ModifierCombination};
-use rmk::tap_dance::{MorsePattern, TapDance};
+use rmk::morse::{Morse, MorsePattern};
 use rmk::{k, lt, mt, td};
 
 use crate::common::wrap_keymap;
@@ -20,7 +20,7 @@ pub fn create_simple_morse_keyboard(behavior_config: BehaviorConfig) -> Keyboard
         [[k!(Kp1), k!(Kp2), k!(Kp3), k!(Kp4), k!(Kp5)]],
     ];
 
-    let morse0 = TapDance {
+    let morse0 = Morse {
         actions: Vec::from_slice(&[
             (MorsePattern::from_u16(0b1_01), Action::Key(KeyCode::A)),
             (MorsePattern::from_u16(0b1_1000), Action::Key(KeyCode::B)),
@@ -36,8 +36,8 @@ pub fn create_simple_morse_keyboard(behavior_config: BehaviorConfig) -> Keyboard
     };
 
     let behavior_config = BehaviorConfig {
-        tap_dance: TapDancesConfig {
-            tap_dances: Vec::from_slice(&[morse0]).unwrap(),
+        morse: MorsesConfig {
+            morses: Vec::from_slice(&[morse0]).unwrap(),
         },
         ..behavior_config
     };

--- a/rmk/tests/keyboard_combo_test.rs
+++ b/rmk/tests/keyboard_combo_test.rs
@@ -56,7 +56,7 @@ pub fn get_combos_config() -> CombosConfig {
 mod combo_test {
     use rmk::config::{BehaviorConfig, OneShotConfig, TapHoldConfig};
     use rmk::keycode::KeyCode;
-    use rmk::tap_dance::TapHoldMode;
+    use rmk::morse::MorseMode;
     use rmk::th;
     use rusty_fork::rusty_fork_test;
 
@@ -184,7 +184,7 @@ mod combo_test {
                     let behavior_config = BehaviorConfig {
                         tap_hold: TapHoldConfig {
                             enable_hrm: true,
-                            mode: TapHoldMode::PermissiveHold,
+                            mode: MorseMode::PermissiveHold,
                             unilateral_tap: false,
                             ..TapHoldConfig::default()
                         },

--- a/rmk/tests/keyboard_morse_hold_on_other_press_test.rs
+++ b/rmk/tests/keyboard_morse_hold_on_other_press_test.rs
@@ -7,7 +7,7 @@ use rmk::config::{BehaviorConfig, CombosConfig, TapHoldConfig};
 use rmk::k;
 use rmk::keyboard::Keyboard;
 use rmk::keycode::{KeyCode, ModifierCombination};
-use rmk::tap_dance::TapHoldMode;
+use rmk::morse::MorseMode;
 use rusty_fork::rusty_fork_test;
 
 use crate::common::morse::create_simple_morse_keyboard;
@@ -17,7 +17,7 @@ fn create_hold_on_other_key_press_keyboard() -> Keyboard<'static, 1, 5, 2> {
     create_simple_morse_keyboard(BehaviorConfig {
         tap_hold: TapHoldConfig {
             enable_hrm: false,
-            mode: TapHoldMode::HoldOnOtherPress,
+            mode: MorseMode::HoldOnOtherPress,
             unilateral_tap: false,
             ..TapHoldConfig::default()
         },
@@ -32,7 +32,7 @@ fn create_hold_on_other_key_press_keyboard_with_combo() -> Keyboard<'static, 1, 
     create_simple_morse_keyboard(BehaviorConfig {
         tap_hold: TapHoldConfig {
             enable_hrm: false,
-            mode: TapHoldMode::HoldOnOtherPress,
+            mode: MorseMode::HoldOnOtherPress,
             unilateral_tap: false,
             ..TapHoldConfig::default()
         },

--- a/rmk/tests/keyboard_morse_hrm_test.rs
+++ b/rmk/tests/keyboard_morse_hrm_test.rs
@@ -10,7 +10,7 @@ use rmk::config::{BehaviorConfig, CombosConfig, TapHoldConfig};
 use rmk::k;
 use rmk::keyboard::Keyboard;
 use rmk::keycode::{KeyCode, ModifierCombination};
-use rmk::tap_dance::TapHoldMode;
+use rmk::morse::MorseMode;
 use rusty_fork::rusty_fork_test;
 
 use crate::common::morse::create_simple_morse_keyboard;
@@ -20,7 +20,7 @@ fn create_hrm_keyboard() -> Keyboard<'static, 1, 5, 2> {
     create_simple_morse_keyboard(BehaviorConfig {
         tap_hold: TapHoldConfig {
             enable_hrm: true,
-            mode: TapHoldMode::PermissiveHold,
+            mode: MorseMode::PermissiveHold,
             unilateral_tap: true,
             ..TapHoldConfig::default()
         },
@@ -36,7 +36,7 @@ fn create_hrm_keyboard_with_combo() -> Keyboard<'static, 1, 5, 2> {
     create_simple_morse_keyboard(BehaviorConfig {
         tap_hold: TapHoldConfig {
             enable_hrm: true,
-            mode: TapHoldMode::PermissiveHold,
+            mode: MorseMode::PermissiveHold,
             unilateral_tap: true,
             ..TapHoldConfig::default()
         },

--- a/rmk/tests/keyboard_morse_permissive_hold_test.rs
+++ b/rmk/tests/keyboard_morse_permissive_hold_test.rs
@@ -7,7 +7,7 @@ use rmk::config::{BehaviorConfig, CombosConfig, TapHoldConfig};
 use rmk::k;
 use rmk::keyboard::Keyboard;
 use rmk::keycode::{KeyCode, ModifierCombination};
-use rmk::tap_dance::TapHoldMode;
+use rmk::morse::MorseMode;
 use rusty_fork::rusty_fork_test;
 
 use crate::common::morse::create_simple_morse_keyboard;
@@ -17,7 +17,7 @@ fn create_permissive_hold_keyboard() -> Keyboard<'static, 1, 5, 2> {
     create_simple_morse_keyboard(BehaviorConfig {
         tap_hold: TapHoldConfig {
             enable_hrm: false,
-            mode: TapHoldMode::PermissiveHold,
+            mode: MorseMode::PermissiveHold,
             unilateral_tap: false,
             ..TapHoldConfig::default()
         },
@@ -32,7 +32,7 @@ fn create_permissive_hold_keyboard_with_combo() -> Keyboard<'static, 1, 5, 2> {
     create_simple_morse_keyboard(BehaviorConfig {
         tap_hold: TapHoldConfig {
             enable_hrm: false,
-            mode: TapHoldMode::PermissiveHold,
+            mode: MorseMode::PermissiveHold,
             unilateral_tap: false,
             ..TapHoldConfig::default()
         },

--- a/rmk/tests/keyboard_morse_tap_dance_test.rs
+++ b/rmk/tests/keyboard_morse_tap_dance_test.rs
@@ -1,12 +1,12 @@
-/// Test cases for tap-dance
+/// Test cases for tap-dance like morses
 pub mod common;
 
 use heapless::Vec;
 use rmk::action::Action;
-use rmk::config::{BehaviorConfig, TapDancesConfig};
+use rmk::config::{BehaviorConfig, MorsesConfig};
 use rmk::keyboard::Keyboard;
 use rmk::keycode::{KeyCode, ModifierCombination};
-use rmk::tap_dance::TapDance;
+use rmk::morse::Morse;
 use rmk::{k, td};
 use rusty_fork::rusty_fork_test;
 
@@ -19,23 +19,23 @@ pub fn create_tap_dance_test_keyboard() -> Keyboard<'static, 1, 4, 2> {
     ];
 
     let behavior_config = BehaviorConfig {
-        tap_dance: TapDancesConfig {
-            tap_dances: Vec::from_slice(&[
-                TapDance::new_from_vial(
+        morse: MorsesConfig {
+            morses: Vec::from_slice(&[
+                Morse::new_from_vial(
                     Action::Key(KeyCode::A),
                     Action::Key(KeyCode::B),
                     Action::Key(KeyCode::C),
                     Action::Key(KeyCode::D),
                     250,
                 ),
-                TapDance::new_from_vial(
+                Morse::new_from_vial(
                     Action::Key(KeyCode::X),
                     Action::Key(KeyCode::Y),
                     Action::Key(KeyCode::Z),
                     Action::Key(KeyCode::Space),
                     250,
                 ),
-                TapDance::new_from_vial(
+                Morse::new_from_vial(
                     Action::Key(KeyCode::Kp1),
                     Action::Modifier(ModifierCombination::SHIFT),
                     Action::Key(KeyCode::Kp2),


### PR DESCRIPTION
Morse key was introduced in #530, but now the configuration & processing uses tap dance, which is actually different from what the original tap dance means. 

This PR rename `TapDance` to `Morse`, adds documentation that explains the difference between `Morse` and `TapDance`.

`TapHold` is kept as is now, but in the future `TapHold` can also be merged into `Morse` action. That means there's only one kind of multi-role key in RMK world, definitions like `TapHold` and `TapDance` are only a subset of `Morse`. To help the new users, the documentation needs to be polished. 