### PR TITLE
Remove unused `EnumIter` in rmk-types

### DIFF
--- a/rmk-types/src/keycode.rs
+++ b/rmk-types/src/keycode.rs
@@ -2,14 +2,14 @@
 //!
 //! This module provides keycode definitions following the USB HID
 //! specification, extended with additional codes
-use strum::{EnumIter, FromRepr};
+use strum::FromRepr;
 
 use crate::modifier::ModifierCombination;
 
 /// KeyCode is the internal representation of all keycodes, keyboard operations, etc.
 /// Use flat representation of keycodes.
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, FromRepr, EnumIter)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, FromRepr)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(postcard::experimental::max_size::MaxSize)]
 pub enum KeyCode {
@@ -1322,7 +1322,7 @@ impl From<u16> for KeyCode {
 /// Ref: <https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf#page=75>
 #[non_exhaustive]
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, FromRepr, EnumIter)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, FromRepr)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConsumerKey {
     No = 0x00,
@@ -1395,7 +1395,7 @@ impl From<u16> for ConsumerKey {
 /// Ref: <https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf#page=26>
 #[non_exhaustive]
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, FromRepr, EnumIter)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, FromRepr)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SystemControlKey {
     No = 0x00,


### PR DESCRIPTION
A try to fix #640 