### PR TITLE
feat: add Kinesis Advantage 360 Pro split BLE example

### DIFF
--- a/examples/use_config/nrf52840_ble_split_kinesis360/.cargo/config.toml
+++ b/examples/use_config/nrf52840_ble_split_kinesis360/.cargo/config.toml
@@ -1,0 +1,12 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "probe-rs run --chip nRF52840_xxAA"
+
+# Use flip-link overflow check: https://github.com/knurling-rs/flip-link
+linker = "flip-link"
+
+[build]
+target = "thumbv7em-none-eabihf"     # Cortex-M4F and Cortex-M7F (with FPU)
+
+[env]
+DEFMT_LOG = "info"
+KEYBOARD_TOML_PATH =  { value = "keyboard.toml", relative = true }

--- a/examples/use_config/nrf52840_ble_split_kinesis360/Cargo.toml
+++ b/examples/use_config/nrf52840_ble_split_kinesis360/Cargo.toml
@@ -1,0 +1,85 @@
+[package]
+name = "rmk-nrf52840-kinesis360"
+version = "0.2.0"
+authors = ["Haobo Gu <haobogu@outlook.com>"]
+description = "Keyboard firmware written in Rust"
+homepage = "https://github.com/haobogu/rmk"
+repository = "https://github.com/haobogu/rmk"
+readme = "README.md"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+rmk = { path = "../../../rmk", features = [
+    "nrf52840_ble",
+    "split",
+    "adafruit_bl",
+] }
+nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc", rev = "11d5c3c", features = [
+    "defmt",
+    "peripheral",
+    "central",
+    "nrf52840",
+] }
+nrf-mpsl = { git = "https://github.com/alexmoon/nrf-sdc", rev = "11d5c3c", features = [
+    "defmt",
+    "critical-section-impl",
+    "nrf52840",
+] }
+bt-hci = { version = "0.6", features = ["defmt"] }
+
+cortex-m = "0.7.7"
+cortex-m-rt = "0.7.5"
+embassy-time = { version = "0.5", features = ["tick-hz-32_768", "defmt", "defmt-timestamp-uptime"] }
+embassy-nrf = { version = "0.8", features = [
+    "defmt",
+    "nrf52840",
+    "time-driver-rtc1",
+    "gpiote",
+    "unstable-pac",
+    "nfc-pins-as-gpio",
+    "time",
+] }
+embassy-executor = { version = "0.9", features = [
+    "defmt",
+    "arch-cortex-m",
+    "executor-thread",
+] }
+defmt = "1.0"
+defmt-rtt = "1.0"
+panic-probe = { version = "1.0", features = ["print-defmt"] }
+static_cell = "2"
+
+rand = { version = "0.8.4", default-features = false }
+rand_core = { version = "0.6" }
+rand_chacha = { version = "0.3", default-features = false }
+
+
+[build-dependencies]
+xz2 = "0.1.7"
+json = "0.12"
+const-gen = "1.6"
+
+# Split keyboard example
+[[bin]]
+name = "central"
+path = "src/central.rs"
+
+[[bin]]
+name = "peripheral"
+path = "src/peripheral.rs"
+
+[profile.dev]
+codegen-units = 1      # better optimizations
+debug = true
+opt-level = 1
+overflow-checks = true
+lto = false
+panic = 'unwind'
+
+[profile.release]
+codegen-units = 1       # better optimizations
+debug = true            # no overhead for bare-metal
+opt-level = "z"         # optimize for binary size
+overflow-checks = false
+lto = "fat"

