### PR TITLE
Replace const PollingController::INTERVAL with interval() method

### DIFF
--- a/docs/docs/main/docs/features/controller.md
+++ b/docs/docs/main/docs/features/controller.md
@@ -63,12 +63,44 @@ Controllers that need periodic updates implement `PollingController`:
 
 ```rust
 impl PollingController for MyPollingController {
-    const INTERVAL: embassy_time::Duration = embassy_time::Duration::from_millis(100);
+    fn interval(&self) -> embassy_time::Duration {
+        embassy_time::Duration::from_millis(100)
+    }
 
     async fn update(&mut self) {
         // Periodic update logic (e.g., LED animations, sensor readings)
     }
 }
+```
+
+The polling interval can also be passed as a parameter like this:
+
+```rust
+struct ConfigurableController {
+    interval: embassy_time::Duration,
+}
+
+impl ConfigurableController {
+    /// Create a controller with a specific update frequency in Hz
+    pub fn with_hz(hz: u32) -> Self {
+        Self {
+            interval: embassy_time::Duration::from_hz(hz as u64),
+        }
+    }
+}
+
+impl PollingController for ConfigurableController {
+    fn interval(&self) -> embassy_time::Duration {
+        self.interval
+    }
+
+    async fn update(&mut self) {
+        // update periodic
+    }
+}
+
+// Usage: create a controller with 60Hz update rate
+let controller = ConfigurableController::with_hz(60);
 ```
 
 ### Controller Events
@@ -201,7 +233,9 @@ impl<P: StatefulOutputPin> Controller for BlinkingController<P> {
 }
 
 impl<P: StatefulOutputPin> PollingController for BlinkingController<P> {
-    const INTERVAL: embassy_time::Duration = embassy_time::Duration::from_millis(500);
+    fn interval(&self) -> embassy_time::Duration {
+        embassy_time::Duration::from_millis(500)
+    }
 
     async fn update(&mut self) {
         // Toggle LED every 500ms when active (i.e., current layer is not 0)

--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `PollingController::INTERVAL` constant is now `PollingController::interval()` method, allowing dynamic interval configuration at runtime
+
 ## [0.8.2] - 2025-12-18
 
 ### Added

--- a/rmk/src/controller/battery_led.rs
+++ b/rmk/src/controller/battery_led.rs
@@ -60,7 +60,9 @@ impl<P: StatefulOutputPin> Controller for BatteryLedController<P> {
 }
 
 impl<P: StatefulOutputPin> PollingController for BatteryLedController<P> {
-    const INTERVAL: embassy_time::Duration = embassy_time::Duration::from_secs(1);
+    fn interval(&self) -> embassy_time::Duration {
+        embassy_time::Duration::from_secs(1)
+    }
 
     async fn update(&mut self) {
         match self.state {

--- a/rmk/src/controller/mod.rs
+++ b/rmk/src/controller/mod.rs
@@ -63,10 +63,12 @@ impl<T: Controller> EventController for T {}
 /// The trait for polling controllers.
 ///
 /// This trait defines the interface for polling controllers in RMK.
+/// The polling interval can be configured either as a fixed value or
+/// dynamically at runtime through the [`Self::interval()`] method.
 ///
-/// # Example
+/// # Example (Fixed Interval)
 /// ```rust
-/// // Define a controller
+/// // Define a controller with a fixed interval
 /// struct MyController;
 ///
 /// impl Controller for MyController {
@@ -76,7 +78,9 @@ impl<T: Controller> EventController for T {}
 /// }
 ///
 /// impl PollingController for MyController {
-///     type INTERVAL: embassy_time::Duration = embassy_time::Duration::from_hz(30);
+///     fn interval(&self) -> embassy_time::Duration {
+///         embassy_time::Duration::from_hz(30)
+///     }
 ///
 ///     async fn update(&mut self) {
 ///         // update periodic
@@ -95,11 +99,49 @@ impl<T: Controller> EventController for T {}
 /// )
 /// .await;
 /// ```
+///
+/// # Example (Dynamic Interval)
+/// ```rust
+/// // Define a controller with a configurable interval
+/// struct ConfigurableController {
+///     interval: embassy_time::Duration,
+/// }
+///
+/// impl ConfigurableController {
+///     /// Create a controller with a specific update frequency in Hz
+///     pub fn with_hz(hz: u32) -> Self {
+///         Self {
+///             interval: embassy_time::Duration::from_hz(hz as u64),
+///         }
+///     }
+/// }
+///
+/// impl Controller for ConfigurableController {
+///     async fn process_event(&mut self, event: Self::Event) {
+///         // handle event
+///     }
+/// }
+///
+/// impl PollingController for ConfigurableController {
+///     fn interval(&self) -> embassy_time::Duration {
+///         self.interval
+///     }
+///
+///     async fn update(&mut self) {
+///         // update periodic
+///     }
+/// }
+///
+/// // Use the controller with 60Hz update rate
+/// let c = ConfigurableController::with_hz(60);
+/// ```
 pub trait PollingController: Controller {
-    /// Interval between `update` calls
-    const INTERVAL: embassy_time::Duration;
+    /// Returns the interval between `update` calls.
+    ///
+    /// This method can be overridden to provide a custom interval
+    fn interval(&self) -> embassy_time::Duration;
 
-    /// Update periodically, will be called according to [`Self::INTERVAL`]
+    /// Update periodically, will be called according to [`Self::interval()`]
     async fn update(&mut self);
 
     /// Polling loop
@@ -111,7 +153,7 @@ pub trait PollingController: Controller {
 
             match select(
                 embassy_time::Timer::after(
-                    Self::INTERVAL
+                    self.interval()
                         .checked_sub(elapsed)
                         .unwrap_or(embassy_time::Duration::MIN),
                 ),

--- a/rmk/src/controller/wpm.rs
+++ b/rmk/src/controller/wpm.rs
@@ -41,7 +41,9 @@ impl Controller for WpmController {
 }
 
 impl PollingController for WpmController {
-    const INTERVAL: embassy_time::Duration = embassy_time::Duration::from_secs(1);
+    fn interval(&self) -> embassy_time::Duration {
+        embassy_time::Duration::from_secs(1)
+    }
 
     async fn update(&mut self) {
         self.update_count = SAMPLES.min(self.update_count + 1);


### PR DESCRIPTION
Replaced const `PollingController::INTERVAL` with `interval()` method so that values from `keyboard.toml` can be passed, as required in #678.