### PR TITLE
Fix missed keypresses in default matrix scan implementation.

### DIFF
--- a/rmk/src/matrix.rs
+++ b/rmk/src/matrix.rs
@@ -2,7 +2,7 @@
 use core::pin::pin;
 use core::sync::atomic::Ordering;
 
-use embassy_time::{Instant, Timer};
+use embassy_time::Timer;
 use embedded_hal::digital::{InputPin, OutputPin};
 #[cfg(feature = "async_matrix")]
 use {embassy_futures::select::select_slice, embedded_hal_async::digital::Wait, heapless::Vec};
@@ -172,10 +172,10 @@ pub struct Matrix<
     debouncer: D,
     /// Key state matrix
     key_states: [[KeyState; ROW]; COL],
-    /// Start scanning
-    scan_start: Option<Instant>,
     /// Current scan pos: (out_idx, in_idx)
     scan_pos: (usize, usize),
+    /// Re-scan needed flag
+    #[cfg(feature = "async_matrix")]
     rescan_needed: bool
 }
 
@@ -346,8 +346,8 @@ where
             col_pins,
             debouncer,
             key_states: [[KeyState::new(); ROW]; COL],
-            scan_start: None,
             scan_pos: (0, 0),
+            #[cfg(feature = "async_matrix")]
             rescan_needed: false,
         }
     }
@@ -395,8 +395,6 @@ where
     async fn read_event(&mut self) -> crate::event::Event {
         loop {
             let (out_idx_start, in_idx_start) = self.scan_pos;
-            #[cfg(feature = "async_matrix")]
-            self.wait_for_key().await;
 
             // Scan matrix and send report
             for out_idx in out_idx_start..Self::OUTPUT_PIN_NUM {
@@ -404,7 +402,9 @@ where
                 if let Some(out_pin) = self.get_output_pins_mut().get_mut(out_idx) {
                     out_pin.set_high().ok();
                 }
+                // This may take >1ms on some platforms if other tasks are running!
                 Timer::after_micros(1).await;
+
                 for in_idx in in_idx_start..Self::INPUT_PIN_NUM {
                     let in_pin_state = if let Some(in_pin) = self.get_input_pins_mut().get_mut(in_idx) {
                         in_pin.is_high().ok().unwrap_or_default()
@@ -422,7 +422,10 @@ where
                     if let DebounceState::Debounced = debounce_state {
                         self.toggle_key_state(out_idx, in_idx);
                         self.scan_pos = (out_idx, in_idx);
-                        self.rescan_needed = true;
+                        #[cfg(feature = "async_matrix")]
+                        {
+                            self.rescan_needed = true;
+                        }
                         return Event::Key(self.get_key_event(out_idx, in_idx));
                     }
 
@@ -438,10 +441,14 @@ where
                     out_pin.set_low().ok();
                 }
             }
-            if self.rescan_needed {
-                self.scan_start = Some(Instant::now());
+
+            #[cfg(feature = "async_matrix")]
+            {
+                if !self.rescan_needed {
+                    self.wait_for_key().await;
+                }
+                self.rescan_needed = false;
             }
-            self.rescan_needed = false;
             self.scan_pos = (0, 0);
         }
     }
@@ -464,15 +471,7 @@ where
 {
     #[cfg(feature = "async_matrix")]
     async fn wait_for_key(&mut self) {
-        if let Some(start_time) = self.scan_start {
-            // If no key press over 1ms, stop scanning and wait for interupt
-            if self.rescan_needed || start_time.elapsed().as_millis() <= 1 {
-                return;
-            } else {
-                self.scan_start = None;
-            }
-        }
-        // First, set all output pin to high
+        // First, set all output pins to high
         for out in self.get_output_pins_mut().iter_mut() {
             out.set_high().ok();
         }
@@ -484,8 +483,6 @@ where
         for out in self.get_output_pins_mut().iter_mut() {
             out.set_low().ok();
         }
-
-        self.scan_start = Some(Instant::now());
     }
 }
 


### PR DESCRIPTION
The matrix scan algorithm can miss releases in some cases when other tasks take to long.

This happens after a debounce was completed while other keys are still pressed in the following way:
- If a several keys are pressed and a key with a higher (row,col) number is released the event is reported
- The scan is continued from the (row,col) position and will not detect any pressed keys
- If the scan continuation takes longer than 1ms interrupts are enabled and the algorithm goes to sleep while a key is still pressed.

I fixed this by adding a flag `rescan_needed` to detect these situations and block sleep.

To Does:
- [x] I'm not sure if we still need the scan_start field. We can just go to sleep if no rescan is needed. Should I remove it?
- [x] Also adapt the implementation in [split/central.rs](rmk/src/split/central.rs). Should I refactor it so we do not have two copies?
- [x] Should I add feature flags for the rescan logic to only be included when `async_matrix` is enabled?