--- a/examples/use_config/nrf52840_ble_split_kinesis360/Makefile.toml
+++ b/examples/use_config/nrf52840_ble_split_kinesis360/Makefile.toml
@@ -1,0 +1,78 @@
+[tasks.install-llvm-tools]
+install_crate = { rustup_component_name = "llvm-tools" }
+
+[tasks.flip-link]
+install_crate = { crate_name = "flip-link", binary = "flip-link", test_arg = ["-h"] }
+
+[tasks.objcopy-central]
+install_crate = { crate_name = "cargo-binutils", binary = "cargo", test_arg = [
+    "objcopy",
+    "--help",
+] }
+command = "cargo"
+args = [
+    "objcopy",
+    "--release",
+    "--bin",
+    "central",
+    "--",
+    "-O",
+    "ihex",
+    "kinesis360-central.hex",
+]
+dependencies = ["install-llvm-tools", "flip-link"]
+
+[tasks.objcopy-peripheral]
+install_crate = { crate_name = "cargo-binutils", binary = "cargo", test_arg = [
+    "objcopy",
+    "--help",
+] }
+command = "cargo"
+args = [
+    "objcopy",
+    "--release",
+    "--bin",
+    "peripheral",
+    "--",
+    "-O",
+    "ihex",
+    "kinesis360-peripheral.hex",
+]
+dependencies = ["install-llvm-tools", "flip-link"]
+
+[tasks.uf2-central]
+install_crate = { crate_name = "cargo-hex-to-uf2", binary = "cargo", test_arg = [
+    "hex-to-uf2",
+    "--help",
+] }
+command = "cargo"
+args = [
+    "hex-to-uf2",
+    "--input-path",
+    "kinesis360-central.hex",
+    "--output-path",
+    "kinesis360-central.uf2",
+    "--family",
+    "nrf52840",
+]
+dependencies = ["objcopy-central"]
+
+[tasks.uf2-peripheral]
+install_crate = { crate_name = "cargo-hex-to-uf2", binary = "cargo", test_arg = [
+    "hex-to-uf2",
+    "--help",
+] }
+command = "cargo"
+args = [
+    "hex-to-uf2",
+    "--input-path",
+    "kinesis360-peripheral.hex",
+    "--output-path",
+    "kinesis360-peripheral.uf2",
+    "--family",
+    "nrf52840",
+]
+dependencies = ["objcopy-peripheral"]
+
+[tasks.uf2]
+dependencies = ["uf2-central", "uf2-peripheral"]

