### PR TITLE
Custom controllers execution mode

### DIFF
--- a/docs/en/docs/features/controller.md
+++ b/docs/en/docs/features/controller.md
@@ -111,14 +111,19 @@ scrolllock.low_active = false
 
 ### Custom Controllers
 
-Custom controllers are declared using the `#[controller]` attribute within your keyboard module:
+Custom controllers are declared using the `#[controller(event)]` or `#[controller(poll)]` attribute within your keyboard module.
+If `#[controller(event)]` is used the controller must implement `EventController` (or just `Controller`) and the `EventController::event_loop` method will be called.
+If `#[controller(poll)]` is used the controller must implement `PollingController` and the `PollingController::polling_loop` method will be called.
+
+A `p` variable containing the chip peripherals is in scope inside the function.
+It's also possible to define extra interrupts using the `bind_interrupts!` macro.
 
 ```rust
 #[rmk_keyboard]
 mod keyboard {
     // ... keyboard configuration ...
 
-    #[controller]
+    #[controller(event)]
     fn my_custom_controller() -> MyCustomController {
         // Initialize your controller
         let pin = Output::new(p.PIN_4, Level::Low, OutputDrive::Standard);
@@ -289,17 +294,17 @@ You can define multiple controllers in your keyboard module:
 ```rust
 #[rmk_keyboard]
 mod keyboard {
-    #[controller]
+    #[controller(event)]
     fn status_led() -> StatusLedController {
         StatusLedController::new(p.PIN_1)
     }
 
-    #[controller] 
+    #[controller(event)]
     fn layer_indicator() -> LayerLedController {
         LayerLedController::new(p.PIN_2)
     }
 
-    #[controller]
+    #[controller(poll)]
     fn battery_monitor() -> BatteryController {
         BatteryController::new(p.PIN_3)
     }

--- a/rmk-macro/src/controller/mod.rs
+++ b/rmk-macro/src/controller/mod.rs
@@ -1,9 +1,12 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use rmk_config::KeyboardTomlConfig;
+use rmk_config::{ChipModel, KeyboardTomlConfig, PinConfig};
 use syn::ItemMod;
 
-use crate::gpio_config::convert_gpio_str_to_output_pin;
+use crate::{
+    feature::{get_rmk_features, is_feature_enabled},
+    gpio_config::convert_gpio_str_to_output_pin,
+};
 
 /// Expands the controller initialization code based on the keyboard configuration.
 /// Returns a tuple containing: (controller_initialization, controller_execution)
@@ -11,53 +14,14 @@ pub(crate) fn expand_controller_init(
     keyboard_config: &KeyboardTomlConfig,
     item_mod: &ItemMod,
 ) -> (TokenStream, Vec<TokenStream>) {
-    // TODO: Check whether the `controller` feature is enabled
-    let chip = keyboard_config.get_chip_model().unwrap();
+    let controller_feature_enabled = is_feature_enabled(&get_rmk_features(), "controller");
 
-    let light_config = keyboard_config.get_light_config();
     let mut initializers = TokenStream::new();
     let mut executors = vec![];
-    if let Some(c) = light_config.numslock {
-        let p = convert_gpio_str_to_output_pin(&chip, c.pin.clone(), c.low_active);
-        let low_active = c.low_active;
-        let numlock_init = quote! {
-            let mut numslock_controller = ::rmk::controller::led_indicator::KeyboardIndicatorController::new(
-                #p,
-                #low_active,
-                ::rmk::types::led_indicator::LedIndicatorType::NumLock,
-            );
-        };
-        initializers.extend(numlock_init);
-        executors.push(quote! { numslock_controller.event_loop() });
-    }
 
-    if let Some(c) = light_config.scrolllock {
-        let p = convert_gpio_str_to_output_pin(&chip, c.pin.clone(), c.low_active);
-        let low_active = c.low_active;
-        let scrollock_init = quote! {
-            let mut scrolllock_controller = ::rmk::controller::led_indicator::KeyboardIndicatorController::new(
-                #p,
-                #low_active,
-                ::rmk::types::led_indicator::LedIndicatorType::ScrollLock,
-            );
-        };
-        initializers.extend(scrollock_init);
-        executors.push(quote! { scrolllock_controller.event_loop() });
-    }
-
-    if let Some(c) = light_config.capslock {
-        let p = convert_gpio_str_to_output_pin(&chip, c.pin.clone(), c.low_active);
-        let low_active = c.low_active;
-        let capslock_init = quote! {
-            let mut capslock_controller = ::rmk::controller::led_indicator::KeyboardIndicatorController::new(
-                #p,
-                #low_active,
-                ::rmk::types::led_indicator::LedIndicatorType::CapsLock,
-            );
-        };
-        initializers.extend(capslock_init);
-        executors.push(quote! { capslock_controller.event_loop() });
-    }
+    let (i, e) = expand_light_controllers(keyboard_config, controller_feature_enabled);
+    initializers.extend(i);
+    executors.extend(e);
 
     // external controller
     if let Some((_, items)) = &item_mod.content {
@@ -65,6 +29,9 @@ pub(crate) fn expand_controller_init(
             if let syn::Item::Fn(item_fn) = &item {
                 if let Some(attr) = item_fn.attrs.iter().find(|attr| attr.path().is_ident("controller")) {
                     let _ = attr.parse_nested_meta(|meta| {
+                        if !controller_feature_enabled {
+                            panic!("\"controller\" feature of RMK must be enabled to use the #[controller] attribute");
+                        }
                         let (custom_init, custom_exec) = expand_custom_controller(&item_fn);
                         initializers.extend(custom_init);
 
@@ -86,6 +53,76 @@ pub(crate) fn expand_controller_init(
     }
 
     (initializers, executors)
+}
+
+fn expand_light_controllers(
+    keyboard_config: &KeyboardTomlConfig,
+    controller_feature_enabled: bool,
+) -> (TokenStream, Vec<TokenStream>) {
+    let chip = keyboard_config.get_chip_model().unwrap();
+    let light_config = keyboard_config.get_light_config();
+
+    let mut initializers = TokenStream::new();
+    let mut executors = vec![];
+
+    create_keyboard_indicator_controller(
+        &chip,
+        &light_config.numslock,
+        quote! { numlock_controller },
+        quote! { NumLock },
+        controller_feature_enabled,
+        &mut initializers,
+        &mut executors,
+    );
+
+    create_keyboard_indicator_controller(
+        &chip,
+        &light_config.scrolllock,
+        quote! { scrolllock_controller },
+        quote! { ScrollLock },
+        controller_feature_enabled,
+        &mut initializers,
+        &mut executors,
+    );
+
+    create_keyboard_indicator_controller(
+        &chip,
+        &light_config.capslock,
+        quote! { capslock_controller },
+        quote! { CapsLock },
+        controller_feature_enabled,
+        &mut initializers,
+        &mut executors,
+    );
+
+    (initializers, executors)
+}
+
+fn create_keyboard_indicator_controller(
+    chip: &ChipModel,
+    pin_config: &Option<PinConfig>,
+    controller_ident: TokenStream,
+    led_indicator_variant: TokenStream,
+    controller_feature_enabled: bool,
+    initializers: &mut TokenStream,
+    executors: &mut Vec<TokenStream>,
+) {
+    if let Some(c) = pin_config {
+        if !controller_feature_enabled {
+            panic!("\"controller\" feature of RMK must be enabled to use the [light] configuration")
+        }
+        let p = convert_gpio_str_to_output_pin(chip, c.pin.clone(), c.low_active);
+        let low_active = c.low_active;
+        let controller_init = quote! {
+            let mut #controller_ident = ::rmk::controller::led_indicator::KeyboardIndicatorController::new(
+                #p,
+                #low_active,
+                ::rmk::types::led_indicator::LedIndicatorType::#led_indicator_variant,
+            );
+        };
+        initializers.extend(controller_init);
+        executors.push(quote! { #controller_ident.event_loop() });
+    }
 }
 
 fn expand_custom_controller(fn_item: &syn::ItemFn) -> (TokenStream, &syn::Ident) {

--- a/rmk-macro/src/entry.rs
+++ b/rmk-macro/src/entry.rs
@@ -90,12 +90,7 @@ pub(crate) fn rmk_entry_select(
                 keyboard.run(),
             };
             let mut tasks = vec![devices_task, keyboard_task];
-            // TODO: Handle polling controllers
-            for controller in controllers {
-                tasks.push(quote! {
-                    #controller.event_loop(),
-                });
-            }
+            tasks.extend(controllers);
             if split_config.connection == "ble" {
                 let rmk_task = quote! {
                     ::rmk::run_rmk(&keymap, #usb_driver_arg &stack, #storage rmk_config),
@@ -183,12 +178,7 @@ pub(crate) fn rmk_entry_default(
     if !processors_task.is_empty() {
         tasks.push(processors_task);
     }
-    // TODO: Handle polling controllers
-    for controller in controllers {
-        tasks.push(quote! {
-            #controller.event_loop()
-        });
-    }
+    tasks.extend(controllers);
     // Remove the storage argument if disabled in config. The feature also needs to be disabled.
     let storage = if keyboard_config.get_storage_config().enabled {
         quote! {&mut storage,}

--- a/rmk/src/controller/mod.rs
+++ b/rmk/src/controller/mod.rs
@@ -1,7 +1,6 @@
 //! Controller module for RMK
 //!
-//! This module defines the `Controller` trait and several macros for running output device controllers.
-//! The `Controller` trait provides the interface for individual output device controllers, and the macros facilitate their concurrent execution.
+//! This module defines the `Controller` trait and its variations for different modes of execution.
 
 pub mod battery_led;
 pub mod led_indicator;
@@ -9,7 +8,7 @@ pub(crate) mod wpm;
 
 use embassy_futures::select::{Either, select};
 
-/// Common trait for controllers.
+/// This trait provides the interface for individual output device controllers.
 pub trait Controller {
     /// Type of the received events
     type Event;
@@ -36,9 +35,7 @@ pub trait Controller {
 ///     }
 /// }
 ///
-/// impl EventController for MyController { }
-///
-/// // Use the input device
+/// // Use the controller
 /// let c = MyController;
 ///
 /// // Run device simultaneously with RMK
@@ -79,14 +76,14 @@ impl<T: Controller> EventController for T {}
 /// }
 ///
 /// impl PollingController for MyController {
-///     type INTERVAL: embassy_time::Duration = embassy_time::Duration::from_hz(60);
+///     type INTERVAL: embassy_time::Duration = embassy_time::Duration::from_hz(30);
 ///
 ///     async fn update(&mut self) {
 ///         // update periodic
 ///     }
 /// }
 ///
-/// // Use the input device
+/// // Use the controller
 /// let c = MyController;
 ///
 /// // Run device simultaneously with RMK
@@ -102,7 +99,7 @@ pub trait PollingController: Controller {
     /// Interval between `update` calls
     const INTERVAL: embassy_time::Duration;
 
-    /// Update periodically
+    /// Update periodically, will be called according to [`Self::INTERVAL`]
     async fn update(&mut self);
 
     /// Polling loop


### PR DESCRIPTION
We should allow the user to choose the execution mode of custom controllers defined via `#[controller]`. I propose to change the attribute to be either `#[controller(event)]` or `#[controller(poll)]` so we know what method to call when expanding the controller tasks.