### PR TITLE
feat: add one-shot sticky modifiers

### DIFF
--- a/docs/docs/main/docs/configuration/appendix.md
+++ b/docs/docs/main/docs/configuration/appendix.md
@@ -109,9 +109,21 @@ MouseWheelLeft   MouseDown  MouseWheelRight  MouseWheelDown
 # Behavior configuration, if you don't want to customize anything, just ignore this section
 [behavior]
 # Tri Layer configuration
-tri_layer = { upper = 1, lower = 2, adjust = 3 }
-# One Shot configuration
-one_shot = { timeout = "1s" }
+tri_layer = {
+  upper = 1,
+  lower = 2,
+  adjust = 3,
+}
+
+# OneShot configuration
+one_shot = {
+  timeout = "1s"
+}
+
+# One Shot Modifiers configuration
+one_shot_modifiers = {
+  activate_on_keypress = false,
+}
 
 [behavior.morse]
 # default profile for morse, tap dance and tap-hold keys:

--- a/docs/docs/main/docs/configuration/behavior.md
+++ b/docs/docs/main/docs/configuration/behavior.md
@@ -4,8 +4,17 @@ The `[behavior]` section contains configuration for how different keyboard actio
 
 ```toml
 [behavior]
-tri_layer = { upper = 1, lower = 2, adjust = 3 }
-one_shot = { timeout = "1s" }
+tri_layer = {
+  upper = 1,
+  lower = 2,
+  adjust = 3,
+}
+one_shot = {
+  timeout = "1s",
+}
+one_shot_modifiers = {
+  activate_on_keypress = false,
+}
 ```
 
 ## Tri Layer
@@ -25,13 +34,34 @@ In this example, when both layers 1 (`upper`) and 2 (`lower`) are active, layer 
 
 Note that `"#layer_name"` could also be used in place of layer numbers.
 
-## One Shot
+## One-Shot
 
-The `one_shot` sub-table configures one-shot modifiers or one-shot layers (OSM/OSL). Use `timeout` to specify how long the modifier/layer remains active. The value is a string suffixed with `s` or `ms` (default: `1s`).
+The `one_shot` sub-table contains common one-shot configuration (for both OSM and OSL)
 
+Currently, there are only `timeout` field that specifies how long the one-shot modifier/layer remains active.
+When no key is pressed within this time, the one-shot modifier/layer will be canceled.
+`timeout` value is a string suffixed with `s` or `ms` (default: `1s`).
+
+## One-Shot Modifiers
+
+The `one_shot_modifiers` sub-table configures one-shot modifiers (OSM).
+
+By default, one-shot modifiers do not activate on keypress and will be sent only when other key is pressed.
+You can change this behavior by setting `activate_on_keypress` to `true`.
+This behavior is also known as One-Shot Sticky Modifiers (OSSM).
+
+If you press One-Shot Modifier again, it will be sent as a normal modifier key press and, therefore, released.
+
+Default values:
 ```toml
-[behavior.one_shot]
-timeout = "5s"
+[behavior.one_shot_modifiers]
+activate_on_keypress = false
+```
+
+OSSM example:
+```toml
+[behavior.one_shot_modifiers]
+activate_on_keypress = true
 ```
 
 ## Combo