--- a/examples/use_config/nrf52840_ble_split_kinesis360/README.md
+++ b/examples/use_config/nrf52840_ble_split_kinesis360/README.md
@@ -1,0 +1,91 @@
+# Kinesis Advantage 360 Pro - RMK Split BLE Example
+
+RMK firmware for the [Kinesis Advantage 360 Pro](https://kinesis-ergo.com/keyboards/advantage360/), a wireless split ergonomic keyboard with nRF52840 MCUs and Adafruit nRF52 bootloader.
+
+## Hardware
+
+- **MCU**: nRF52840 (both halves)
+- **Bootloader**: Adafruit nRF52 (UF2-compatible)
+- **Connection**: BLE split (central = left, peripheral = right)
+- **Matrix**: 5 rows x 20 columns (10 per half)
+- **LEDs**: WS2812 RGB via P0.13 power MOSFET (MOSFET enabled, RGB control not yet supported in RMK TOML config)
+
+## Prerequisites
+
+- Rust nightly with `thumbv7em-none-eabihf` target
+- `cargo-make`: `cargo install cargo-make`
+- `flip-link`: `cargo install flip-link`
+- `cargo-binutils`: `cargo install cargo-binutils`
+- `cargo-hex-to-uf2`: `cargo install cargo-hex-to-uf2`
+- LLVM tools: `rustup component add llvm-tools`
+- For build.rs: `BINDGEN_EXTRA_CLANG_ARGS` may need to point to your ARM GCC sysroot, e.g.:
+  ```shell
+  export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=/usr/lib/arm-none-eabi"
+  ```
+
+## Build
+
+```shell
+cd examples/use_config/nrf52840_ble_split_kinesis360
+cargo make uf2
+```
+
+This produces two UF2 files:
+- `kinesis360-central.uf2` (left half)
+- `kinesis360-peripheral.uf2` (right half)
+
+## Flash
+
+1. **Flash the right half (peripheral) first**:
+   - Connect the right half via USB
+   - Double-tap the reset button to enter bootloader mode (a USB drive named `KINESIS360` or `NRF52BOOT` appears)
+   - Copy `kinesis360-peripheral.uf2` to the drive
+   - The board will reboot automatically
+
+2. **Flash the left half (central)**:
+   - Connect the left half via USB
+   - Double-tap the reset button to enter bootloader mode
+   - Copy `kinesis360-central.uf2` to the drive
+   - The board will reboot automatically
+
+3. **Remove USB cables** — RMK switches to USB mode when a cable is connected. Disconnect both halves after flashing so BLE split communication activates.
+
+## Storage Overlap Warning
+
+**This is critical.** The Kinesis Adv360 Pro firmware (central binary) is approximately 426KB. RMK's default nRF BLE storage address is `0x60000` (384KB), which means the firmware code overlaps with the storage region. On first boot, the storage initialization erases flash pages that contain running code, causing an instant crash loop.
+
+This example sets `start_addr = 0xEC000` in `keyboard.toml` to place storage safely past the firmware end and below the bootloader at `0xF4000`. **Do not remove this setting.**
+
+If your firmware grows, verify the binary size stays below the storage address:
+```shell
+cargo size --release --bin central
+```
+
+## Important: No `async_matrix`
+
+This example does **not** use the `async_matrix` feature. The Kinesis Adv360 Pro's matrix pin configuration is incompatible with `async_matrix` on nRF52840 (GPIOTE channel conflicts). Use the default polling matrix instead.
+
+## BLE Pairing
+
+The keymap includes a BLE control layer (Layer 3, activated by holding `MO(3)` in the top-right position):
+
+| Key | Function |
+|-----|----------|
+| Layer 3 + `1` | BLE profile 0 |
+| Layer 3 + `2` | BLE profile 1 |
+| Layer 3 + `3` | BLE profile 2 |
+| Layer 3 + `4` | Next BLE profile |
+| Layer 3 + `5` | Previous BLE profile |
+| Layer 3 + `LGui` | Clear current BLE bond |
+
+## Recovery: Switching Back to ZMK/Clique
+
+If you need to return to the stock ZMK or Clique firmware:
+
+1. Enter bootloader mode (double-tap reset)
+2. Flash the Kinesis `settings-reset` UF2 to clear nRF storage
+3. Flash the SoftDevice s140 UF2 (required for ZMK, not present after RMK)
+4. Flash the ZMK/Clique firmware UF2
+5. Repeat for both halves
+
+The `settings-reset` step is important because RMK uses different storage addresses than ZMK, so leftover data can cause pairing issues.

--- a/examples/use_config/nrf52840_ble_split_kinesis360/build.rs
+++ b/examples/use_config/nrf52840_ble_split_kinesis360/build.rs
@@ -1,0 +1,87 @@
+//! This build script copies the `memory.x` file from the crate root into
+//! a directory where the linker can always find it at build time.
+//! For many projects this is optional, as the linker always searches the
+//! project root directory -- wherever `Cargo.toml` is. However, if you
+//! are using a workspace or have a more complicated build setup, this
+//! build script becomes required. Additionally, by requesting that
+//! Cargo re-run the build script whenever `memory.x` is changed,
+//! updating `memory.x` ensures a rebuild of the application with the
+//! new memory settings.
+//!
+//! The build script also sets the linker flags to tell it which link script to use.
+
+use const_gen::*;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+use xz2::read::XzEncoder;
+
+fn main() {
+    // Generate vial config at the root of project
+    println!("cargo:rerun-if-changed=vial.json");
+    println!("cargo:rerun-if-changed=keyboard.toml");
+
+    generate_vial_config();
+
+    // Put `memory.x` in our output directory and ensure it's
+    // on the linker search path.
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // By default, Cargo will re-run a build script whenever
+    // any file in the project changes. By specifying `memory.x`
+    // here, we ensure the build script is only re-run when
+    // `memory.x` is changed.
+    println!("cargo:rerun-if-changed=memory.x");
+
+    // Specify linker arguments.
+
+    // `--nmagic` is required if memory section addresses are not aligned to 0x10000,
+    // for example the FLASH and RAM sections in your `memory.x`.
+    // See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+    println!("cargo:rustc-link-arg=--nmagic");
+
+    // Set the linker script to the one provided by cortex-m-rt.
+    println!("cargo:rustc-link-arg=-Tlink.x");
+
+    // Set the extra linker script from defmt
+    println!("cargo:rustc-link-arg=-Tdefmt.x");
+
+    // Use flip-link overflow check: https://github.com/knurling-rs/flip-link
+    println!("cargo:rustc-linker=flip-link");
+}
+
+fn generate_vial_config() {
+    // Generated vial config file
+    let out_file = Path::new(&env::var_os("OUT_DIR").unwrap()).join("config_generated.rs");
+
+    let p = Path::new("vial.json");
+    let mut content = String::new();
+    match File::open(p) {
+        Ok(mut file) => {
+            file.read_to_string(&mut content)
+                .expect("Cannot read vial.json");
+        }
+        Err(e) => println!("Cannot find vial.json {:?}: {}", p, e),
+    };
+
+    let vial_cfg = json::stringify(json::parse(&content).unwrap());
+    let mut keyboard_def_compressed: Vec<u8> = Vec::new();
+    XzEncoder::new(vial_cfg.as_bytes(), 6)
+        .read_to_end(&mut keyboard_def_compressed)
+        .unwrap();
+
+    let keyboard_id: Vec<u8> = vec![0xB9, 0xBC, 0x09, 0xB2, 0x9D, 0x37, 0x4C, 0xEA];
+    let const_declarations = [
+        const_declaration!(pub VIAL_KEYBOARD_DEF = keyboard_def_compressed),
+        const_declaration!(pub VIAL_KEYBOARD_ID = keyboard_id),
+    ]
+    .map(|s| "#[allow(clippy::redundant_static_lifetimes)]\n".to_owned() + s.as_str())
+    .join("\n");
+    fs::write(out_file, const_declarations).unwrap();
+}

--- a/examples/use_config/nrf52840_ble_split_kinesis360/keyboard.toml
+++ b/examples/use_config/nrf52840_ble_split_kinesis360/keyboard.toml
@@ -1,0 +1,113 @@
+[keyboard]
+name = "Kinesis Adv360 Pro"
+product_name = "Kinesis Adv360 Pro"
+vendor_id = 0x4c4b
+product_id = 0x4643
+manufacturer = "Kinesis"
+chip = "nrf52840"
+
+# The Adv360 has a complex matrix layout with 5 rows x 20 columns total
+# Left side: 10 columns, Right side: 10 columns
+[layout]
+rows = 5
+cols = 20
+layers = 4
+keymap = [
+    # Layer 0: Base layer (matching ZMK default layout)
+    # The matrix is sparse - many positions are not used
+    [
+        # Row 0 (bottom row with thumb cluster)
+        ["MO(2)", "Grave", "CapsLock", "Left", "Right", "_", "_", "Backspace", "Delete", "End", "PageDown", "Enter", "Space", "_", "_", "Up", "Down", "LeftBracket", "RightBracket", "MO(2)"],
+        # Row 1
+        ["LShift", "Z", "X", "C", "V", "B", "_", "_", "_", "Home", "PageUp", "_", "_", "_", "N", "M", "Comma", "Dot", "Slash", "RShift"],
+        # Row 2
+        ["Escape", "A", "S", "D", "F", "G", "_", "_", "LCtrl", "LAlt", "LGui", "RCtrl", "_", "_", "H", "J", "K", "L", "Semicolon", "Quote"],
+        # Row 3
+        ["Tab", "Q", "W", "E", "R", "T", "_", "_", "_", "_", "_", "_", "_", "_", "Y", "U", "I", "O", "P", "Backslash"],
+        # Row 4 (top row with numbers)
+        ["Equal", "1", "2", "3", "4", "5", "TG(1)", "_", "_", "_", "_", "_", "_", "MO(3)", "6", "7", "8", "9", "0", "Minus"]
+    ],
+    # Layer 1: Keypad
+    [
+        ["MO(2)", "Grave", "CapsLock", "Left", "Right", "_", "_", "Backspace", "Delete", "End", "PageDown", "Enter", "Kp0", "_", "_", "Up", "Down", "KpDot", "RightBracket", "MO(2)"],
+        ["LShift", "Z", "X", "C", "V", "B", "_", "_", "_", "Home", "PageUp", "_", "_", "_", "N", "Kp1", "Kp2", "Kp3", "KpEnter", "RShift"],
+        ["Escape", "A", "S", "D", "F", "G", "_", "_", "LCtrl", "LAlt", "LGui", "RCtrl", "_", "_", "H", "Kp4", "Kp5", "Kp6", "KpPlus", "Quote"],
+        ["Tab", "Q", "W", "E", "R", "T", "_", "_", "_", "_", "_", "_", "_", "_", "Y", "Kp7", "Kp8", "Kp9", "KpMinus", "Backslash"],
+        ["Equal", "1", "2", "3", "4", "5", "_", "_", "_", "_", "_", "_", "_", "MO(3)", "6", "NumLock", "KpEqual", "KpSlash", "KpAsterisk", "Minus"]
+    ],
+    # Layer 2: Function layer
+    [
+        ["_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_"],
+        ["_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_"],
+        ["_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_"],
+        ["_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_"],
+        ["F1", "F2", "F3", "F4", "F5", "F6", "TG(1)", "_", "_", "_", "_", "_", "_", "MO(3)", "F7", "F8", "F9", "F10", "F11", "F12"]
+    ],
+    # Layer 3: Mod/BLE layer - User0-2 for BLE profiles, User3 for next, User4 for prev, User5 for clear
+    [
+        ["_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_"],
+        ["_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_"],
+        ["_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "User5", "_", "_", "_", "_", "_", "_", "_", "_", "_"],
+        ["_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_"],
+        ["_", "User0", "User1", "User2", "User3", "User4", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_"]
+    ]
+]
+
+[ble]
+enabled = true
+battery_adc_pin = "P0_04"
+
+[storage]
+enabled = true
+clear_storage = true
+start_addr = 0xEC000
+num_sectors = 2
+
+[split]
+connection = "ble"
+
+# Split central (left half)
+[split.central]
+rows = 5
+cols = 10
+row_offset = 0
+col_offset = 0
+
+# Central's matrix - col2row diode direction
+# From adv360_left.dts:
+# row-gpios: P1_11, P1_15, P0_03, P1_14, P1_12
+# col-gpios: P0_25, P0_11, P0_02, P0_28, P0_29, P0_30, P0_31, P1_09, P0_12, P0_07
+[split.central.matrix]
+matrix_type = "normal"
+row_pins = ["P1_11", "P1_15", "P0_03", "P1_14", "P1_12"]
+col_pins = ["P0_25", "P0_11", "P0_02", "P0_28", "P0_29", "P0_30", "P0_31", "P1_09", "P0_12", "P0_07"]
+
+# Peripheral 0 (right half)
+[[split.peripheral]]
+rows = 5
+cols = 10
+row_offset = 0
+col_offset = 10
+
+# Peripheral's matrix - col2row diode direction
+# From adv360_right.dts:
+# row-gpios: P0_19, P0_05, P0_31, P0_30, P0_29
+# col-gpios: P0_12, P1_09, P0_07, P1_11, P1_10, P1_13, P1_15, P0_03, P0_02, P0_28
+[split.peripheral.matrix]
+matrix_type = "normal"
+row_pins = ["P0_19", "P0_05", "P0_31", "P0_30", "P0_29"]
+col_pins = ["P0_12", "P1_09", "P0_07", "P1_11", "P1_10", "P1_13", "P1_15", "P0_03", "P0_02", "P0_28"]
+
+# Enable LED power on both halves (P0_13 must be HIGH for LEDs to work)
+[[split.central.output]]
+pin = "P0_13"
+low_active = false
+initial_state_active = true
+
+[[split.peripheral.output]]
+pin = "P0_13"
+low_active = false
+initial_state_active = true
+
+[rmk]
+split_peripherals_num = 1

--- a/examples/use_config/nrf52840_ble_split_kinesis360/memory.x
+++ b/examples/use_config/nrf52840_ble_split_kinesis360/memory.x
@@ -1,0 +1,8 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiB = 1024 bytes */
+  /* Kinesis Adv360 Pro with Adafruit nRF52 bootloader */
+  /* App starts at 0x1000, bootloader occupies 0xF4000-0xFFFFF */
+  FLASH : ORIGIN = 0x00001000, LENGTH = 1020K
+  RAM : ORIGIN = 0x20000008, LENGTH = 255K
+}

--- a/examples/use_config/nrf52840_ble_split_kinesis360/src/central.rs
+++ b/examples/use_config/nrf52840_ble_split_kinesis360/src/central.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#![no_std]
+
+use rmk::macros::rmk_central;
+
+#[rmk_central]
+mod keyboard_central {}

--- a/examples/use_config/nrf52840_ble_split_kinesis360/src/peripheral.rs
+++ b/examples/use_config/nrf52840_ble_split_kinesis360/src/peripheral.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#![no_std]
+
+use rmk::macros::rmk_peripheral;
+
+#[rmk_peripheral(id = 0)]
+mod keyboard_peripheral {}

--- a/examples/use_config/nrf52840_ble_split_kinesis360/vial.json
+++ b/examples/use_config/nrf52840_ble_split_kinesis360/vial.json
@@ -1,0 +1,161 @@
+{
+    "name": "Kinesis Adv360 Pro",
+    "vendorId": "0x4C4B",
+    "productId": "0x4643",
+    "lighting": "none",
+    "matrix": {
+        "rows": 5,
+        "cols": 20
+    },
+    "customKeycodes": [
+        {
+            "name": "BT0",
+            "title": "Bluetooth Channel 0",
+            "shortName": "BT0"
+        },
+        {
+            "name": "BT1",
+            "title": "Bluetooth Channel 1",
+            "shortName": "BT1"
+        },
+        {
+            "name": "BT2",
+            "title": "Bluetooth Channel 2",
+            "shortName": "BT2"
+        },
+        {
+            "name": "NEXT_BT",
+            "title": "Switch to the next Bluetooth channel",
+            "shortName": "Next\nBT"
+        },
+        {
+            "name": "PREV_BT",
+            "title": "Switch to the previous Bluetooth channel",
+            "shortName": "Prev\nBT"
+        },
+        {
+            "name": "CLR_BT",
+            "title": "Clear bond info for current channel",
+            "shortName": "Clear\nBT"
+        },
+        {
+            "name": "SWITCH",
+            "title": "Switch default output mode between USB/BLE",
+            "shortName": "Switch\nOutput"
+        }
+    ],
+    "layouts": {
+        "keymap": [
+            [
+                "0,0",
+                "0,1",
+                "0,2",
+                "0,3",
+                "0,4",
+                "0,5",
+                "0,6",
+                "0,7",
+                "0,8",
+                "0,9",
+                "0,10",
+                "0,11",
+                "0,12",
+                "0,13",
+                "0,14",
+                "0,15",
+                "0,16",
+                "0,17",
+                "0,18",
+                "0,19"
+            ],
+            [
+                "1,0",
+                "1,1",
+                "1,2",
+                "1,3",
+                "1,4",
+                "1,5",
+                "1,6",
+                "1,7",
+                "1,8",
+                "1,9",
+                "1,10",
+                "1,11",
+                "1,12",
+                "1,13",
+                "1,14",
+                "1,15",
+                "1,16",
+                "1,17",
+                "1,18",
+                "1,19"
+            ],
+            [
+                "2,0",
+                "2,1",
+                "2,2",
+                "2,3",
+                "2,4",
+                "2,5",
+                "2,6",
+                "2,7",
+                "2,8",
+                "2,9",
+                "2,10",
+                "2,11",
+                "2,12",
+                "2,13",
+                "2,14",
+                "2,15",
+                "2,16",
+                "2,17",
+                "2,18",
+                "2,19"
+            ],
+            [
+                "3,0",
+                "3,1",
+                "3,2",
+                "3,3",
+                "3,4",
+                "3,5",
+                "3,6",
+                "3,7",
+                "3,8",
+                "3,9",
+                "3,10",
+                "3,11",
+                "3,12",
+                "3,13",
+                "3,14",
+                "3,15",
+                "3,16",
+                "3,17",
+                "3,18",
+                "3,19"
+            ],
+            [
+                "4,0",
+                "4,1",
+                "4,2",
+                "4,3",
+                "4,4",
+                "4,5",
+                "4,6",
+                "4,7",
+                "4,8",
+                "4,9",
+                "4,10",
+                "4,11",
+                "4,12",
+                "4,13",
+                "4,14",
+                "4,15",
+                "4,16",
+                "4,17",
+                "4,18",
+                "4,19"
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
Add a working configuration for the Kinesis Advantage 360 Pro, a wireless split keyboard with nRF52840 MCUs and Adafruit nRF52 bootloader.

Key details:
- 5x20 matrix (10 cols per half), 4 layers, BLE split
- Storage explicitly set to 0xEC000 to avoid overlap with the ~426KB central firmware binary (default 0x60000 causes crash loop)
- async_matrix disabled due to GPIOTE channel conflicts on this board
- P0.13 output pin enabled to power the LED MOSFET on both halves
- Includes UF2 build pipeline via cargo-make
- README covers build, flash, BLE pairing, storage warning, and recovery procedure for switching back to ZMK/Clique