### PR TITLE
fix stm32h7 usb clock mux configuration

### DIFF
--- a/examples/use_config/stm32h7/src/main.rs
+++ b/examples/use_config/stm32h7/src/main.rs
@@ -30,7 +30,7 @@ mod my_keyboard {
     fn config() -> Config {
         let mut config = Config::default();
         {
-            use embassy_stm32::rcc::*;
+            use embassy_stm32::rcc::{mux, *};
             config.rcc.hsi = Some(HSIPrescaler::DIV1);
             config.rcc.csi = true;
             // Needed for USB
@@ -55,6 +55,9 @@ mod my_keyboard {
             config.rcc.apb3_pre = APBPrescaler::DIV2;
             config.rcc.apb4_pre = APBPrescaler::DIV2;
             config.rcc.voltage_scale = VoltageScale::Scale0;
+            // Configure USB clock mux to use HSI48 (internal 48MHz oscillator)
+            // HSI48 is internal, no external crystal needed for USB - better compatibility
+            config.rcc.mux.usbsel = mux::Usbsel::HSI48;
         }
         config
     }

--- a/examples/use_rust/stm32h7/src/main.rs
+++ b/examples/use_rust/stm32h7/src/main.rs
@@ -40,7 +40,7 @@ async fn main(_spawner: Spawner) {
     // RCC config
     let mut config = Config::default();
     {
-        use embassy_stm32::rcc::*;
+        use embassy_stm32::rcc::{mux, *};
         config.rcc.hsi = Some(HSIPrescaler::DIV1);
         config.rcc.csi = true;
         // Needed for USB
@@ -65,6 +65,9 @@ async fn main(_spawner: Spawner) {
         config.rcc.apb3_pre = APBPrescaler::DIV2;
         config.rcc.apb4_pre = APBPrescaler::DIV2;
         config.rcc.voltage_scale = VoltageScale::Scale0;
+        // Configure USB clock mux to use HSI48 (internal 48MHz oscillator)
+        // HSI48 is internal, no external crystal needed for USB - better compatibility
+        config.rcc.mux.usbsel = mux::Usbsel::HSI48;
     }
 
     // Initialize peripherals


### PR DESCRIPTION
## Problem
Without explicit USB clock mux configuration, the USB_OTG_HS peripheral fails to initialize with the following error:
panicked at 'attempted to use peripheral 'USB_OTG_HS' but its clock mux is not set to a valid clock. Change 'config.rcc.mux' to another clock.'

## Solution
Add USB clock mux configuration for STM32H7 examples to fix USB initialization failure. Configure `config.rcc.mux.usbsel = mux::Usbsel::HSI48` to explicitly select HSI48 as the USB clock source.

## Changes
- `examples/use_rust/stm32h7/src/main.rs`: Added USB clock mux configuration
- `examples/use_config/stm32h7/src/main.rs`: Added USB clock mux configuration