--- a/examples/use_rust/nrf52840_ble_split_dongle/Cargo.lock
+++ b/examples/use_rust/nrf52840_ble_split_dongle/Cargo.lock
@@ -1829,7 +1829,6 @@ dependencies = [
  "bt-hci",
  "byteorder",
  "chrono",
- "const-gen",
  "cortex-m",
  "crc32fast",
  "defmt 1.0.1",
@@ -1850,14 +1849,12 @@ dependencies = [
  "paste",
  "postcard",
  "rand_core 0.6.4",
- "rmk-config",
  "rmk-macro",
  "rmk-types",
  "sequential-storage",
  "serde",
  "ssmarshal",
  "static_cell",
- "toml 1.0.3+spec-1.1.0",
  "trouble-host",
  "usbd-hid 0.9.0",
 ]
@@ -1922,8 +1919,10 @@ dependencies = [
  "bitfield-struct",
  "defmt 1.0.1",
  "postcard",
+ "rmk-config",
  "serde",
  "strum",
+ "toml 1.0.3+spec-1.1.0",
 ]
 
 [[package]]

--- a/rmk-config/src/behavior.rs
+++ b/rmk-config/src/behavior.rs
@@ -20,6 +20,7 @@ impl crate::KeyboardTomlConfig {
                     None => default.tri_layer,
                 };
                 behavior.one_shot = behavior.one_shot.or(default.one_shot);
+                behavior.one_shot_modifiers = behavior.one_shot_modifiers.or(default.one_shot_modifiers);
                 behavior.combo = behavior.combo.or(default.combo);
                 if let Some(combo) = &behavior.combo {
                     if combo.combos.len() > self.rmk.combo_max_num {

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -547,6 +547,7 @@ pub struct KeyInfo {
 pub(crate) struct BehaviorConfig {
     pub tri_layer: Option<TriLayerConfig>,
     pub one_shot: Option<OneShotConfig>,
+    pub one_shot_modifiers: Option<OneShotModifiersConfig>,
     pub combo: Option<CombosConfig>,
     #[serde(alias = "macro")]
     pub macros: Option<MacrosConfig>,
@@ -583,11 +584,18 @@ pub(crate) struct TriLayerConfig {
     pub adjust: u8,
 }
 
-/// Configurations for one shot
+/// Configurations for oneshot modifiers/layers
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct OneShotConfig {
     pub timeout: Option<DurationMillis>,
+}
+
+/// Configurations for oneshot modifiers
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OneShotModifiersConfig {
+    pub activate_on_keypress: Option<bool>,
 }
 
 /// Configurations for combos

--- a/rmk-config/src/resolved/behavior.rs
+++ b/rmk-config/src/resolved/behavior.rs
@@ -4,10 +4,15 @@ use std::collections::HashMap;
 pub struct Behavior {
     pub tri_layer: Option<[u8; 3]>,
     pub one_shot_timeout_ms: Option<u64>,
+    pub one_shot_modifiers: Option<OneShot>,
     pub combos: Option<Combos>,
     pub macros: Option<Macros>,
     pub forks: Option<Forks>,
     pub morse: Option<Morse>,
+}
+
+pub struct OneShot {
+    pub activate_on_keypress: Option<bool>,
 }
 
 pub struct Combos {
@@ -95,6 +100,10 @@ impl crate::KeyboardTomlConfig {
         let tri_layer = toml_behavior.tri_layer.map(|t| [t.upper, t.lower, t.adjust]);
 
         let one_shot_timeout_ms = toml_behavior.one_shot.and_then(|o| o.timeout.map(|t| t.0));
+
+        let one_shot_modifiers = toml_behavior.one_shot_modifiers.map(|o| OneShot {
+            activate_on_keypress: o.activate_on_keypress,
+        });
 
         let combos = toml_behavior.combo.map(|c| Combos {
             combos: c
@@ -191,6 +200,7 @@ impl crate::KeyboardTomlConfig {
         Ok(Behavior {
             tri_layer,
             one_shot_timeout_ms,
+            one_shot_modifiers,
             combos,
             macros,
             forks,

--- a/rmk-macro/src/codegen/behavior.rs
+++ b/rmk-macro/src/codegen/behavior.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use quote::quote;
 use rmk_config::resolved::Behavior;
 use rmk_config::resolved::behavior::{
-    Combos, Forks, MacroOperation, Macros, Morse, MorseActionPair, MorseKey, MorseProfile,
+    Combos, Forks, MacroOperation, Macros, Morse, MorseActionPair, MorseKey, MorseProfile, OneShot,
 };
 
 use super::action_parser::{expand_profile, expand_profile_name, get_key_with_alias, parse_key};
@@ -31,6 +31,27 @@ fn expand_one_shot(one_shot_timeout_ms: &Option<u64>) -> proc_macro2::TokenStrea
             quote! {
                 ::rmk::config::OneShotConfig {
                     timeout: #timeout,
+                }
+            }
+        }
+        None => default,
+    }
+}
+
+fn expand_one_shot_modifiers(one_shot_modifiers: &Option<OneShot>) -> proc_macro2::TokenStream {
+    let default = quote! { ::core::default::Default::default() };
+
+    match one_shot_modifiers {
+        Some(one_shot_modifier) => {
+            let activate_on_keypress = match one_shot_modifier.activate_on_keypress {
+                Some(value) => quote! { activate_on_keypress: #value, },
+                None => quote! {},
+            };
+
+            quote! {
+                ::rmk::config::OneShotModifiersConfig {
+                    #activate_on_keypress
+                    ..Default::default()
                 }
             }
         }
@@ -441,6 +462,7 @@ pub(crate) fn expand_behavior_config(behavior: &Behavior) -> proc_macro2::TokenS
 
     let tri_layer = expand_tri_layer(&behavior.tri_layer);
     let one_shot = expand_one_shot(&behavior.one_shot_timeout_ms);
+    let one_shot_modifiers = expand_one_shot_modifiers(&behavior.one_shot_modifiers);
     let combos = expand_combos(&behavior.combos, &profiles);
     let macros = expand_macros(&behavior.macros);
     let forks = expand_forks(&behavior.forks, &profiles);
@@ -451,6 +473,7 @@ pub(crate) fn expand_behavior_config(behavior: &Behavior) -> proc_macro2::TokenS
         let mut behavior_config = ::rmk::config::BehaviorConfig {
             tri_layer: #tri_layer,
             one_shot: #one_shot,
+            one_shot_modifiers: #one_shot_modifiers,
             combo: #combos,
             fork: #forks,
             morse: #morse,

--- a/rmk-types/src/action.rs
+++ b/rmk-types/src/action.rs
@@ -114,7 +114,7 @@ impl MorseProfile {
     ///   the hold action of current morse key will be triggered
     ///   https://docs.qmk.fm/tap_hold#tap-or-hold-decision-modes
     /// - if hold_on_other_press is set - triggers hold immediately if any other non-morse
-    ///   key is pressed while the current morse key is held    
+    ///   key is pressed while the current morse key is held
     pub fn mode(self) -> Option<MorseMode> {
         match self.0 & 0xC000_0000 {
             0xC000_0000 => Some(MorseMode::Normal),
@@ -241,7 +241,7 @@ pub enum KeyAction {
     Single(Action),
     /// Don't wait the release of the key, auto-release after a time threshold.
     Tap(Action),
-    /// Tap hold action    
+    /// Tap hold action
     TapHold(Action, Action, MorseProfile),
 
     /// Morse action, references a morse configuration by index.
@@ -316,7 +316,7 @@ pub enum Action {
     TriggerMacro(u8),
     /// Oneshot layer, keep the layer active until the next key is triggered.
     OneShotLayer(u8),
-    /// Oneshot modifier, keep the modifier active until the next key is triggered.
+    /// Oneshot modifier, applies ModifierCombination for the next keypress only.
     OneShotModifier(ModifierCombination),
     /// Oneshot key, keep the key active until the next key is triggered.
     OneShotKey(KeyCode),

--- a/rmk/src/config/behavior.rs
+++ b/rmk/src/config/behavior.rs
@@ -13,6 +13,7 @@ pub struct BehaviorConfig {
     pub tri_layer: Option<[u8; 3]>,
     pub tap: TapConfig,
     pub one_shot: OneShotConfig,
+    pub one_shot_modifiers: OneShotModifiersConfig,
     pub combo: CombosConfig,
     pub fork: ForksConfig,
     pub morse: MorsesConfig,
@@ -61,6 +62,7 @@ impl Default for MorsesConfig {
 /// Config for one shot behavior
 #[derive(Clone, Copy, Debug)]
 pub struct OneShotConfig {
+    /// Timeout after which modifiers/layers are canceled/released
     pub timeout: Duration,
 }
 
@@ -68,6 +70,20 @@ impl Default for OneShotConfig {
     fn default() -> Self {
         Self {
             timeout: Duration::from_secs(1),
+        }
+    }
+}
+/// Config for one-shot behavior
+#[derive(Clone, Copy, Debug)]
+pub struct OneShotModifiersConfig {
+    /// Should modifiers be active from keypress (sticky modifiers)
+    pub activate_on_keypress: bool,
+}
+
+impl Default for OneShotModifiersConfig {
+    fn default() -> Self {
+        Self {
+            activate_on_keypress: false,
         }
     }
 }

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -8,7 +8,7 @@ mod vial;
 
 pub use behavior::{
     BehaviorConfig, CombosConfig, ForksConfig, KeyboardMacrosConfig, MorsesConfig, MouseKeyConfig, OneShotConfig,
-    TapConfig,
+    OneShotModifiersConfig, TapConfig,
 };
 #[cfg(feature = "_ble")]
 pub use ble_battery::BleBatteryConfig;

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1,5 +1,6 @@
 use core::fmt::Debug;
 
+#[cfg(all(feature = "split", feature = "_ble"))]
 use embassy_futures::select::{Either, select};
 use embassy_futures::yield_now;
 #[cfg(feature = "_ble")]
@@ -27,6 +28,7 @@ use crate::hid::Report;
 use crate::input_device::Runnable;
 use crate::keyboard::held_buffer::{HeldBuffer, HeldKey, KeyState};
 use crate::keyboard::mouse::{MouseAction, MouseState};
+use crate::keyboard::oneshot::OneShotState;
 use crate::keyboard_macros::MacroOperation;
 use crate::keymap::KeyMap;
 use crate::morse::{MorsePattern, TAP};
@@ -49,30 +51,6 @@ pub(crate) static LAST_KEY_TIMESTAMP: Signal<crate::RawMutex, u32> = Signal::new
 /// Led states for the keyboard hid report (its value is received by by the light service in a hid report)
 /// LedIndicator type would be nicer, but that does not have const expr constructor
 pub(crate) static LOCK_LED_STATES: core::sync::atomic::AtomicU8 = core::sync::atomic::AtomicU8::new(0u8);
-
-/// State machine for one shot keys
-#[derive(Default)]
-enum OneShotState<T> {
-    /// First one shot key press
-    Initial(T),
-    /// One shot key was released before any other key, normal one shot behavior
-    Single(T),
-    /// Another key was pressed before one shot key was released, treat as a normal modifier/layer
-    Held(T),
-    /// One shot inactive
-    #[default]
-    None,
-}
-
-impl<T> OneShotState<T> {
-    /// Get the current one shot value if any
-    pub fn value(&self) -> Option<&T> {
-        match self {
-            OneShotState::Initial(v) | OneShotState::Single(v) | OneShotState::Held(v) => Some(v),
-            OneShotState::None => None,
-        }
-    }
-}
 
 /// State machine for Caps Word
 #[derive(Debug, Default)]
@@ -211,10 +189,10 @@ pub struct Keyboard<'a> {
     /// Used in repeat-key
     last_key_code: KeyCode,
 
-    /// One shot layer state
+    /// Oneshot Layer state
     osl_state: OneShotState<u8>,
 
-    /// One shot modifier state
+    /// Oneshot Modifier state
     osm_state: OneShotState<ModifierCombination>,
 
     /// Caps Word state machine
@@ -1267,99 +1245,6 @@ impl<'a> Keyboard<'a> {
             .for_each(|(i, k)| info!("\n✅Held buffer {}: {:?}, state: {:?}", i, k.event, k.state));
     }
 
-    async fn process_action_osm(&mut self, modifiers: ModifierCombination, event: KeyboardEvent) {
-        // Update one shot state
-        if event.pressed {
-            // Add new modifier combination to existing one shot or init if none
-            self.osm_state = match self.osm_state {
-                OneShotState::None => OneShotState::Initial(modifiers),
-                OneShotState::Initial(m) => OneShotState::Initial(m | modifiers),
-                OneShotState::Single(m) => OneShotState::Single(m | modifiers),
-                OneShotState::Held(m) => OneShotState::Held(m | modifiers),
-            };
-
-            self.update_osl(event);
-        } else {
-            match self.osm_state {
-                OneShotState::Initial(m) | OneShotState::Single(m) => {
-                    self.osm_state = OneShotState::Single(m);
-                    let timeout = Timer::after(self.keymap.one_shot_timeout());
-                    match select(timeout, self.keyboard_event_subscriber.next_message_pure()).await {
-                        Either::First(_) => {
-                            // Timeout, release modifiers
-                            self.update_osl(event);
-                            self.osm_state = OneShotState::None;
-                        }
-                        Either::Second(e) => {
-                            // New event, send it to queue
-                            if self.unprocessed_events.push(e).is_err() {
-                                warn!("Unprocessed event queue is full, dropping event");
-                            }
-                        }
-                    }
-                }
-                OneShotState::Held(_) => {
-                    // Release modifier
-                    self.update_osl(event);
-                    self.osm_state = OneShotState::None;
-
-                    // This sends a separate hid report with the
-                    // currently registered modifiers except the
-                    // one shoot modifiers -> this way "releasing" them.
-                    self.send_keyboard_report_with_resolved_modifiers(event.pressed).await;
-                }
-                _ => (),
-            };
-        }
-    }
-
-    async fn process_action_osl(&mut self, layer_num: u8, event: KeyboardEvent) {
-        // Update one shot state
-        if event.pressed {
-            // Deactivate old layer if any
-            if let Some(&l) = self.osl_state.value() {
-                self.keymap.deactivate_layer(l);
-            }
-
-            // Update layer of one shot
-            self.osl_state = match self.osl_state {
-                OneShotState::None => OneShotState::Initial(layer_num),
-                OneShotState::Initial(_) => OneShotState::Initial(layer_num),
-                OneShotState::Single(_) => OneShotState::Single(layer_num),
-                OneShotState::Held(_) => OneShotState::Held(layer_num),
-            };
-
-            // Activate new layer
-            self.keymap.activate_layer(layer_num);
-        } else {
-            match self.osl_state {
-                OneShotState::Initial(l) | OneShotState::Single(l) => {
-                    self.osl_state = OneShotState::Single(l);
-
-                    let timeout = embassy_time::Timer::after(self.keymap.one_shot_timeout());
-                    match select(timeout, self.keyboard_event_subscriber.next_message_pure()).await {
-                        Either::First(_) => {
-                            // Timeout, deactivate layer
-                            self.keymap.deactivate_layer(layer_num);
-                            self.osl_state = OneShotState::None;
-                        }
-                        Either::Second(e) => {
-                            // New event, send it to queue
-                            if self.unprocessed_events.push(e).is_err() {
-                                warn!("Unprocessed event queue is full, dropping event");
-                            }
-                        }
-                    }
-                }
-                OneShotState::Held(layer_num) => {
-                    self.osl_state = OneShotState::None;
-                    self.keymap.deactivate_layer(layer_num);
-                }
-                _ => (),
-            };
-        }
-    }
-
     /// Calculates the combined effect of "explicit modifiers":
     /// - registered modifiers
     /// - one-shot modifiers
@@ -1374,7 +1259,7 @@ impl<'a> Keyboard<'a> {
             }
         } else if let OneShotState::Held(osm) = self.osm_state {
             // One shot modifiers usually "released" together with the key release,
-            // except when one-shoot is in "held mode" (to allow Alt+Tab like use cases)
+            // except when oneshot is in "held mode" (to allow Alt+Tab like use cases)
             // In this later case Held -> None state change will report
             // the "modifier released" change in a separate hid report
             result |= osm;
@@ -1793,31 +1678,6 @@ impl<'a> Keyboard<'a> {
     pub(crate) async fn send_mouse_report(&mut self) {
         self.send_report(Report::MouseReport(self.mouse.get_report())).await;
         yield_now().await;
-    }
-
-    fn update_osm(&mut self, event: KeyboardEvent) {
-        match self.osm_state {
-            OneShotState::Initial(m) => self.osm_state = OneShotState::Held(m),
-            OneShotState::Single(_) => {
-                if !event.pressed {
-                    self.osm_state = OneShotState::None;
-                }
-            }
-            _ => (),
-        }
-    }
-
-    fn update_osl(&mut self, event: KeyboardEvent) {
-        match self.osl_state {
-            OneShotState::Initial(l) => self.osl_state = OneShotState::Held(l),
-            OneShotState::Single(layer_num) => {
-                if !event.pressed {
-                    self.keymap.deactivate_layer(layer_num);
-                    self.osl_state = OneShotState::None;
-                }
-            }
-            _ => (),
-        }
     }
 
     /// Register a key, the key can be a basic keycode or a modifier.

--- a/rmk/src/keyboard/oneshot.rs
+++ b/rmk/src/keyboard/oneshot.rs
@@ -1,1 +1,187 @@
-// TODO: Move oneshot processing to this module
+use embassy_futures::select::{Either, select};
+use embassy_time::Timer;
+use rmk_types::modifier::ModifierCombination;
+
+use crate::event::KeyboardEvent;
+use crate::keyboard::Keyboard;
+
+/// State machine for one shot keys
+#[derive(Default)]
+pub enum OneShotState<T> {
+    /// First one shot key press
+    Initial(T),
+    /// One shot key was released before any other key, normal one shot behavior
+    Single(T),
+    /// Another key was pressed before one shot key was released, treat as a normal modifier/layer
+    Held(T),
+    /// One shot inactive
+    #[default]
+    None,
+}
+
+impl<T> OneShotState<T> {
+    /// Get the current one shot value if any
+    pub fn value(&self) -> Option<&T> {
+        match self {
+            OneShotState::Initial(v) | OneShotState::Single(v) | OneShotState::Held(v) => Some(v),
+            OneShotState::None => None,
+        }
+    }
+}
+
+impl<'a> Keyboard<'a> {
+    pub(crate) async fn process_action_osm(&mut self, new_modifiers: ModifierCombination, event: KeyboardEvent) {
+        let activate_on_keypress = self.keymap.one_shot_modifiers_config().activate_on_keypress;
+
+        // Update one shot state
+        if event.pressed {
+            let mut was_active = false;
+            // Add new modifier combination to existing one shot or init if none
+            self.osm_state = match self.osm_state {
+                OneShotState::None => OneShotState::Initial(new_modifiers),
+                OneShotState::Initial(cur_modifiers) => OneShotState::Initial(cur_modifiers | new_modifiers),
+                OneShotState::Single(cur_modifiers) => {
+                    was_active = cur_modifiers & new_modifiers == new_modifiers;
+
+                    if was_active {
+                        let result = cur_modifiers & !new_modifiers;
+                        // Remove the matching event from unprocessed_events queue
+                        self.unprocessed_events.retain(|e| e.pos != event.pos);
+                        // Send report for current osm_state modifiers
+                        self.send_keyboard_report_with_resolved_modifiers(true).await;
+
+                        if result.into_bits() == 0 {
+                            OneShotState::None
+                        } else {
+                            OneShotState::Single(result)
+                        }
+                    } else {
+                        OneShotState::Single(cur_modifiers | new_modifiers)
+                    }
+                }
+                OneShotState::Held(cur_modifiers) => OneShotState::Held(cur_modifiers | new_modifiers),
+            };
+
+            self.update_osl(event);
+
+            // Send report for updated osm_state modifiers
+            if was_active || activate_on_keypress {
+                self.send_keyboard_report_with_resolved_modifiers(true).await;
+            }
+        } else {
+            match self.osm_state {
+                OneShotState::Initial(cur_modifiers) | OneShotState::Single(cur_modifiers) => {
+                    self.osm_state = OneShotState::Single(cur_modifiers);
+                    let timeout = Timer::after(self.keymap.one_shot_timeout());
+                    match select(timeout, self.keyboard_event_subscriber.next_message_pure()).await {
+                        Either::First(_) => {
+                            // Timeout, release modifiers
+                            self.update_osl(event);
+                            self.osm_state = OneShotState::None;
+
+                            // Send release report because modifiers were held
+                            if activate_on_keypress {
+                                self.send_keyboard_report_with_resolved_modifiers(false).await;
+                            }
+                        }
+                        Either::Second(e) => {
+                            // New event, send it to queue
+                            if self.unprocessed_events.push(e).is_err() {
+                                warn!("Unprocessed event queue is full, dropping event");
+                            }
+                        }
+                    }
+                }
+                OneShotState::Held(cur_modifiers) => {
+                    let was_active = cur_modifiers & new_modifiers == new_modifiers;
+
+                    if !was_active {
+                        return;
+                    }
+
+                    // Release modifier
+                    self.update_osl(event);
+                    self.osm_state = OneShotState::None;
+
+                    // This sends a separate hid report with the
+                    // currently registered modifiers except the
+                    // one shot modifiers -> this way "releasing" them.
+                    self.send_keyboard_report_with_resolved_modifiers(false).await;
+                }
+                _ => (),
+            };
+        }
+    }
+
+    pub(crate) async fn process_action_osl(&mut self, layer_num: u8, event: KeyboardEvent) {
+        // Update one shot state
+        if event.pressed {
+            // Deactivate old layer if any
+            if let Some(&l) = self.osl_state.value() {
+                self.keymap.deactivate_layer(l);
+            }
+
+            // Update layer of one shot
+            self.osl_state = match self.osl_state {
+                OneShotState::None => OneShotState::Initial(layer_num),
+                OneShotState::Initial(_) => OneShotState::Initial(layer_num),
+                OneShotState::Single(_) => OneShotState::Single(layer_num),
+                OneShotState::Held(_) => OneShotState::Held(layer_num),
+            };
+
+            // Activate new layer
+            self.keymap.activate_layer(layer_num);
+        } else {
+            match self.osl_state {
+                OneShotState::Initial(l) | OneShotState::Single(l) => {
+                    self.osl_state = OneShotState::Single(l);
+
+                    let timeout = embassy_time::Timer::after(self.keymap.one_shot_timeout());
+                    match select(timeout, self.keyboard_event_subscriber.next_message_pure()).await {
+                        Either::First(_) => {
+                            // Timeout, deactivate layer
+                            self.keymap.deactivate_layer(layer_num);
+                            self.osl_state = OneShotState::None;
+                        }
+                        Either::Second(e) => {
+                            // New event, send it to queue
+                            if self.unprocessed_events.push(e).is_err() {
+                                warn!("Unprocessed event queue is full, dropping event");
+                            }
+                        }
+                    }
+                }
+                OneShotState::Held(layer_num) => {
+                    self.osl_state = OneShotState::None;
+                    self.keymap.deactivate_layer(layer_num);
+                }
+                _ => (),
+            };
+        }
+    }
+
+    pub(crate) fn update_osm(&mut self, event: KeyboardEvent) {
+        match self.osm_state {
+            OneShotState::Initial(m) => self.osm_state = OneShotState::Held(m),
+            OneShotState::Single(_) => {
+                if !event.pressed {
+                    self.osm_state = OneShotState::None;
+                }
+            }
+            _ => (),
+        }
+    }
+
+    pub(crate) fn update_osl(&mut self, event: KeyboardEvent) {
+        match self.osl_state {
+            OneShotState::Initial(l) => self.osl_state = OneShotState::Held(l),
+            OneShotState::Single(layer_num) => {
+                if !event.pressed {
+                    self.keymap.deactivate_layer(layer_num);
+                    self.osl_state = OneShotState::None;
+                }
+            }
+            _ => (),
+        }
+    }
+}

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -11,7 +11,7 @@ use {
 
 use crate::MACRO_SPACE_SIZE;
 use crate::combo::Combo;
-use crate::config::{BehaviorConfig, Hand, MouseKeyConfig, PositionalConfig};
+use crate::config::{BehaviorConfig, Hand, MouseKeyConfig, OneShotModifiersConfig, PositionalConfig};
 use crate::event::{KeyboardEvent, KeyboardEventPos, LayerChangeEvent, publish_event};
 use crate::fork::Fork;
 use crate::input_device::rotary_encoder::Direction;
@@ -493,6 +493,10 @@ impl<'a> KeyMap<'a> {
 
     pub(crate) fn one_shot_timeout(&self) -> Duration {
         self.inner.borrow().behavior.one_shot.timeout
+    }
+
+    pub(crate) fn one_shot_modifiers_config(&self) -> OneShotModifiersConfig {
+        self.inner.borrow().behavior.one_shot_modifiers
     }
 
     pub(crate) fn tap_interval(&self) -> u16 {

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -334,15 +334,19 @@ macro_rules! osl {
 /// Create a one-shot modifier action.
 ///
 /// This macro creates a key that applies modifiers for the next keypress only.
-/// After the next key is pressed, the modifiers automatically deactivate.
+/// They automatically deactivate if:
+/// - other key that sends keyboard report is pressed,
+/// - timeout has passed before next key is triggered.
 ///
 /// # Parameters
 /// - `$m`: `ModifierCombination` to apply for the next keypress
 ///
 /// # Example
 /// ```ignore
-/// osm!(ModifierCombination::LSHIFT)  // Next key will be shifted
-/// osm!(ModifierCombination::LCTRL)   // Next key will have Ctrl applied
+/// // Next key will be shifted
+/// osm!(ModifierCombination::LSHIFT)
+/// // Next key will have both Shift and Ctrl applied
+/// osm!(ModifierCombination::LSHIFT | ModifierCombination::LCTRL)
 /// ```
 #[macro_export]
 macro_rules! osm {

--- a/rmk/tests/keyboard_combo_test.rs
+++ b/rmk/tests/keyboard_combo_test.rs
@@ -148,11 +148,14 @@ rusty_fork_test! {
 
 
     #[test]
-    fn test_combo_with_one_shot_mod() {
+    fn test_combo_with_one_shot_modifier() {
         key_sequence_test! {
             keyboard: create_test_keyboard_with_config(BehaviorConfig {
                 combo: get_combos_config(),
-                one_shot: OneShotConfig { timeout: Duration::from_millis(300) },
+                one_shot: OneShotConfig {
+                    timeout: Duration::from_millis(300),
+                    ..Default::default()
+                },
                 ..Default::default()
             }),
             sequence: [

--- a/rmk/tests/keyboard_one_shot_test.rs
+++ b/rmk/tests/keyboard_one_shot_test.rs
@@ -1,17 +1,11 @@
 pub mod common;
 
 use embassy_time::Duration;
-use rmk::config::{BehaviorConfig, OneShotConfig};
+use rmk::config::{BehaviorConfig, OneShotModifiersConfig};
 use rmk::types::modifier::ModifierCombination;
 
-fn one_shot_config_with_short_timeout() -> OneShotConfig {
-    OneShotConfig {
-        timeout: Duration::from_millis(100),
-    }
-}
-
 mod one_shot_test {
-    use rmk::config::PositionalConfig;
+    use rmk::config::{OneShotConfig, PositionalConfig};
     use rmk::keyboard::Keyboard;
     use rmk::types::action::KeyAction;
     use rmk::{k, osl, osm, th, wm};
@@ -19,6 +13,10 @@ mod one_shot_test {
 
     use super::*;
     use crate::common::{KC_LCTRL, KC_LGUI, KC_LSHIFT, wrap_keymap};
+
+    // KEYMAP
+    // Layer 0: OSM(LShift)        OSL(1)  A  TH(B)  OSM(LCtrl)  WM(B)
+    // Layer 1: OSM(LShift|LCtrl)  No      C  D      E           F
 
     const KEYMAP: [[[KeyAction; 6]; 1]; 2] = [
         [[
@@ -49,11 +47,18 @@ mod one_shot_test {
         Keyboard::new(wrap_keymap(KEYMAP, per_key_config, behavior_config))
     }
 
-    /// Create test keyboard with short timeout
-    fn create_test_keyboard_with_short_timeout() -> Keyboard<'static> {
+    fn create_test_keyboard_with_behavior_config(config: BehaviorConfig) -> Keyboard<'static> {
+        static BEHAVIOR_CONFIG: static_cell::StaticCell<BehaviorConfig> = static_cell::StaticCell::new();
+        let behavior_config = BEHAVIOR_CONFIG.init(config);
+        static KEY_CONFIG: static_cell::StaticCell<PositionalConfig<1, 6>> = static_cell::StaticCell::new();
+        let per_key_config = KEY_CONFIG.init(PositionalConfig::default());
+        Keyboard::new(wrap_keymap(KEYMAP, per_key_config, behavior_config))
+    }
+
+    fn create_test_keyboard_with_one_shot_modifiers_config(config: OneShotModifiersConfig) -> Keyboard<'static> {
         static BEHAVIOR_CONFIG: static_cell::StaticCell<BehaviorConfig> = static_cell::StaticCell::new();
         let behavior_config = BEHAVIOR_CONFIG.init(BehaviorConfig {
-            one_shot: one_shot_config_with_short_timeout(),
+            one_shot_modifiers: config,
             ..BehaviorConfig::default()
         });
         static KEY_CONFIG: static_cell::StaticCell<PositionalConfig<1, 6>> = static_cell::StaticCell::new();
@@ -62,15 +67,30 @@ mod one_shot_test {
     }
 
     rusty_fork_test! {
+        /// OSM Test Case 1
+        ///
+        /// Config:
+        /// - timeout: 1000ms
+        /// - activate_on_keypress: false
+        ///
+        /// Sequence:
+        /// - Press and Release OSM LShift
+        /// - Press and Release regular key A
+        ///
+        /// Expected:
+        /// - A with LShift
+        /// - All released
         #[test]
         fn test_osm_basic_single_behavior() {
             key_sequence_test! {
                 keyboard: create_test_keyboard(),
                 sequence: [
-                    [0, 0, true, 10],   // Press OSM LShift
-                    [0, 0, false, 10],  // Release OSM LShift
-                    [0, 2, true, 10],   // Press A
-                    [0, 2, false, 10],  // Release A
+                    // Press and Release OSM LShift
+                    [0, 0, true, 10],
+                    [0, 0, false, 10],
+                    // Press and Release A
+                    [0, 2, true, 10],
+                    [0, 2, false, 10],
                 ],
                 expected_reports: [
                     [KC_LSHIFT, [kc_to_u8!(A), 0, 0, 0, 0, 0]], // A with LShift
@@ -79,6 +99,62 @@ mod one_shot_test {
             };
         }
 
+        /// OSM Test Case 2
+        ///
+        /// Config:
+        /// - timeout: 100ms
+        /// - activate_on_keypress: false
+        ///
+        /// Sequence:
+        /// - Press and Release OSM LShift
+        /// - Press and Release A after timeout (delay > 100ms)
+        ///
+        /// Expected:
+        /// - A is sent without LShift
+        /// - All released
+        #[test]
+        fn test_osm_timeout() {
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_behavior_config(
+                    BehaviorConfig {
+                        one_shot: OneShotConfig {
+                            timeout: Duration::from_millis(100),
+                            ..OneShotConfig::default()
+                        },
+                        ..BehaviorConfig::default()
+                    }
+                ),
+                sequence: [
+                    // Press and Release OSM LShift
+                    [0, 0, true, 10],
+                    [0, 0, false, 10],
+                    // Press and Release A after timeout (delay > 100ms)
+                    [0, 2, true, 150],
+                    [0, 2, false, 10],
+                ],
+                expected_reports: [
+                    [0, [kc_to_u8!(A), 0, 0, 0, 0, 0]], // A without LShift (timeout)
+                    [0, [0, 0, 0, 0, 0, 0]], // All released
+                ]
+            };
+        }
+
+        /// OSM Test Case 3
+        ///
+        /// Config:
+        /// - timeout: 1000ms
+        /// - activate_on_keypress: false
+        ///
+        /// Sequence:
+        /// - Press OSM LShift
+        /// - Press A while OSM is held
+        /// - Release A
+        /// - Release OSM LShift
+        ///
+        /// Expected:
+        /// - A with LShift
+        /// - LShift is still held
+        /// - All released
         #[test]
         fn test_osm_held_behavior() {
             key_sequence_test! {
@@ -97,34 +173,36 @@ mod one_shot_test {
             };
         }
 
-        #[test]
-        fn test_osm_timeout() {
-            key_sequence_test! {
-                keyboard: create_test_keyboard_with_short_timeout(),
-                sequence: [
-                    [0, 0, true, 10],   // Press OSM LShift
-                    [0, 0, false, 10],  // Release OSM LShift
-                    [0, 2, true, 150],  // Press A after timeout (delay > 100ms)
-                    [0, 2, false, 10],  // Release A
-                ],
-                expected_reports: [
-                    [0, [kc_to_u8!(A), 0, 0, 0, 0, 0]], // A without LShift (timeout)
-                    [0, [0, 0, 0, 0, 0, 0]], // All released
-                ]
-            };
-        }
-
+        /// OSM Test Case 4
+        ///
+        /// Config:
+        /// - timeout: 1000ms
+        /// - activate_on_keypress: false
+        ///
+        /// Sequence:
+        /// - Press and Release OSM LShift
+        /// - Press and Release regular key A
+        /// - Press and Release regular key B
+        ///
+        /// Expected:
+        /// - A with LShift
+        /// - All released
+        /// - B without LShift
+        /// - All released
         #[test]
         fn test_osm_multiple_keys() {
             key_sequence_test! {
                 keyboard: create_test_keyboard(),
                 sequence: [
-                    [0, 0, true, 10],   // Press OSM LShift
-                    [0, 0, false, 10],  // Release OSM LShift
-                    [0, 2, true, 10],   // Press A
-                    [0, 2, false, 10],  // Release A
-                    [0, 3, true, 10],   // Press B (should not have shift)
-                    [0, 3, false, 10],  // Release B
+                    // Press and Release OSM LShift
+                    [0, 0, true, 10],
+                    [0, 0, false, 10],
+                    // Press and Release A
+                    [0, 2, true, 10],
+                    [0, 2, false, 10],
+                    // Press and Release B
+                    [0, 3, true, 10],
+                    [0, 3, false, 10],
                 ],
                 expected_reports: [
                     [KC_LSHIFT, [kc_to_u8!(A), 0, 0, 0, 0, 0]], // A with LShift
@@ -135,36 +213,185 @@ mod one_shot_test {
             };
         }
 
+
+        /// OSM Test Case 5
+        ///
+        /// Config:
+        /// - timeout: 1000ms
+        /// - activate_on_keypress: false
+        ///
+        /// Sequence:
+        /// - Press OSM LShift
+        /// - Press B
+        /// - Release OSM LShift
+        /// - Release B
+        ///
+        /// Expected:
+        /// - B with LShift
+        /// - All released
         #[test]
         fn test_osm_rolling_with_tap_hold() {
             key_sequence_test! {
                 keyboard: create_test_keyboard(),
                 sequence: [
                     [0, 0, true, 10],   // Press OSM LShift
-                    [0, 3, true, 10],   // Press B (should not have shift)
+                    [0, 3, true, 10],   // Press B
                     [0, 0, false, 10],  // Release OSM LShift
                     [0, 3, false, 10],  // Release B
                 ],
                 expected_reports: [
-                    [KC_LSHIFT, [kc_to_u8!(B), 0, 0, 0, 0, 0]], // A with LShift
+                    [KC_LSHIFT, [kc_to_u8!(B), 0, 0, 0, 0, 0]], // B with LShift
                     [0, [0, 0, 0, 0, 0, 0]], // All released
                 ]
             };
         }
 
+        /// OSM Test Case 6
+        ///
+        /// Config:
+        /// - timeout: 1000ms
+        /// - activate_on_keypress: false
+        ///
+        /// Sequence:
+        /// - Press and Release OSM LShift
+        /// - Press and Release OSM LCtrl
+        /// - Press and Release regular key A
+        ///
+        /// Expected:
+        /// - A with LShift+LCtrl
+        /// - All released
         #[test]
         fn test_osm_combined_modifiers() {
             key_sequence_test! {
                 keyboard: create_test_keyboard(),
                 sequence: [
+                    // Press and Release OSM LShift
+                    [0, 0, true, 10],
+                    [0, 0, false, 10],
+                    // Press and Release OSM LCtrl
+                    [0, 4, true, 10],
+                    [0, 4, false, 10],
+                    // Press and Release A
+                    [0, 2, true, 10],
+                    [0, 2, false, 10],
+                ],
+                expected_reports: [
+                    [KC_LSHIFT | KC_LCTRL, [kc_to_u8!(A), 0, 0, 0, 0, 0]], // A with LShift+LCtrl
+                    [0, [0, 0, 0, 0, 0, 0]], // All released
+                ]
+            };
+        }
+
+        /// OSM Test Case 7
+        ///
+        /// Config:
+        /// - timeout: 100ms
+        /// - activate_on_keypress: false
+        ///
+        /// Sequence:
+        /// - Press and Release OSM LShift
+        /// - Press and Release OSM LCtrl
+        /// - Press and Release WM(B, LGui)
+        ///
+        /// Expected:
+        /// - B is sent with LShift + LCtrl + LGui
+        /// - All released
+        #[test]
+        fn test_osm_multiple_osm_with_wm() {
+            key_sequence_test! {
+                keyboard: create_test_keyboard(),
+                sequence: [
+                    // Press and Release OSM LShift
+                    [0, 0, true, 10],
+                    [0, 0, false, 10],
+                    // Press and Release OSM LCtrl
+                    [0, 4, true, 10],
+                    [0, 4, false, 10],
+                    // Press and Release WM(B, LGui)
+                    [0, 5, true, 10],
+                    [0, 5, false, 10],
+                ],
+                expected_reports: [
+                    [KC_LSHIFT | KC_LCTRL | KC_LGUI, [kc_to_u8!(B), 0, 0, 0, 0, 0]], // B with LShift + LCtrl + LGui
+                    [0, [0, 0, 0, 0, 0, 0]], // All released
+                ]
+            };
+        }
+
+        /// OSM Test Case 8
+        ///
+        /// Config:
+        /// - timeout: 100ms
+        /// - activate_on_keypress: true
+        ///
+        /// Sequence:
+        /// - Press OSM LShift
+        /// - Release OSM LShift
+        /// - Press A
+        /// - Release A
+        ///
+        /// Expected:
+        /// - LShift is sent from the start
+        /// - A with LShift
+        /// - All released
+        #[test]
+        fn test_osm_activate_on_keypress() {
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_one_shot_modifiers_config(OneShotModifiersConfig {
+                    activate_on_keypress: true,
+                    ..OneShotModifiersConfig::default()
+                }),
+                sequence: [
                     [0, 0, true, 10],   // Press OSM LShift
                     [0, 0, false, 10],  // Release OSM LShift
-                    [0, 4, true, 10],   // Press OSM LCtrl
-                    [0, 4, false, 10],  // Release OSM LCtrl
                     [0, 2, true, 10],   // Press A
                     [0, 2, false, 10],  // Release A
                 ],
                 expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]], // LShift is sent from the start
+                    [KC_LSHIFT, [kc_to_u8!(A), 0, 0, 0, 0, 0]], // A with LShift
+                    [0, [0, 0, 0, 0, 0, 0]], // All released
+                ]
+            }
+        }
+
+        /// OSM Test Case 9
+        ///
+        /// Config:
+        /// - timeout: 100ms
+        /// - activate_on_keypress: true
+        ///
+        /// Sequence:
+        /// - Press and Release OSM LShift
+        /// - Press and Release OSM LCtrl
+        /// - Press and Release regular key A
+        ///
+        /// Expected:
+        /// - LShift is sent first
+        /// - LCtrl is added to combination
+        /// - A with LShift+LCtrl
+        /// - All released
+        #[test]
+        fn test_osm_combined_modifiers_with_activate_on_keypress() {
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_one_shot_modifiers_config(OneShotModifiersConfig {
+                    activate_on_keypress: true,
+                    ..OneShotModifiersConfig::default()
+                }),
+                sequence: [
+                    // Press and Release OSM LShift
+                    [0, 0, true, 10],
+                    [0, 0, false, 10],
+                    // Press and Release OSM LCtrl
+                    [0, 4, true, 10],
+                    [0, 4, false, 10],
+                    // Press and Release A
+                    [0, 2, true, 10],
+                    [0, 2, false, 10],
+                ],
+                expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]], // LShift is sent first
+                    [KC_LSHIFT | KC_LCTRL, [0, 0, 0, 0, 0, 0]], // LCtrl is added to combination
                     [KC_LSHIFT | KC_LCTRL, [kc_to_u8!(A), 0, 0, 0, 0, 0]], // A with LShift+LCtrl
                     [0, [0, 0, 0, 0, 0, 0]], // All released
                 ]
@@ -209,7 +436,18 @@ mod one_shot_test {
         #[test]
         fn test_osl_timeout() {
             key_sequence_test! {
-                keyboard: create_test_keyboard_with_short_timeout(),
+                keyboard: create_test_keyboard_with_behavior_config(
+                    BehaviorConfig {
+                        one_shot: OneShotConfig {
+                            timeout: Duration::from_millis(100),
+                            ..OneShotConfig::default()
+                        },
+                        one_shot_modifiers: OneShotModifiersConfig {
+                            ..OneShotModifiersConfig::default()
+                        },
+                        ..BehaviorConfig::default()
+                    }
+                ),
                 sequence: [
                     [0, 1, true, 10],   // Press OSL Layer 1
                     [0, 1, false, 10],  // Release OSL Layer 1
@@ -285,7 +523,18 @@ mod one_shot_test {
         #[test]
         fn test_osm_and_osl_timeout() {
             key_sequence_test! {
-                keyboard: create_test_keyboard_with_short_timeout(),
+                keyboard: create_test_keyboard_with_behavior_config(
+                    BehaviorConfig {
+                        one_shot: OneShotConfig {
+                            timeout: Duration::from_millis(100),
+                            ..OneShotConfig::default()
+                        },
+                        one_shot_modifiers: OneShotModifiersConfig {
+                            ..OneShotModifiersConfig::default()
+                        },
+                        ..BehaviorConfig::default()
+                    }
+                ),
                 sequence: [
                     [0, 0, true, 10],   // Press OSM LShift
                     [0, 0, false, 10],  // Release OSM LShift
@@ -296,44 +545,6 @@ mod one_shot_test {
                 ],
                 expected_reports: [
                     [0, [kc_to_u8!(A), 0, 0, 0, 0, 0]], // A from layer 0 (both timeout)
-                    [0, [0, 0, 0, 0, 0, 0]], // All released
-                ]
-            };
-        }
-
-        #[test]
-        fn test_multiple_osm() {
-            key_sequence_test! {
-                keyboard: create_test_keyboard(),
-                sequence: [
-                    [0, 0, true, 10],   // Press OSM LShift
-                    [0, 0, false, 10],  // Release OSM LShift
-                    [0, 4, true, 10],   // Press OSM LCtrl
-                    [0, 4, false, 10],  // Release OSM LCtrl
-                    [0, 3, true, 10],   // Press key at (0,3), should get B from layer 0 with shift + ctrl
-                    [0, 3, false, 10],  // Release key
-                ],
-                expected_reports: [
-                    [KC_LSHIFT | KC_LCTRL, [kc_to_u8!(B), 0, 0, 0, 0, 0]], // B from layer 0 with LShift
-                    [0, [0, 0, 0, 0, 0, 0]], // All released
-                ]
-            };
-        }
-
-        #[test]
-        fn test_multiple_osm_with_wm() {
-            key_sequence_test! {
-                keyboard: create_test_keyboard(),
-                sequence: [
-                    [0, 0, true, 10],   // Press OSM LShift
-                    [0, 0, false, 10],  // Release OSM LShift
-                    [0, 4, true, 10],   // Press OSM LCtrl
-                    [0, 4, false, 10],  // Release OSM LCtrl
-                    [0, 5, true, 10],   // Press key at (0,5), should get B from layer 0 with LShift + LCtrl + LGui
-                    [0, 5, false, 10],  // Release key
-                ],
-                expected_reports: [
-                    [KC_LSHIFT | KC_LCTRL | KC_LGUI, [kc_to_u8!(B), 0, 0, 0, 0, 0]], // B from layer 0 with LShift + LCtrl + LGui
                     [0, [0, 0, 0, 0, 0, 0]], // All released
                 ]
             };


### PR DESCRIPTION
Added One-Shot Sticky Modifiers functionality
Moved OSM/OSL logic into `oneshot.rs` file

Added two boolean config variables:
- `activate_on_keypress`: Should modifiers be active from keypress (sticky modifiers)
- `send_on_second_press`: Should the second keypress send modifiers and unstick them

Updated `behavior.md` docs to correspond with the new config structure:
```toml
[behavior.one_shot_modifiers]
  timeout = "1s"
  activate_on_keypress = false
  send_on_second_press = false

[behavior.one_shot_layers]
  timeout = "1s"
```