### PR TITLE
Draft: Add LowPowerMatrix

### DIFF
--- a/rmk-config/src/board.rs
+++ b/rmk-config/src/board.rs
@@ -78,7 +78,7 @@ impl KeyboardTomlConfig {
             },
             (Some(m), None) => {
                 match m.matrix_type {
-                    MatrixType::normal => {
+                    MatrixType::normal | MatrixType::low_power => {
                         if m.row_pins.is_none() || m.col_pins.is_none() {
                             return Err("`row_pins` and `col_pins` is required for normal matrix".to_string());
                         }

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -324,6 +324,7 @@ pub enum MatrixType {
     #[default]
     normal,
     direct_pin,
+    low_power,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/rmk-macro/src/gpio_config.rs
+++ b/rmk-macro/src/gpio_config.rs
@@ -1,12 +1,12 @@
 use quote::{format_ident, quote};
 use rmk_config::{ChipModel, ChipSeries};
 
-pub(crate) fn convert_output_pins_to_initializers(chip: &ChipModel, pins: Vec<String>) -> proc_macro2::TokenStream {
+pub(crate) fn convert_output_pins_to_initializers(chip: &ChipModel, pins: Vec<String>, low_active: bool) -> proc_macro2::TokenStream {
     let mut initializers = proc_macro2::TokenStream::new();
     let mut idents = vec![];
     let pin_initializers = pins
         .into_iter()
-        .map(|p| (p.clone(), convert_gpio_str_to_output_pin(chip, p, false)))
+        .map(|p| (p.clone(), convert_gpio_str_to_output_pin(chip, p, low_active)))
         .map(|(p, ts)| {
             let ident_name = format_ident!("{}", p.to_lowercase());
             idents.push(ident_name.clone());
@@ -24,6 +24,7 @@ pub(crate) fn convert_input_pins_to_initializers(
     chip: &ChipModel,
     pins: Vec<String>,
     async_matrix: bool,
+    pull: Option<bool>,
 ) -> proc_macro2::TokenStream {
     let mut initializers = proc_macro2::TokenStream::new();
     let mut idents = vec![];
@@ -32,7 +33,7 @@ pub(crate) fn convert_input_pins_to_initializers(
         .map(|p| {
             (
                 p.clone(),
-                convert_gpio_str_to_input_pin(chip, p, async_matrix, Some(false)), // low active = false == pull down
+                convert_gpio_str_to_input_pin(chip, p, async_matrix, pull), // low active = false == pull down
             )
         })
         .map(|(p, ts)| {

--- a/rmk-macro/src/keyboard.rs
+++ b/rmk-macro/src/keyboard.rs
@@ -319,6 +319,14 @@ pub(crate) fn expand_matrix_and_keyboard_init(keyboard_config: &KeyboardTomlConf
                     let mut matrix = ::rmk::matrix::Matrix::<_, _, _, ROW, COL, #col2row>::new(row_pins, col_pins, debouncer);
                 }
             }
+            MatrixType::low_power => {
+                let col2row = !matrix_config.row2col;
+                let debouncer_type = get_debouncer_type(&matrix_config);
+                quote! {
+                    let debouncer = #debouncer_type::new();
+                    let mut matrix = ::rmk::matrix::LowPowerMatric::<_, _, _, ROW, COL, #col2row>::new(row_pins, col_pins, debouncer);
+                }
+            }
             MatrixType::direct_pin => {
                 let low_active = matrix_config.direct_pin_low_active;
                 let debouncer_type = get_debouncer_type(&matrix_config);
@@ -343,6 +351,7 @@ pub(crate) fn expand_matrix_and_keyboard_init(keyboard_config: &KeyboardTomlConf
                         let mut matrix = ::rmk::split::central::CentralMatrix::<_, _, _, #central_row_offset, #central_col_offset, #central_row, #central_col, #col2row>::new(row_pins, col_pins, debouncer);
                     }
                 }
+                MatrixType::low_power => {todo!()}
                 MatrixType::direct_pin => {
                     let low_active = split_config.central.matrix.direct_pin_low_active;
                     let size = split_config.central.rows * split_config.central.cols;

--- a/rmk/src/matrix.rs
+++ b/rmk/src/matrix.rs
@@ -14,6 +14,7 @@ use crate::input_device::InputDevice;
 use crate::state::ConnectionState;
 
 pub mod bidirectional_matrix;
+pub mod low_power_matrix;
 
 /// Recording the matrix pressed state
 #[cfg(feature = "vial_lock")]

--- a/rmk/src/matrix/low_power_matrix.rs
+++ b/rmk/src/matrix/low_power_matrix.rs
@@ -1,0 +1,240 @@
+use core::pin::pin;
+use embassy_time::Timer;
+use embedded_hal::digital::{ErrorType, InputPin, OutputPin};
+
+#[cfg(feature = "async_matrix")]
+use {embassy_futures::select::select_slice, embedded_hal_async::digital::Wait, heapless::Vec};
+
+use crate::debounce::{DebounceState, DebouncerTrait};
+use crate::event::{Event, KeyboardEvent};
+use crate::input_device::InputDevice;
+use crate::matrix::{KeyState, MatrixTrait};
+
+pub trait ActiveIn<const COL2ROW: bool>: ErrorType {
+    fn is_active(&mut self) -> bool;
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error>;
+}
+
+impl<
+    #[cfg(feature = "async_matrix")]
+    In: InputPin + Wait,
+    #[cfg(not(feature = "async_matrix"))]
+    In: InputPin,
+    const COL2ROW: bool
+> ActiveIn<COL2ROW> for In {
+    fn is_active(&mut self) -> bool {
+        if COL2ROW {
+            self.is_low().ok().unwrap_or_default()
+        } else {
+            self.is_high().ok().unwrap_or_default()
+        }
+    }
+
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        self.wait_for_any_edge().await
+    }
+}
+
+pub trait ActiveOut<const COL2ROW: bool> {
+    fn deactivate(&mut self);
+    fn activate(&mut self);
+}
+
+impl<Out: OutputPin, const COL2ROW: bool> ActiveOut<COL2ROW> for Out {
+    fn deactivate(&mut self) {
+        if COL2ROW {
+            self.set_high().ok();
+        } else {
+            self.set_low().ok();
+        }
+    }
+
+    fn activate(&mut self) {
+        if COL2ROW {
+            self.set_low().ok();
+        } else {
+            self.set_high().ok();
+        }
+    }
+}
+
+/// Matrix is the physical pcb layout of the keyboard matrix.
+pub struct LowPowerMatrix<
+    In: ActiveIn<COL2ROW>,
+    Out: ActiveOut<COL2ROW>,
+    D: DebouncerTrait<ROW, COL>,
+    const ROW: usize,
+    const COL: usize,
+    const COL2ROW: bool,
+> {
+    /// Row pins of the pcb matrix, are always input pins
+    row_pins: [Out; ROW],
+    /// Column pins of the pcb matrix, are always output pins
+    col_pins: [In; COL],
+    /// Debouncer
+    debouncer: D,
+    /// Key state matrix
+    key_states: [[KeyState; ROW]; COL],
+    scan_pos: (usize, usize),
+    in_progress: bool,
+    any_key_pressed: bool,
+}
+
+impl<
+    In: ActiveIn<COL2ROW>,
+    Out: ActiveOut<COL2ROW>,
+    D: DebouncerTrait<ROW, COL>,
+    const ROW: usize,
+    const COL: usize,
+    const COL2ROW: bool,
+> LowPowerMatrix<In, Out, D, ROW, COL, COL2ROW>
+{
+    /// Create a matrix from input and output pins.
+    pub fn new(row_pins: [Out; ROW], col_pins: [In; COL], debouncer: D) -> Self {
+        LowPowerMatrix {
+            row_pins,
+            col_pins,
+            debouncer,
+            key_states: [[KeyState::new(); ROW]; COL],
+            scan_pos: (0, 0),
+            in_progress: false,
+            any_key_pressed: false,
+        }
+    }
+
+    fn get_key_event(&self, row_idx: usize, col_idx: usize) -> KeyboardEvent {
+        KeyboardEvent::key(
+            row_idx as u8,
+            col_idx as u8,
+            self.key_states[col_idx][row_idx].pressed,
+        )
+    }
+
+    fn get_key_state(&self, row_idx: usize, col_idx: usize) -> KeyState {
+        self.key_states[col_idx][row_idx]
+    }
+
+    fn toggle_key_state(&mut self, row_idx: usize, col_idx: usize) {
+        self.key_states[col_idx][row_idx].toggle_pressed();
+    }
+
+    #[cfg(feature = "async_matrix")]
+    async fn wait_input_pins(&mut self) {
+        let mut futs: Vec<_, COL> = self
+            .col_pins
+            .iter_mut()
+            .map(|col_pin| col_pin.wait_for_any_edge())
+            .collect();
+        let _ = select_slice(pin!(futs.as_mut_slice())).await;
+    }
+}
+
+impl<
+    In: ActiveIn<COL2ROW>,
+    Out: ActiveOut<COL2ROW>,
+    D: DebouncerTrait<ROW, COL>,
+    const ROW: usize,
+    const COL: usize,
+    const COL2ROW: bool,
+> InputDevice for LowPowerMatrix<In, Out, D, ROW, COL, COL2ROW>
+{
+    async fn read_event(&mut self) -> Event {
+        loop {
+            let (row_idx_start, col_idx_start) = self.scan_pos;
+
+            for row_idx in row_idx_start..ROW {
+                // Activate output pin, wait 1us ensuring the change comes into effect
+                if let Some(row_pin) = self.row_pins.get_mut(row_idx) {
+                    row_pin.activate();
+                }
+                Timer::after_micros(1).await;
+
+                for col_idx in col_idx_start..COL {
+                    let col_pin_state = if let Some(col_pin) = self.col_pins.get_mut(col_idx) {
+                        col_pin.is_active()
+                    } else {
+                        false
+                    };
+
+                    // Check input pins and debounce
+                    let debounce_state = self.debouncer.detect_change_with_debounce(
+                        row_idx,
+                        col_idx,
+                        col_pin_state,
+                        &self.get_key_state(row_idx, col_idx),
+                    );
+
+                    match debounce_state {
+                        DebounceState::Debounced => {
+                            self.toggle_key_state(row_idx, col_idx);
+                            self.scan_pos = (row_idx, col_idx);
+                            return Event::Key(self.get_key_event(row_idx, col_idx));
+                        }
+                        DebounceState::InProgress => {
+                            self.in_progress = true;
+                        }
+                        DebounceState::Ignored => {
+                            if self.get_key_state(row_idx, col_idx).pressed {
+                                self.any_key_pressed = true;
+                            }
+                        }
+                    }
+                }
+
+                // Deactivate pin
+                if let Some(row_pin) = self.row_pins.get_mut(row_idx) {
+                    row_pin.deactivate();
+                }
+            }
+
+            if self.in_progress {
+                // Sleep 1 ms before scanning again
+                Timer::after_millis(1).await;
+            } else if self.any_key_pressed {
+                // Wait for any key change
+                // Scan again after 10 ms to detect other keys in the same column as they are ghosted
+                Timer::after_millis(10).await;
+                // Todo: measure which approach is more efficient:
+                // This might depend on the microcontroller and its pull-resistors
+                // select(Timer::after_millis(10), self.wait_for_key()).await;
+            } else {
+                // Sleep until a key is pressed
+                #[cfg(feature = "async_matrix")]
+                self.wait_for_key().await;
+                #[cfg(not(feature = "async_matrix"))]
+                Timer::after_millis(10).await;
+            }
+
+            self.scan_pos = (0, 0);
+            self.any_key_pressed = false;
+            self.in_progress = false;
+        }
+    }
+}
+
+impl<
+    In: ActiveIn<COL2ROW>,
+    Out: ActiveOut<COL2ROW>,
+    D: DebouncerTrait<ROW, COL>,
+    const ROW: usize,
+    const COL: usize,
+    const COL2ROW: bool,
+> MatrixTrait<ROW, COL> for LowPowerMatrix<In, Out, D, ROW, COL, COL2ROW>
+{
+    #[cfg(feature = "async_matrix")]
+    async fn wait_for_key(&mut self) {
+        // First, set activate row pins
+        for row_pin in self.row_pins.iter_mut() {
+            row_pin.activate();
+        }
+        Timer::after_micros(1).await;
+
+        // Wait for any key press
+        self.wait_input_pins().await;
+
+        // Deactivate row pins
+        for row_pin in self.row_pins.iter_mut() {
+            row_pin.deactivate();
+        }
+    }
+}


### PR DESCRIPTION
This is a work in progress improvement of the default matrix reducing power drain while de-bouncing and while keys are pressed.

First results measured with nrf52840:
- default matrix scan: ~3 mA
- low power scan: 300 - 600 µA

The improvements are two fold:
- sleeping and disabling output pins to between scans during de-bouncing
- Using interrupts while buttons are pressed

There are a lot of trade-offs and customizations possible. While interrupts would allow for low latency detection of key presses and releases, there are some drawbacks. The pressed key closes the circuit which results in current flowing over the pull-up/-down resistors. Depending on their size this might lead to a significant energy loss. Additionally the pressed key will block the detection of presses/releases of other keys connected to the same input pin. This can be somewhat mitigated by always scanning row2col, assuming one row will be only used by one single finger during fast typing. However at some point we need to scan again to detect those key changes.

To achieve row2col scanning with a col2row matrix, this implementation uses inverse polarity (pulling input pin high, setting output pin low), while using normal polarity with a row2col matrix.

To-Does:
- [ ] Check out other interrupt (hybrid) patterns and their efficiency
- [ ] Measure efficiency of using interrupts vs polling when key is pressed
- [ ] Add logic to generate code for central key matrix in split mod