### PR TITLE
Fix a bug of Caps Word

### DIFF
--- a/rmk-types/src/keycode.rs
+++ b/rmk-types/src/keycode.rs
@@ -1024,7 +1024,7 @@ impl KeyCode {
         }
     }
 
-    /// Does current keycode continues caps word?
+    /// Does current keycode continues Caps Word?
     pub fn is_caps_word_continue_key(self) -> bool {
         if self >= KeyCode::A && self <= KeyCode::Z {
             return true;
@@ -1038,7 +1038,7 @@ impl KeyCode {
         false
     }
 
-    /// Does current keycode is to be shifted by caps word?
+    /// Does current keycode is to be shifted by Caps Word?
     pub fn is_caps_word_shifted_key(self) -> bool {
         if self >= KeyCode::A && self <= KeyCode::Z {
             return true;

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -76,6 +76,80 @@ impl<T> OneShotState<T> {
     }
 }
 
+/// State machine for Caps Word
+#[derive(Debug, Default)]
+enum CapsWordState {
+    /// Caps Word is activated (but may have timed out thus becoming inactive)
+    Activated {
+        /// Time since last key press
+        timer: Instant,
+        /// Whether the current key should be shifted
+        shift_current: bool,
+    },
+    /// Caps Word is deactivated
+    #[default]
+    Deactivated,
+}
+
+impl CapsWordState {
+    /// Caps Word timeout duration
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// Activate Caps Word
+    fn activate(&mut self) {
+        *self = CapsWordState::Activated {
+            timer: Instant::now(),
+            shift_current: false,
+        };
+    }
+
+    /// Deactivate Caps Word
+    fn deactivate(&mut self) {
+        *self = CapsWordState::Deactivated;
+    }
+
+    /// Toggle Caps Word
+    fn toggle(&mut self) {
+        match self {
+            CapsWordState::Activated { .. } => self.deactivate(),
+            CapsWordState::Deactivated => self.activate(),
+        }
+    }
+
+    /// Return whether Caps Word is active (and has not timed out)
+    fn is_active(&self) -> bool {
+        if let CapsWordState::Activated { timer, .. } = self {
+            timer.elapsed() < Self::TIMEOUT
+        } else {
+            false
+        }
+    }
+
+    /// Return whether the current key pressed is to be shifted
+    fn is_shift_current(&self) -> bool {
+        if let CapsWordState::Activated { shift_current, .. } = self {
+            *shift_current
+        } else {
+            false
+        }
+    }
+
+    /// Check whether to shift the given key, and update the state accordingly
+    ///
+    /// Note that this function does not check the CapsWord key itself.
+    fn check(&mut self, key: KeyCode) {
+        if let CapsWordState::Activated { timer, shift_current } = self {
+            if key.is_caps_word_continue_key() && timer.elapsed() < Self::TIMEOUT
+            {
+                *timer = Instant::now();
+                *shift_current = key.is_caps_word_shifted_key();
+            } else {
+                self.deactivate();
+            }
+        }
+    }
+}
+
 impl<const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_ENCODER: usize> Runnable
     for Keyboard<'_, ROW, COL, NUM_LAYER, NUM_ENCODER>
 {
@@ -133,13 +207,8 @@ pub struct Keyboard<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usi
     /// One shot modifier state
     osm_state: OneShotState<ModifierCombination>,
 
-    /// Caps word state - whether caps word is currently active
-    caps_word_active: bool,
-    /// Caps word shift state - whether the current pressed key should be shifted.
-    /// Its value doesn't matter if caps word is not active (or has timed out) or no key is pressed.
-    caps_word_shift: bool,
-    /// Caps word idle timer - tracks when caps word should timeout
-    caps_word_timer: Option<Instant>,
+    /// Caps Word state machine
+    caps_word: CapsWordState,
 
     /// The modifiers coming from (last) Action::KeyWithModifier
     with_modifiers: ModifierCombination,
@@ -195,9 +264,7 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
             last_press_time: Instant::now(),
             osl_state: OneShotState::default(),
             osm_state: OneShotState::default(),
-            caps_word_active: false,
-            caps_word_shift: false,
-            caps_word_timer: None,
+            caps_word: CapsWordState::default(),
             with_modifiers: ModifierCombination::default(),
             macro_texting: false,
             macro_caps: false,
@@ -1320,19 +1387,10 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
         // the suppression effect of forks should not apply on these
         result |= self.with_modifiers;
 
-        // Apply caps word shift if it is active, has not timed out,
-        // and the current key belongs to those that should be shifted
-        if self.caps_word_active
-            && let Some(timer) = self.caps_word_timer
-            && timer.elapsed() < Duration::from_secs(5)
-        {
-            if pressed && self.caps_word_shift {
-                result |= ModifierCombination::new().with_left_shift(true);
-            }
-        } else {
-            self.caps_word_timer = None;
-            self.caps_word_active = false;
-        };
+        // Apply Caps Word shift
+        if self.caps_word.is_active() && pressed && self.caps_word.is_shift_current() {
+            result |= ModifierCombination::new().with_left_shift(true);
+        }
 
         result
     }
@@ -1366,16 +1424,9 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
                 }
             }
             KeyCode::CapsWordToggle => {
-                // Handle caps word keycode by triggering the action
+                // Handle Caps Word keycode
                 if event.pressed {
-                    self.caps_word_active = !self.caps_word_active;
-                    if self.caps_word_active {
-                        // The caps word is just activated, set the timer
-                        self.caps_word_timer = Some(Instant::now());
-                    } else {
-                        // The caps word is just deactivated, reset the timer
-                        self.caps_word_timer = None;
-                    }
+                    self.caps_word.toggle();
                 };
                 return;
             }
@@ -1400,19 +1451,8 @@ impl<'a, const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_E
                 );
                 self.last_key_code = key;
             }
-            // Check caps word
-            if self.caps_word_active {
-                if key.is_caps_word_continue_key()
-                    && let Some(timer) = self.caps_word_timer
-                    && timer.elapsed() < Duration::from_secs(5)
-                {
-                    self.caps_word_timer = Some(Instant::now());
-                    self.caps_word_shift = key.is_caps_word_shifted_key();
-                } else {
-                    self.caps_word_active = false;
-                    self.caps_word_timer = None;
-                }
-            }
+            // Check Caps Word
+            self.caps_word.check(key);
         }
 
         // Consumer, system and mouse keys should be processed before basic keycodes, since basic keycodes contain them all


### PR DESCRIPTION
This PR is a small fix of Caps Word.

According to [QMK](https://docs.qmk.fm/features/caps_word) and [ZMK](https://docs.qmk.fm/features/caps_word) documentations, Caps Word has two set of keys:
- keys that continue Caps Word, including A-Z, 0-9, minus (underscore), backspace, and delete, and
- keys that are shifted if Caps Word is activated now, including only A-Z and minus

This design makes typing capitalized acronyms (like “USA”) and constants (like `FOO_123`) easier.

However, the current implementation only recognizes when Caps Word is active (like, after tapping `KeyCode::CapsWordToggle`), and if so, capitalizes any key pressed. This results in an undesired behavior that the key sequence {CapsWord key, f, o, o, -, 1, 2, 3} is interpreted as “FOO_!@#” but not “FOO_123”.

This PR makes the following changes:
- Adds a boolean member variable for `Keyboard` to mark whether the current pressed key should be shifted
- Updates the variable when Caps Word is active and a key is pressed
- Adds a function for `KeyCode` which decides whether a key belongs to those that can be shifted by Caps Word