### PR TITLE
Remove key_info, rename PerKeyConfig to PositionalConfig

### DIFF
--- a/docs/en/docs/features/configuration/layout.md
+++ b/docs/en/docs/features/configuration/layout.md
@@ -15,17 +15,12 @@ matrix_map = """
 """
 ```
 
-The `matrix_map` is a string built from `(row, col, <hand> : <profile_name>)` tuples, listed in the same order as you want to define your keys in your key map. 
+The `matrix_map` is a string built from `(row, col, <hand>)` tuples, listed in the same order as you want to define your keys in your key map. 
 
 The `(row, col)` coordinates are using zero based indexing and referring to the position in the "electronic matrix" of your keyboard. As you can see in [matrix configuration](keyboard_matrix.md), even the direct pin based keyboards are represented with a matrix. In case of split keyboards, the positions refer to the position in the "big unified matrix" of all split parts. 
 With the help of this matrix map, the configuration of non-regular key matrices can be intuitively arranged in your key maps. (Triple quote mark `"""` is used to limit multi-line strings)
 
-The `<hand>` and `<profile_name>` are both optional, they are generally needed for split ergo keyboards. 
-
-The `<hand>` field is optional and should only be used when `unilateral_tap = true` is set in a key’s profile. By assigning `L` or `R` to `<hand>`, each key can be associated with either the left or right hand.
-
-The `<profile_name>` is also optional, if given, it selects a key profile from [`behavior.morse.profiles`](./behavior.md#fine-tuning) to override the default settings defined in `behavior.morse`. For defining a key profile, please refer to [behavior](./behavior.md#fine-tuning) doc. Please note that the profile name is case sensitive.
-
+The `<hand>` is optional, it should only be used when `unilateral_tap = true`. By assigning `L` or `R` to `<hand>`, each key can be associated with either the left or right hand.
 
 ```toml
 # simple numpad example:
@@ -134,9 +129,7 @@ The definitions of those operations are same with QMK, you can found [here](http
 
 9.  For keyboard macros, use `Macro(n)`
 
-The optional `<profile_name>` can be used to select morse profile (per key) from `[behavior.morse.profiles]` for the tap hold like keys. 
-If not given, the default profile defined in `[behavior.morse]` will be used, except when `matrix_map` used to override the default profile for some keys positions by similarly referring to the profiles by their name - see the example above for more details.
-Please note that the profile name is case sensitive.
+The optional `<profile_name>` can be used to select morse profile (per key) from `[behavior.morse.profiles]` for the tap hold like keys. If not given, the default profile defined in `[behavior.morse]` will be used. Please note that the profile name is case sensitive.
 
 ::: tip
 If you want to use Vial, the positional profile override is recommended instead of per key override, since Vial does not support the profile configuration of tap hold keys, so the profile information will likely be lost.

--- a/examples/use_rust/esp32c3_ble/src/main.rs
+++ b/examples/use_rust/esp32c3_ble/src/main.rs
@@ -18,7 +18,7 @@ use esp_radio::ble::controller::BleConnector;
 use esp_storage::FlashStorage;
 use rmk::ble::build_ble_stack;
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -85,7 +85,7 @@ async fn main(_s: Spawner) {
     // Initialize the storage and keymap
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/esp32c6_ble/src/main.rs
+++ b/examples/use_rust/esp32c6_ble/src/main.rs
@@ -18,7 +18,7 @@ use esp_radio::ble::controller::BleConnector;
 use esp_storage::FlashStorage;
 use rmk::ble::build_ble_stack;
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -85,7 +85,7 @@ async fn main(_s: Spawner) {
     // Initialize the storage and keymap
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/esp32s3_ble/src/main.rs
+++ b/examples/use_rust/esp32s3_ble/src/main.rs
@@ -22,7 +22,7 @@ use esp_radio::ble::controller::BleConnector;
 use esp_storage::FlashStorage;
 use rmk::ble::build_ble_stack;
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -96,7 +96,7 @@ async fn main(_s: Spawner) {
     // Initialize the storage and keymap
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/nrf52832_ble/src/main.rs
+++ b/examples/use_rust/nrf52832_ble/src/main.rs
@@ -20,7 +20,7 @@ use rand_chacha::ChaCha12Rng;
 use rand_core::SeedableRng;
 use rmk::ble::build_ble_stack;
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable as _;
@@ -144,7 +144,7 @@ async fn main(spawner: Spawner) {
     // Initialize the storage and keymap
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/nrf52840/src/main.rs
+++ b/examples/use_rust/nrf52840/src/main.rs
@@ -16,7 +16,7 @@ use embassy_nrf::usb::{self, Driver};
 use embassy_nrf::{bind_interrupts, peripherals};
 use keymap::{COL, ROW};
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -66,7 +66,7 @@ async fn main(_spawner: Spawner) {
     let mut default_keymap = keymap::get_default_keymap();
     let storage_config = StorageConfig::default();
     let mut behavior_config = BehaviorConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/nrf52840_ble/src/main.rs
+++ b/examples/use_rust/nrf52840_ble/src/main.rs
@@ -25,7 +25,7 @@ use rand_core::SeedableRng;
 use rmk::ble::build_ble_stack;
 use rmk::channel::EVENT_CHANNEL;
 use rmk::config::{
-    BehaviorConfig, BleBatteryConfig, KeyboardUsbConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig,
+    BehaviorConfig, BleBatteryConfig, KeyboardUsbConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig,
 };
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join4;
@@ -182,7 +182,7 @@ async fn main(spawner: Spawner) {
     // Initialze keyboard stuffs
     // Initialize the storage and keymap
     let mut default_keymap = keymap::get_default_keymap();
-    let mut key_config = PerKeyConfig::default();
+    let mut key_config = PositionalConfig::default();
     let mut behavior_config = BehaviorConfig::default();
     let mut encoder_map = keymap::get_default_encoder_map();
     let (keymap, mut storage) = initialize_encoder_keymap_and_storage(

--- a/examples/use_rust/nrf52840_ble_split/src/central.rs
+++ b/examples/use_rust/nrf52840_ble_split/src/central.rs
@@ -24,7 +24,7 @@ use rand_core::SeedableRng;
 use rmk::ble::build_ble_stack;
 use rmk::channel::EVENT_CHANNEL;
 use rmk::config::{
-    BehaviorConfig, BleBatteryConfig, KeyboardUsbConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig,
+    BehaviorConfig, BleBatteryConfig, KeyboardUsbConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig,
 };
 use rmk::controller::EventController as _;
 use rmk::controller::led_indicator::KeyboardIndicatorController;
@@ -190,7 +190,7 @@ async fn main(spawner: Spawner) {
     let mut behavior_config = BehaviorConfig::default();
     behavior_config.morse.enable_flow_tap = true;
     let mut encoder_map: [[rmk::types::action::EncoderAction; _]; _] = keymap::get_default_encoder_map();
-    let mut key_config = PerKeyConfig::default();
+    let mut key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_encoder_keymap_and_storage(
         &mut default_keymap,
         &mut encoder_map,

--- a/examples/use_rust/pi_pico_w_ble/src/main.rs
+++ b/examples/use_rust/pi_pico_w_ble/src/main.rs
@@ -21,7 +21,7 @@ use keymap::{COL, ROW};
 use rand::SeedableRng;
 use rmk::ble::build_ble_stack;
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -125,7 +125,7 @@ async fn main(spawner: Spawner) {
     // Initialize the storage and keymap
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/pi_pico_w_ble_split/src/central.rs
+++ b/examples/use_rust/pi_pico_w_ble_split/src/central.rs
@@ -21,7 +21,7 @@ use keymap::{COL, ROW};
 use rand::SeedableRng;
 use rmk::ble::build_ble_stack;
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::{join, join3};
 use rmk::input_device::Runnable;
@@ -127,7 +127,7 @@ async fn main(spawner: Spawner) {
     // Initialize the storage and keymap
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/py32f07x/src/main.rs
+++ b/examples/use_rust/py32f07x/src/main.rs
@@ -15,7 +15,7 @@ use py32_hal::gpio::{Input, Output};
 use py32_hal::rcc::{HsiFs, Pll, PllMul, PllSource, Sysclk};
 use py32_hal::usb::{Driver, InterruptHandler};
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PerKeyConfig, RmkConfig, VialConfig};
+use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PositionalConfig, RmkConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -74,7 +74,7 @@ async fn main(_spawner: Spawner) {
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
     // let storage_config = StorageConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let keymap = rmk::initialize_keymap(&mut default_keymap, &mut behavior_config, &mut per_key_config).await;
     // let (keymap, mut storage) = initialize_keymap_and_storage(
     //     &mut default_keymap,

--- a/examples/use_rust/rp2040/src/main.rs
+++ b/examples/use_rust/rp2040/src/main.rs
@@ -16,7 +16,7 @@ use embassy_rp::peripherals::USB;
 use embassy_rp::usb::{Driver, InterruptHandler};
 use keymap::{COL, ROW};
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -70,7 +70,7 @@ async fn main(_spawner: Spawner) {
     let mut default_keymap = keymap::get_default_keymap();
     let storage_config = StorageConfig::default();
     let mut behavior_config = BehaviorConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/rp2040_direct_pin/src/main.rs
+++ b/examples/use_rust/rp2040_direct_pin/src/main.rs
@@ -16,7 +16,7 @@ use embassy_rp::peripherals::USB;
 use embassy_rp::usb::{Driver, InterruptHandler};
 use keymap::{COL, ROW, SIZE};
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::direct_pin::DirectPinMatrix;
 use rmk::futures::future::join3;
@@ -78,7 +78,7 @@ async fn main(_spawner: Spawner) {
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
     let storage_config = StorageConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/rp2040_split/src/central.rs
+++ b/examples/use_rust/rp2040_split/src/central.rs
@@ -16,7 +16,7 @@ use embassy_rp::peripherals::{UART0, USB};
 use embassy_rp::uart::{self, BufferedUart};
 use embassy_rp::usb::{Driver, InterruptHandler};
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join4;
 use rmk::input_device::Runnable;
@@ -79,7 +79,7 @@ async fn main(_spawner: Spawner) {
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
     let storage_config = StorageConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/rp2040_split_pio/src/central.rs
+++ b/examples/use_rust/rp2040_split_pio/src/central.rs
@@ -15,7 +15,7 @@ use embassy_rp::gpio::{Input, Output};
 use embassy_rp::peripherals::{PIO0, USB};
 use embassy_rp::usb::{Driver, InterruptHandler};
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join4;
 use rmk::input_device::Runnable;
@@ -75,7 +75,7 @@ async fn main(_spawner: Spawner) {
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
     let storage_config = StorageConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/rp2350/src/main.rs
+++ b/examples/use_rust/rp2350/src/main.rs
@@ -17,7 +17,7 @@ use embassy_rp::peripherals::USB;
 use embassy_rp::usb::{Driver, InterruptHandler};
 use keymap::{COL, ROW};
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -84,7 +84,7 @@ async fn main(_spawner: Spawner) {
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
     let storage_config = StorageConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/sf32lb52x_usb/src/main.rs
+++ b/examples/use_rust/sf32lb52x_usb/src/main.rs
@@ -11,7 +11,7 @@ use defmt::info;
 use embassy_executor::Spawner;
 use keymap::{COL, ROW};
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PerKeyConfig, RmkConfig, VialConfig};
+use rmk::config::{BehaviorConfig, KeyboardUsbConfig, PositionalConfig, RmkConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -79,7 +79,7 @@ async fn main(_spawner: Spawner) {
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
     // let storage_config = StorageConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let keymap = rmk::initialize_keymap(&mut default_keymap, &mut behavior_config, &mut per_key_config).await;
     // let (keymap, mut storage) = initialize_keymap_and_storage(
     //     &mut default_keymap,

--- a/examples/use_rust/stm32f1/src/main.rs
+++ b/examples/use_rust/stm32f1/src/main.rs
@@ -14,7 +14,7 @@ use embassy_time::Timer;
 use keymap::{COL, ROW};
 use panic_halt as _;
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, PerKeyConfig, RmkConfig};
+use rmk::config::{BehaviorConfig, PositionalConfig, RmkConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -55,7 +55,7 @@ async fn main(_spawner: Spawner) {
     // Initialize the storage and keymap
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let keymap = initialize_keymap(&mut default_keymap, &mut behavior_config, &mut per_key_config).await;
 
     // Initialize the matrix + keyboard

--- a/examples/use_rust/stm32f4/src/main.rs
+++ b/examples/use_rust/stm32f4/src/main.rs
@@ -15,7 +15,7 @@ use embassy_stm32::usb::{Driver, InterruptHandler};
 use embassy_stm32::{Config, bind_interrupts};
 use keymap::{COL, ROW};
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -70,7 +70,7 @@ async fn main(_spawner: Spawner) {
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
     let storage_config = StorageConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/examples/use_rust/stm32g4/src/main.rs
+++ b/examples/use_rust/stm32g4/src/main.rs
@@ -13,7 +13,7 @@ use embassy_stm32::usb::{Driver, InterruptHandler};
 use embassy_stm32::{Config, bind_interrupts};
 use keymap::{COL, ROW};
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, PerKeyConfig, RmkConfig};
+use rmk::config::{BehaviorConfig, PositionalConfig, RmkConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -48,7 +48,7 @@ async fn main(_spawner: Spawner) {
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
     // let storage_config = StorageConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let keymap = initialize_keymap(&mut default_keymap, &mut behavior_config, &mut per_key_config).await;
 
     // Initialize the matrix + keyboard

--- a/examples/use_rust/stm32h7/src/main.rs
+++ b/examples/use_rust/stm32h7/src/main.rs
@@ -18,7 +18,7 @@ use embassy_stm32::usb::{Driver, InterruptHandler};
 use embassy_stm32::{Config, bind_interrupts};
 use keymap::{COL, ROW};
 use rmk::channel::EVENT_CHANNEL;
-use rmk::config::{BehaviorConfig, PerKeyConfig, RmkConfig, StorageConfig, VialConfig};
+use rmk::config::{BehaviorConfig, PositionalConfig, RmkConfig, StorageConfig, VialConfig};
 use rmk::debounce::default_debouncer::DefaultDebouncer;
 use rmk::futures::future::join3;
 use rmk::input_device::Runnable;
@@ -109,7 +109,7 @@ async fn main(_spawner: Spawner) {
     let mut default_keymap = keymap::get_default_keymap();
     let mut behavior_config = BehaviorConfig::default();
     let storage_config = StorageConfig::default();
-    let mut per_key_config = PerKeyConfig::default();
+    let mut per_key_config = PositionalConfig::default();
     let (keymap, mut storage) = initialize_keymap_and_storage(
         &mut default_keymap,
         flash,

--- a/rmk-config/src/keymap.pest
+++ b/rmk-config/src/keymap.pest
@@ -118,7 +118,7 @@ right_hand = { ^"R" | ^"RH" | ^"Right" }
 hand = _{ left_hand | right_hand }
 
 // Define the key_info structure, capturing row and col numbers, and optionally some extra key information
-keypos_info = { "(" ~ number ~ "," ~ number ~ ("," ~ hand)? ~ (":" ~ profile_name)? ~ ")" }
+keypos_info = { "(" ~ number ~ "," ~ number ~ ("," ~ hand)? ~ ")" }
 
 // The main rule: Start, zero or more key_info or whitespace occurrences, End.
 // This ensures the entire string consists *only* of valid key_info tuples and whitespace.

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -417,8 +417,7 @@ pub struct LayoutConfig {
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct KeyInfo {
-    pub hand: char,              // 'L' or 'R' or other chars
-    pub profile: Option<String>, // name of key profile (BehaviorConfig::morse.profiles[self.profile])
+    pub hand: char, // 'L' or 'R' or other chars
 }
 
 /// Configurations for actions behavior

--- a/rmk-macro/src/keyboard_config.rs
+++ b/rmk-macro/src/keyboard_config.rs
@@ -11,7 +11,7 @@ pub(crate) fn read_keyboard_toml_config() -> KeyboardTomlConfig {
 
 pub(crate) fn expand_keyboard_info(keyboard_config: &KeyboardTomlConfig) -> proc_macro2::TokenStream {
     let basic = keyboard_config.get_basic_info();
-    let (layout, _key_info) = keyboard_config.get_layout_config().unwrap();
+    let (layout, _) = keyboard_config.get_layout_config().unwrap();
     let board = keyboard_config.get_board_config().unwrap();
     let pid = basic.product_id;
     let vid = basic.vendor_id;

--- a/rmk-macro/src/layout.rs
+++ b/rmk-macro/src/layout.rs
@@ -21,7 +21,7 @@ pub(crate) fn expand_default_keymap(keyboard_config: &KeyboardTomlConfig) -> Tok
     // TODO: config encoder actions in keyboard.toml
     let encoders = vec![quote! { ::rmk::encoder!(::rmk::k!(No), ::rmk::k!(No))}; total_num_encoder];
 
-    let (layout, _key_info) = keyboard_config.get_layout_config().unwrap();
+    let (layout, _) = keyboard_config.get_layout_config().unwrap();
     let mut layers = vec![];
     let mut encoder_map = vec![];
     for layer in layout.keymap {

--- a/rmk-macro/src/matrix.rs
+++ b/rmk-macro/src/matrix.rs
@@ -34,7 +34,7 @@ pub(crate) fn expand_matrix_config(
                 ));
                 // `generic_arg_infer` is a nightly feature. Const arguments cannot yet be inferred with `_` in stable now.
                 // So we need to declaring them in advance.
-                let (layout, _key_info) = keyboard_config.get_layout_config().unwrap();
+                let (layout, _) = keyboard_config.get_layout_config().unwrap();
                 let rows = layout.rows as usize;
                 let cols = layout.cols as usize;
                 let size = layout.rows as usize * layout.cols as usize;

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -91,7 +91,7 @@ impl Default for MorsesConfig {
     }
 }
 
-/// Configuration that's only related to the key's position
+/// Configuration that's only related to the key's position.
 ///
 /// Now only the hand information is included.
 /// In the future more fields can be added here for the future configurator GUI, such as

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -91,29 +91,31 @@ impl Default for MorsesConfig {
     }
 }
 
-/// Per key position information about a key
-/// In the future more fields can be added here for the future configurator GUI
+/// Configuration that's only related to the key's position
+///
+/// Now only the hand information is included.
+/// In the future more fields can be added here for the future configurator GUI, such as
 /// - physical key position and orientation
 /// - key size,
 /// - key shape,
 /// - backlight sequence number, etc.
 /// IDEA: For Keyboards with low memory, these should be compile time constants to save RAM?
-#[derive(Clone, Copy, Default, Debug)]
-pub struct KeyInfo {
-    /// store hand information for unilateral_tap processing
-    pub hand: Hand,
-    /// this gives possibility to override some the default MorseProfile setting in certain key positions (typically home row mods)
-    pub morse_profile_override: MorseProfile,
+#[derive(Debug)]
+pub struct PositionalConfig<const ROW: usize, const COL: usize> {
+    pub hand: [[Hand; COL]; ROW],
 }
 
-#[derive(Debug, Default)]
-pub struct PerKeyConfig<const ROW: usize, const COL: usize> {
-    pub key_info: Option<[[KeyInfo; COL]; ROW]>,
+impl<const ROW: usize, const COL: usize> Default for PositionalConfig<ROW, COL> {
+    fn default() -> Self {
+        Self {
+            hand: [[Hand::default(); COL]; ROW],
+        }
+    }
 }
 
-impl<const ROW: usize, const COL: usize> PerKeyConfig<ROW, COL> {
-    pub fn new(key_info: Option<[[KeyInfo; COL]; ROW]>) -> Self {
-        Self { key_info }
+impl<const ROW: usize, const COL: usize> PositionalConfig<ROW, COL> {
+    pub fn new(hand: [[Hand; COL]; ROW]) -> Self {
+        Self { hand }
     }
 }
 

--- a/rmk/src/host/storage.rs
+++ b/rmk/src/host/storage.rs
@@ -311,7 +311,7 @@ impl Value<'_> for KeymapData {
                     for _ in 0..count {
                         let pattern = MorsePattern::from_u16(BigEndian::read_u16(&buffer[i..i + 2]));
                         let key_action = from_via_keycode(BigEndian::read_u16(&buffer[i + 2..i + 4]));
-                        _ = morse.actions.push((pattern, key_action.to_action()));
+                        _ = morse.actions.insert(pattern, key_action.to_action());
                         i += 4;
                     }
 
@@ -551,19 +551,19 @@ mod tests {
                 Some(210u16),
                 Some(220u16),
             ),
-            actions: Vec::default(),
+            actions: heapless::LinearMap::default(),
         };
         morse
             .actions
-            .push((MorsePattern::from_u16(0b1_01), Action::Key(KeyCode::A)))
+            .insert(MorsePattern::from_u16(0b1_01), Action::Key(KeyCode::A))
             .ok();
         morse
             .actions
-            .push((MorsePattern::from_u16(0b1_1000), Action::Key(KeyCode::B)))
+            .insert(MorsePattern::from_u16(0b1_1000), Action::Key(KeyCode::B))
             .ok();
         morse
             .actions
-            .push((MorsePattern::from_u16(0b1_1010), Action::Key(KeyCode::C)))
+            .insert(MorsePattern::from_u16(0b1_1010), Action::Key(KeyCode::C))
             .ok();
 
         // Serialization

--- a/rmk/src/keyboard/morse.rs
+++ b/rmk/src/keyboard/morse.rs
@@ -68,7 +68,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
         if event.pressed {
             // Pressed, check the held buffer, update the tap state
             let pressed_time = self.get_timer_value(event).unwrap_or(Instant::now());
-            let timeout_time = pressed_time + Self::morse_timeout(&self.keymap.borrow(), &key_action, true);
+            let timeout_time = pressed_time + Self::morse_timeout(&self.keymap.borrow(), key_action, true);
             match self.held_buffer.find_pos_mut(event.pos) {
                 Some(k) => {
                     // The current key is already in the buffer, update its state

--- a/rmk/src/keyboard/morse.rs
+++ b/rmk/src/keyboard/morse.rs
@@ -2,7 +2,7 @@ use embassy_time::{Duration, Instant};
 use rmk_types::action::{Action, KeyAction, MorseMode};
 
 use crate::config::BehaviorConfig;
-use crate::event::{KeyboardEvent, KeyboardEventPos};
+use crate::event::KeyboardEvent;
 use crate::keyboard::Keyboard;
 use crate::keyboard::held_buffer::{HeldKey, KeyState};
 use crate::keymap::KeyMap;
@@ -68,7 +68,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
         if event.pressed {
             // Pressed, check the held buffer, update the tap state
             let pressed_time = self.get_timer_value(event).unwrap_or(Instant::now());
-            let timeout_time = pressed_time + Self::morse_timeout(&self.keymap.borrow(), event.pos, &key_action, true);
+            let timeout_time = pressed_time + Self::morse_timeout(&self.keymap.borrow(), &key_action, true);
             match self.held_buffer.find_pos_mut(event.pos) {
                 Some(k) => {
                     // The current key is already in the buffer, update its state
@@ -131,7 +131,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
                             k.state = KeyState::Released(pattern);
                             // Use current release time for `IdleAfterTap` state
                             k.press_time = released_time; // Use release time as the "press_time"
-                            let timeout = Self::morse_timeout(&self.keymap.borrow(), event.pos, &k.action, false);
+                            let timeout = Self::morse_timeout(&self.keymap.borrow(), &k.action, false);
                             k.timeout_time = k.press_time + timeout;
                         }
                     }
@@ -142,8 +142,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
                         k.state = KeyState::Released(pattern);
                         // Use current release time for `IdleAfterTap` state
                         k.press_time = released_time; // Use release time as the "press_time"
-                        k.timeout_time =
-                            k.press_time + Self::morse_timeout(&self.keymap.borrow(), event.pos, &k.action, false);
+                        k.timeout_time = k.press_time + Self::morse_timeout(&self.keymap.borrow(), &k.action, false);
                     }
                     KeyState::ProcessedButReleaseNotReportedYet(action) => {
                         // Releasing a tap-hold action whose pressed HID report is already sent
@@ -201,13 +200,11 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
 
     pub fn morse_timeout(
         keymap: &KeyMap<ROW, COL, NUM_LAYER, NUM_ENCODER>,
-        pos: KeyboardEventPos,
         key_action: &KeyAction,
         hold_timeout_needed: bool,
     ) -> Duration {
         let behavior_config = &keymap.behavior;
-        let key_info = &keymap.key_config.key_info;
-        //first: try to look for a per-key profile config
+        // Check per-key profile config first
         match key_action {
             KeyAction::TapHold(_, _, profile) => {
                 let timeout = if hold_timeout_needed {
@@ -236,24 +233,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             _ => {}
         }
 
-        //second: try to look for a positional profile override
-        if let KeyboardEventPos::Key(pos) = pos
-            && let Some(info) = key_info
-        {
-            let profile = info[pos.row as usize][pos.col as usize].morse_profile_override;
-
-            let timeout = if hold_timeout_needed {
-                profile.hold_timeout_ms()
-            } else {
-                profile.gap_timeout_ms()
-            };
-
-            if let Some(timeout) = timeout {
-                return Duration::from_millis(timeout as u64);
-            }
-        }
-
-        //otherwise return the global default profile
+        // If no per-key config, use the global default profile
         let timeout = if hold_timeout_needed {
             behavior_config.morse.default_profile.hold_timeout_ms()
         } else {
@@ -266,14 +246,9 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
 
     /// Decides and returns the morse mode
     /// based on configuration for the given key action / key position
-    pub fn tap_hold_mode(
-        keymap: &KeyMap<ROW, COL, NUM_LAYER, NUM_ENCODER>,
-        pos: KeyboardEventPos,
-        key_action: &KeyAction,
-    ) -> MorseMode {
+    pub fn tap_hold_mode(keymap: &KeyMap<ROW, COL, NUM_LAYER, NUM_ENCODER>, key_action: &KeyAction) -> MorseMode {
         let behavior_config = &keymap.behavior;
-        let key_info = &keymap.key_config.key_info;
-        //first: try to look for a per-key profile config
+        // Check per-key profile config first
         match key_action {
             KeyAction::TapHold(_, _, profile) => {
                 if let Some(mode) = profile.mode() {
@@ -290,15 +265,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             _ => {}
         }
 
-        //second: try to look for a positional profile override
-        if let KeyboardEventPos::Key(pos) = pos
-            && let Some(info) = key_info
-            && let Some(mode) = info[pos.row as usize][pos.col as usize].morse_profile_override.mode()
-        {
-            return mode;
-        }
-
-        //otherwise return the global default
+        // If no per-key config, use the global default profile
         behavior_config
             .morse
             .default_profile
@@ -310,12 +277,10 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
     /// based on configuration for the given key action / key position
     pub fn is_unilateral_tap_enabled(
         keymap: &KeyMap<ROW, COL, NUM_LAYER, NUM_ENCODER>,
-        pos: KeyboardEventPos,
         key_action: &KeyAction,
     ) -> bool {
         let behavior_config = &keymap.behavior;
-        let key_info = &keymap.key_config.key_info;
-        //first: try to look for a per-key profile config
+        // try to look for a per-key profile config
         match key_action {
             KeyAction::TapHold(_, _, profile) => {
                 if let Some(enabled) = profile.unilateral_tap() {
@@ -332,17 +297,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             _ => {}
         }
 
-        //second: try to look for a positional profile override
-        if let KeyboardEventPos::Key(pos) = pos
-            && let Some(info) = key_info
-            && let Some(mode) = info[pos.row as usize][pos.col as usize]
-                .morse_profile_override
-                .unilateral_tap()
-        {
-            return mode;
-        }
-
-        //otherwise return the global default
+        // Use the global default
         behavior_config.morse.default_profile.unilateral_tap().unwrap_or(false)
     }
 

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -12,7 +12,7 @@ use {
 
 use crate::COMBO_MAX_NUM;
 use crate::combo::Combo;
-use crate::config::{BehaviorConfig, PerKeyConfig};
+use crate::config::{BehaviorConfig, PositionalConfig};
 use crate::event::{KeyboardEvent, KeyboardEventPos};
 use crate::input_device::rotary_encoder::Direction;
 use crate::keyboard_macros::MacroOperation;
@@ -38,7 +38,7 @@ pub struct KeyMap<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize
     encoder_layer_cache: [[u8; 2]; NUM_ENCODER],
     /// Options for configurable action behavior
     pub(crate) behavior: &'a mut BehaviorConfig,
-    pub key_config: &'a mut PerKeyConfig<ROW, COL>,
+    pub positional_config: &'a mut PositionalConfig<ROW, COL>,
     /// Publisher for controller channel
     #[cfg(feature = "controller")]
     controller_pub: ControllerPub,
@@ -66,7 +66,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
         action_map: &'a mut [[[KeyAction; COL]; ROW]; NUM_LAYER],
         encoder_map: Option<&'a mut [[EncoderAction; NUM_ENCODER]; NUM_LAYER]>,
         behavior: &'a mut BehaviorConfig,
-        key_info: &'a mut PerKeyConfig<ROW, COL>,
+        positional_config: &'a mut PositionalConfig<ROW, COL>,
     ) -> Self {
         // If the storage is initialized, read keymap from storage
 
@@ -86,7 +86,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             layer_cache: [[0; COL]; ROW],
             encoder_layer_cache: [[0; 2]; NUM_ENCODER],
             behavior,
-            key_config: key_info,
+            positional_config,
             #[cfg(feature = "controller")]
             controller_pub: unwrap!(CONTROLLER_CHANNEL.publisher()),
             #[cfg(feature = "vial_lock")]
@@ -100,7 +100,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
         mut encoder_map: Option<&'a mut [[EncoderAction; NUM_ENCODER]; NUM_LAYER]>,
         storage: Option<&mut Storage<F, ROW, COL, NUM_LAYER, NUM_ENCODER>>,
         behavior: &'a mut BehaviorConfig,
-        key_config: &'a mut PerKeyConfig<ROW, COL>,
+        positional_config: &'a mut PositionalConfig<ROW, COL>,
     ) -> Self {
         // If the storage is initialized, read keymap from storage
         fill_vec(&mut behavior.combo.combos);
@@ -146,7 +146,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             layer_cache: [[0; COL]; ROW],
             encoder_layer_cache: [[0; 2]; NUM_ENCODER],
             behavior,
-            key_config,
+            positional_config,
             #[cfg(feature = "controller")]
             controller_pub: unwrap!(CONTROLLER_CHANNEL.publisher()),
             #[cfg(feature = "vial_lock")]

--- a/rmk/src/morse.rs
+++ b/rmk/src/morse.rs
@@ -184,7 +184,7 @@ impl Morse {
                         return None; //the solution is not unique, so must wait for possible continuation
                     }
                 } else {
-                    first = Some(&pair.1);
+                    first = Some(pair.1);
                 }
             }
         }

--- a/rmk/src/morse.rs
+++ b/rmk/src/morse.rs
@@ -1,4 +1,4 @@
-use heapless::Vec;
+use heapless::{LinearMap, Vec};
 use rmk_types::action::{Action, MorseProfile};
 
 use crate::MAX_PATTERNS_PER_KEY;
@@ -72,20 +72,30 @@ impl MorsePattern {
 /// There is a lists of (pattern, corresponding action) pairs for each morse key:
 /// The number of pairs is limited by MAX_PATTERNS_PER_KEY, which is a const generic parameter.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Morse<const NUM_PATTERNS: usize = MAX_PATTERNS_PER_KEY> {
     /// The profile of this morse key, which defines the timing parameters, etc.
     /// If some of its fields are filled with None, the global default value will be used.
     pub profile: MorseProfile,
     /// The list of pattern -> action pairs, which can be triggered
-    pub actions: Vec<(MorsePattern, Action), NUM_PATTERNS>,
+    pub actions: LinearMap<MorsePattern, Action, NUM_PATTERNS>,
+}
+
+#[cfg(feature = "defmt")]
+impl<const NUM_PATTERNS: usize> defmt::Format for Morse<NUM_PATTERNS> {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        self.profile.format(f);
+        for item in self.actions.iter() {
+            item.format(f)
+        }
+    }
 }
 
 impl Default for Morse {
     fn default() -> Self {
         Self {
             profile: MorseProfile::const_default(),
-            actions: Vec::default(),
+            actions: LinearMap::default(),
         }
     }
 }
@@ -104,16 +114,16 @@ impl Morse {
         };
 
         if tap != Action::No {
-            _ = result.actions.push((TAP, tap));
+            _ = result.actions.insert(TAP, tap);
         }
         if hold != Action::No {
-            _ = result.actions.push((HOLD, hold));
+            _ = result.actions.insert(HOLD, hold);
         }
         if double_tap != Action::No {
-            _ = result.actions.push((DOUBLE_TAP, double_tap));
+            _ = result.actions.insert(DOUBLE_TAP, double_tap);
         }
         if hold_after_tap != Action::No {
-            _ = result.actions.push((HOLD_AFTER_TAP, hold_after_tap));
+            _ = result.actions.insert(HOLD_AFTER_TAP, hold_after_tap);
         }
         result
     }
@@ -157,10 +167,10 @@ impl Morse {
     /// Checks all stored patterns if more than one continuation found for the given pattern, None,
     /// otherwise the unique completion
     pub fn try_predict_final_action(&self, pattern_start: MorsePattern) -> Option<Action> {
-        // Check whether current pattern matches any of the legal patterns
+        // Check whether current pattern matches any of the legal patterns.
         // If not, return early
-        if self.actions.iter().find(|&a| a.0 == pattern_start).is_none() {
-            return None; //the user made a mistake while entering the pattern
+        if !self.actions.contains_key(&pattern_start) {
+            return None;
         }
 
         let mut first: Option<&Action> = None;
@@ -168,7 +178,7 @@ impl Morse {
             // If pair.pattern starts with the given pattern_start
             if pair.0.starts_with(pattern_start) {
                 if let Some(action) = first {
-                    if *action != pair.1 {
+                    if *action != *pair.1 {
                         return None; //the solution is not unique, so must wait for possible continuation
                     }
                 } else {
@@ -181,37 +191,18 @@ impl Morse {
     }
 
     pub fn get(&self, pattern: MorsePattern) -> Option<Action> {
-        for pair in self.actions.iter() {
-            if pair.0 == pattern {
-                return Some(pair.1);
-            }
-        }
-        None
+        self.actions.get(&pattern).copied()
     }
 
     /// A call with Action::No will remove the item from the collection,
     /// otherwise will update the existing action or insert the new action if possible
     pub fn put(&mut self, pattern: MorsePattern, action: Action) {
         if action != Action::No {
-            for pair in self.actions.iter_mut() {
-                // Update if found
-                if pair.0 == pattern {
-                    pair.1 = action;
-                    return;
-                }
-            }
-            if let Err(a) = self.actions.push((pattern, action)) {
+            if let Err(a) = self.actions.insert(pattern, action) {
                 error!("The actions buffer is full in current morse key, pushing {:?} fails", a);
             }
         } else {
-            for i in 0..self.actions.len() {
-                // Found saved pattern, pop it
-                if self.actions[i].0 == pattern {
-                    self.actions[i] = self.actions[self.actions.len() - 1];
-                    self.actions.pop();
-                    return;
-                }
-            }
+            let _ = self.actions.remove(&pattern);
         }
     }
 }

--- a/rmk/src/morse.rs
+++ b/rmk/src/morse.rs
@@ -75,8 +75,7 @@ impl MorsePattern {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Morse<const NUM_PATTERNS: usize = MAX_PATTERNS_PER_KEY> {
     /// The profile of this morse key, which defines the timing parameters, etc.
-    /// if some of its fields are filled with None, the positional override given in KeyInfo,
-    /// or the defaults given in MorsesConfig will be used instead.
+    /// If some of its fields are filled with None, the global default value will be used.
     pub profile: MorseProfile,
     /// The list of pattern -> action pairs, which can be triggered
     pub actions: Vec<(MorsePattern, Action), NUM_PATTERNS>,

--- a/rmk/src/morse.rs
+++ b/rmk/src/morse.rs
@@ -73,13 +73,13 @@ impl MorsePattern {
 /// The number of pairs is limited by MAX_PATTERNS_PER_KEY, which is a const generic parameter.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Morse {
+pub struct Morse<const NUM_PATTERNS: usize = MAX_PATTERNS_PER_KEY> {
     /// The profile of this morse key, which defines the timing parameters, etc.
     /// if some of its fields are filled with None, the positional override given in KeyInfo,
     /// or the defaults given in MorsesConfig will be used instead.
     pub profile: MorseProfile,
     /// The list of pattern -> action pairs, which can be triggered
-    pub actions: Vec<(MorsePattern, Action), MAX_PATTERNS_PER_KEY>,
+    pub actions: Vec<(MorsePattern, Action), NUM_PATTERNS>,
 }
 
 impl Default for Morse {

--- a/rmk/tests/common/mod.rs
+++ b/rmk/tests/common/mod.rs
@@ -11,7 +11,7 @@ use embassy_time::{Duration, Timer};
 use futures::join;
 use log::debug;
 use rmk::channel::{KEY_EVENT_CHANNEL, KEYBOARD_REPORT_CHANNEL};
-use rmk::config::{BehaviorConfig, PerKeyConfig};
+use rmk::config::{BehaviorConfig, PositionalConfig};
 use rmk::descriptor::KeyboardReport;
 use rmk::event::KeyboardEvent;
 use rmk::hid::Report;
@@ -152,14 +152,14 @@ pub const fn get_keymap() -> [[[KeyAction; 14]; 5]; 2] {
 pub fn create_test_keyboard_with_config(config: BehaviorConfig) -> Keyboard<'static, 5, 14, 2> {
     static BEHAVIOR_CONFIG: static_cell::StaticCell<BehaviorConfig> = static_cell::StaticCell::new();
     let behavior_config: &'static mut BehaviorConfig = BEHAVIOR_CONFIG.init(config);
-    static KEY_CONFIG: static_cell::StaticCell<PerKeyConfig<5, 14>> = static_cell::StaticCell::new();
-    let per_key_config = KEY_CONFIG.init(PerKeyConfig::default());
+    static KEY_CONFIG: static_cell::StaticCell<PositionalConfig<5, 14>> = static_cell::StaticCell::new();
+    let per_key_config = KEY_CONFIG.init(PositionalConfig::default());
     Keyboard::new(wrap_keymap(get_keymap(), per_key_config, behavior_config))
 }
 
 pub fn wrap_keymap<'a, const R: usize, const C: usize, const L: usize>(
     keymap: [[[KeyAction; C]; R]; L],
-    per_key_config: &'static mut PerKeyConfig<R, C>,
+    per_key_config: &'static mut PositionalConfig<R, C>,
     config: &'static mut BehaviorConfig,
 ) -> &'a mut RefCell<KeyMap<'static, R, C, L>> {
     // Box::leak is acceptable in tests

--- a/rmk/tests/common/morse.rs
+++ b/rmk/tests/common/morse.rs
@@ -1,5 +1,5 @@
 use heapless::Vec;
-use rmk::config::{BehaviorConfig, KeyInfo, MorsesConfig, PerKeyConfig};
+use rmk::config::{BehaviorConfig, KeyInfo, MorsesConfig, PositionalConfig};
 use rmk::keyboard::Keyboard;
 use rmk::morse::{Morse, MorsePattern};
 use rmk::types::action::Action;
@@ -46,8 +46,8 @@ pub fn create_simple_morse_keyboard(behavior_config: BehaviorConfig) -> Keyboard
 
     static BEHAVIOR_CONFIG: static_cell::StaticCell<BehaviorConfig> = static_cell::StaticCell::new();
     let behavior_config = BEHAVIOR_CONFIG.init(behavior_config);
-    static KEY_CONFIG: static_cell::StaticCell<PerKeyConfig<1, 5>> = static_cell::StaticCell::new();
-    let per_key_config = KEY_CONFIG.init(PerKeyConfig::default());
+    static KEY_CONFIG: static_cell::StaticCell<PositionalConfig<1, 5>> = static_cell::StaticCell::new();
+    let per_key_config = KEY_CONFIG.init(PositionalConfig::default());
     Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
 }
 
@@ -91,7 +91,7 @@ pub fn create_morse_keyboard(
 
     static BEHAVIOR_CONFIG: static_cell::StaticCell<BehaviorConfig> = static_cell::StaticCell::new();
     let behavior_config = BEHAVIOR_CONFIG.init(behavior_config);
-    static KEY_CONFIG: static_cell::StaticCell<PerKeyConfig<1, 5>> = static_cell::StaticCell::new();
-    let per_key_config = KEY_CONFIG.init(PerKeyConfig::new(key_info));
+    static KEY_CONFIG: static_cell::StaticCell<PositionalConfig<1, 5>> = static_cell::StaticCell::new();
+    let per_key_config = KEY_CONFIG.init(PositionalConfig::new(key_info));
     Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
 }

--- a/rmk/tests/common/morse.rs
+++ b/rmk/tests/common/morse.rs
@@ -1,5 +1,5 @@
 use heapless::Vec;
-use rmk::config::{BehaviorConfig, KeyInfo, MorsesConfig, PositionalConfig};
+use rmk::config::{BehaviorConfig, Hand, MorsesConfig, PositionalConfig};
 use rmk::keyboard::Keyboard;
 use rmk::morse::{Morse, MorsePattern};
 use rmk::types::action::Action;
@@ -51,10 +51,7 @@ pub fn create_simple_morse_keyboard(behavior_config: BehaviorConfig) -> Keyboard
     Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
 }
 
-pub fn create_morse_keyboard(
-    behavior_config: BehaviorConfig,
-    key_info: Option<[[KeyInfo; 5]; 1]>,
-) -> Keyboard<'static, 1, 5, 2> {
+pub fn create_morse_keyboard(behavior_config: BehaviorConfig, hand: [[Hand; 5]; 1]) -> Keyboard<'static, 1, 5, 2> {
     let keymap = [
         [[
             k!(A),
@@ -92,6 +89,6 @@ pub fn create_morse_keyboard(
     static BEHAVIOR_CONFIG: static_cell::StaticCell<BehaviorConfig> = static_cell::StaticCell::new();
     let behavior_config = BEHAVIOR_CONFIG.init(behavior_config);
     static KEY_CONFIG: static_cell::StaticCell<PositionalConfig<1, 5>> = static_cell::StaticCell::new();
-    let per_key_config = KEY_CONFIG.init(PositionalConfig::new(key_info));
+    let per_key_config = KEY_CONFIG.init(PositionalConfig::new(hand));
     Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
 }

--- a/rmk/tests/common/morse.rs
+++ b/rmk/tests/common/morse.rs
@@ -1,4 +1,4 @@
-use heapless::Vec;
+use heapless::{LinearMap, Vec};
 use rmk::config::{BehaviorConfig, Hand, MorsesConfig, PositionalConfig};
 use rmk::keyboard::Keyboard;
 use rmk::morse::{Morse, MorsePattern};
@@ -22,17 +22,19 @@ pub fn create_simple_morse_keyboard(behavior_config: BehaviorConfig) -> Keyboard
     ];
 
     let morse0 = Morse {
-        actions: Vec::from_slice(&[
-            (MorsePattern::from_u16(0b1_01), Action::Key(KeyCode::A)),
-            (MorsePattern::from_u16(0b1_1000), Action::Key(KeyCode::B)),
-            (MorsePattern::from_u16(0b1_1010), Action::Key(KeyCode::C)),
-            (MorsePattern::from_u16(0b1_101), Action::Key(KeyCode::K)),
-            (MorsePattern::from_u16(0b1_11), Action::Key(KeyCode::M)),
-            (MorsePattern::from_u16(0b1_111), Action::Key(KeyCode::O)),
-            (MorsePattern::from_u16(0b1_010), Action::Key(KeyCode::R)),
-            (MorsePattern::from_u16(0b1_000), Action::Key(KeyCode::S)),
-        ])
-        .unwrap(),
+        actions: LinearMap::from_iter(
+            [
+                (MorsePattern::from_u16(0b1_01), Action::Key(KeyCode::A)),
+                (MorsePattern::from_u16(0b1_1000), Action::Key(KeyCode::B)),
+                (MorsePattern::from_u16(0b1_1010), Action::Key(KeyCode::C)),
+                (MorsePattern::from_u16(0b1_101), Action::Key(KeyCode::K)),
+                (MorsePattern::from_u16(0b1_11), Action::Key(KeyCode::M)),
+                (MorsePattern::from_u16(0b1_111), Action::Key(KeyCode::O)),
+                (MorsePattern::from_u16(0b1_010), Action::Key(KeyCode::R)),
+                (MorsePattern::from_u16(0b1_000), Action::Key(KeyCode::S)),
+            ]
+            .into_iter(),
+        ),
         ..Default::default()
     };
 
@@ -64,17 +66,19 @@ pub fn create_morse_keyboard(behavior_config: BehaviorConfig, hand: [[Hand; 5]; 
     ];
 
     let morse0 = Morse {
-        actions: Vec::from_slice(&[
-            (MorsePattern::from_u16(0b1_01), Action::Key(KeyCode::A)),
-            (MorsePattern::from_u16(0b1_1000), Action::Key(KeyCode::B)),
-            (MorsePattern::from_u16(0b1_1010), Action::Key(KeyCode::C)),
-            (MorsePattern::from_u16(0b1_101), Action::Key(KeyCode::K)),
-            (MorsePattern::from_u16(0b1_11), Action::Key(KeyCode::M)),
-            (MorsePattern::from_u16(0b1_111), Action::Key(KeyCode::O)),
-            (MorsePattern::from_u16(0b1_010), Action::Key(KeyCode::R)),
-            (MorsePattern::from_u16(0b1_000), Action::Key(KeyCode::S)),
-        ])
-        .unwrap(),
+        actions: LinearMap::from_iter(
+            [
+                (MorsePattern::from_u16(0b1_01), Action::Key(KeyCode::A)),
+                (MorsePattern::from_u16(0b1_1000), Action::Key(KeyCode::B)),
+                (MorsePattern::from_u16(0b1_1010), Action::Key(KeyCode::C)),
+                (MorsePattern::from_u16(0b1_101), Action::Key(KeyCode::K)),
+                (MorsePattern::from_u16(0b1_11), Action::Key(KeyCode::M)),
+                (MorsePattern::from_u16(0b1_111), Action::Key(KeyCode::O)),
+                (MorsePattern::from_u16(0b1_010), Action::Key(KeyCode::R)),
+                (MorsePattern::from_u16(0b1_000), Action::Key(KeyCode::S)),
+            ]
+            .into_iter(),
+        ),
         ..Default::default()
     };
 

--- a/rmk/tests/keyboard_macro_test.rs
+++ b/rmk/tests/keyboard_macro_test.rs
@@ -2,7 +2,7 @@ pub mod common;
 
 mod macro_test {
     use heapless::Vec;
-    use rmk::config::{BehaviorConfig, PerKeyConfig};
+    use rmk::config::{BehaviorConfig, PositionalConfig};
     use rmk::keyboard::Keyboard;
     use rmk::keyboard_macros::{MacroOperation, define_macro_sequences, to_macro_sequence};
     use rmk::types::action::{Action, KeyAction};
@@ -19,8 +19,8 @@ mod macro_test {
         ]]];
         static BEHAVIOR_CONFIG: static_cell::StaticCell<BehaviorConfig> = static_cell::StaticCell::new();
         let behavior_config: &'static mut BehaviorConfig = BEHAVIOR_CONFIG.init(behavior_config);
-        static KEY_CONFIG: static_cell::StaticCell<PerKeyConfig<1, 2>> = static_cell::StaticCell::new();
-        let per_key_config = KEY_CONFIG.init(PerKeyConfig::default());
+        static KEY_CONFIG: static_cell::StaticCell<PositionalConfig<1, 2>> = static_cell::StaticCell::new();
+        let per_key_config = KEY_CONFIG.init(PositionalConfig::default());
         Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
     }
 

--- a/rmk/tests/keyboard_morse_hrm_test.rs
+++ b/rmk/tests/keyboard_morse_hrm_test.rs
@@ -5,7 +5,7 @@ pub mod common;
 
 use embassy_time::Duration;
 use rmk::combo::Combo;
-use rmk::config::{BehaviorConfig, CombosConfig, Hand, KeyInfo, MorsesConfig};
+use rmk::config::{BehaviorConfig, CombosConfig, Hand, MorsesConfig};
 use rmk::k;
 use rmk::keyboard::Keyboard;
 use rmk::types::action::{Action, KeyAction};
@@ -18,28 +18,7 @@ use crate::common::morse::create_morse_keyboard;
 use crate::common::{KC_LGUI, KC_LSHIFT};
 
 fn create_hrm_keyboard() -> Keyboard<'static, 1, 5, 2> {
-    let key_info = Some([[
-        KeyInfo {
-            hand: Hand::Left,
-            ..Default::default()
-        },
-        KeyInfo {
-            hand: Hand::Left,
-            ..Default::default()
-        },
-        KeyInfo {
-            hand: Hand::Right,
-            ..Default::default()
-        },
-        KeyInfo {
-            hand: Hand::Right,
-            ..Default::default()
-        },
-        KeyInfo {
-            hand: Hand::Right,
-            ..Default::default()
-        },
-    ]]);
+    let hand = [[Hand::Left, Hand::Left, Hand::Right, Hand::Right, Hand::Right]];
     create_morse_keyboard(
         BehaviorConfig {
             // All unknown hand, not home row
@@ -56,7 +35,7 @@ fn create_hrm_keyboard() -> Keyboard<'static, 1, 5, 2> {
             },
             ..Default::default()
         },
-        key_info,
+        hand,
     )
 }
 
@@ -73,28 +52,7 @@ fn create_hrm_keyboard_with_combo() -> Keyboard<'static, 1, 5, 2> {
     );
     let combo_key_3 = KeyAction::TapHold(Action::Key(KeyCode::D), Action::LayerOn(1), Default::default());
 
-    let key_info: Option<[[KeyInfo; 5]; 1]> = Some([[
-        KeyInfo {
-            hand: Hand::Left,
-            ..Default::default()
-        },
-        KeyInfo {
-            hand: Hand::Left,
-            ..Default::default()
-        },
-        KeyInfo {
-            hand: Hand::Right,
-            ..Default::default()
-        },
-        KeyInfo {
-            hand: Hand::Right,
-            ..Default::default()
-        },
-        KeyInfo {
-            hand: Hand::Right,
-            ..Default::default()
-        },
-    ]]);
+    let hand = [[Hand::Left, Hand::Left, Hand::Right, Hand::Right, Hand::Right]];
 
     create_morse_keyboard(
         BehaviorConfig {
@@ -120,7 +78,7 @@ fn create_hrm_keyboard_with_combo() -> Keyboard<'static, 1, 5, 2> {
             },
             ..BehaviorConfig::default()
         },
-        key_info,
+        hand,
     )
 }
 

--- a/rmk/tests/keyboard_morse_tap_dance_test.rs
+++ b/rmk/tests/keyboard_morse_tap_dance_test.rs
@@ -2,7 +2,7 @@
 pub mod common;
 
 use heapless::Vec;
-use rmk::config::{BehaviorConfig, MorsesConfig, PerKeyConfig};
+use rmk::config::{BehaviorConfig, MorsesConfig, PositionalConfig};
 use rmk::keyboard::Keyboard;
 use rmk::morse::Morse;
 use rmk::types::action::{Action, MorseMode, MorseProfile};
@@ -59,8 +59,8 @@ pub fn create_tap_dance_test_keyboard() -> Keyboard<'static, 1, 4, 2> {
 
     static BEHAVIOR_CONFIG: static_cell::StaticCell<BehaviorConfig> = static_cell::StaticCell::new();
     let behavior_config = BEHAVIOR_CONFIG.init(behavior_config);
-    static KEY_CONFIG: static_cell::StaticCell<PerKeyConfig<1, 4>> = static_cell::StaticCell::new();
-    let per_key_config = KEY_CONFIG.init(PerKeyConfig::default());
+    static KEY_CONFIG: static_cell::StaticCell<PositionalConfig<1, 4>> = static_cell::StaticCell::new();
+    let per_key_config = KEY_CONFIG.init(PositionalConfig::default());
     Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
 }
 

--- a/rmk/tests/keyboard_one_shot_test.rs
+++ b/rmk/tests/keyboard_one_shot_test.rs
@@ -13,7 +13,7 @@ fn one_shot_config_with_short_timeout() -> OneShotConfig {
 mod one_shot_test {
     use std::cell::RefCell;
 
-    use rmk::config::PerKeyConfig;
+    use rmk::config::PositionalConfig;
     use rmk::keyboard::Keyboard;
     use rmk::keymap::KeyMap;
     use rmk::types::action::KeyAction;
@@ -47,8 +47,8 @@ mod one_shot_test {
     fn create_test_keyboard() -> Keyboard<'static, 1, 6, 2> {
         static BEHAVIOR_CONFIG: static_cell::StaticCell<BehaviorConfig> = static_cell::StaticCell::new();
         let behavior_config = BEHAVIOR_CONFIG.init(BehaviorConfig::default());
-        static KEY_CONFIG: static_cell::StaticCell<PerKeyConfig<1, 6>> = static_cell::StaticCell::new();
-        let per_key_config = KEY_CONFIG.init(PerKeyConfig::default());
+        static KEY_CONFIG: static_cell::StaticCell<PositionalConfig<1, 6>> = static_cell::StaticCell::new();
+        let per_key_config = KEY_CONFIG.init(PositionalConfig::default());
         let keymap: &RefCell<KeyMap<1, 6, 2>> = wrap_keymap(KEYMAP, per_key_config, behavior_config);
         Keyboard::new(keymap)
     }
@@ -60,8 +60,8 @@ mod one_shot_test {
             one_shot: one_shot_config_with_short_timeout(),
             ..BehaviorConfig::default()
         });
-        static KEY_CONFIG: static_cell::StaticCell<PerKeyConfig<1, 6>> = static_cell::StaticCell::new();
-        let per_key_config = KEY_CONFIG.init(PerKeyConfig::default());
+        static KEY_CONFIG: static_cell::StaticCell<PositionalConfig<1, 6>> = static_cell::StaticCell::new();
+        let per_key_config = KEY_CONFIG.init(PositionalConfig::default());
         let keymap: &RefCell<KeyMap<1, 6, 2>> = wrap_keymap(KEYMAP, per_key_config, behavior_config);
         Keyboard::new(keymap)
     }


### PR DESCRIPTION
Recent I got many questions about the profile config, it seems that the `perkey - positional - global` configurations is kind of complex for users. This PR removes `positional` config and keeps only global config and per-key config.

Also this PR renames `PerKeyConfig` to `PositionalConfig`, which will be useful in the following `KeyMap` refactoring