### PR TITLE
Fix `rmk.mouse_wheel_interval` and `rmk.mouse_key_interval` doing nothing

### DIFF
--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -178,10 +178,10 @@ impl KeyboardTomlConfig {
 pub struct RmkConstantsConfig {
     /// Mouse key interval (ms) - controls mouse movement speed
     #[serde_inline_default(20)]
-    pub mouse_key_interval: u32,
+    pub mouse_key_interval: u16,
     /// Mouse wheel interval (ms) - controls scrolling speed
     #[serde_inline_default(80)]
-    pub mouse_wheel_interval: u32,
+    pub mouse_wheel_interval: u16,
     /// Maximum number of combos keyboard can store
     #[serde_inline_default(8)]
     #[serde(deserialize_with = "check_combo_max_num")]

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -12,7 +12,7 @@ use rmk_types::action::{MorseMode, MorseProfile};
 use crate::combo::Combo;
 use crate::fork::Fork;
 use crate::morse::Morse;
-use crate::{COMBO_MAX_NUM, FORK_MAX_NUM, MORSE_MAX_NUM};
+use crate::{COMBO_MAX_NUM, FORK_MAX_NUM, MORSE_MAX_NUM, MOUSE_KEY_INTERVAL, MOUSE_WHEEL_INTERVAL};
 
 /// Internal configurations for RMK keyboard.
 #[derive(Default)]
@@ -263,18 +263,18 @@ impl Default for MouseKeyConfig {
     fn default() -> Self {
         Self {
             // Optimized values for comfortable and responsive mouse movement
-            initial_delay_ms: 100,         // 100ms initial delay
-            repeat_interval_ms: 20,        // 20ms between movements
-            move_delta: 6,                 // 6 pixels per movement (~300 px/sec)
-            max_speed: 3,                  // Conservative max speed multiplier (300 -> 900 px/sec)
-            time_to_max: 50,               // 1.0 second to max
-            wheel_initial_delay_ms: 100,   // 100ms initial wheel delay
-            wheel_repeat_interval_ms: 80,  // 80ms between wheel movements
-            wheel_delta: 1,                // 1 wheel unit per movement
-            wheel_max_speed_multiplier: 3, // Conservative wheel max speed
-            wheel_time_to_max: 40,         // 0.5 second to max
-            move_max: 20,                  // Maximum movement per report
-            wheel_max: 4,                  // Maximum wheel movement per report
+            initial_delay_ms: 100,                          // 100ms initial delay
+            repeat_interval_ms: MOUSE_KEY_INTERVAL,         // 20ms between movements
+            move_delta: 6,                                  // 6 pixels per movement (~300 px/sec)
+            max_speed: 3,                                   // Conservative max speed multiplier (300 -> 900 px/sec)
+            time_to_max: 50,                                // 1.0 second to max
+            wheel_initial_delay_ms: 100,                    // 100ms initial wheel delay
+            wheel_repeat_interval_ms: MOUSE_WHEEL_INTERVAL, // 80ms between wheel movements
+            wheel_delta: 1,                                 // 1 wheel unit per movement
+            wheel_max_speed_multiplier: 3,                  // Conservative wheel max speed
+            wheel_time_to_max: 40,                          // 0.5 second to max
+            move_max: 20,                                   // Maximum movement per report
+            wheel_max: 4,                                   // Maximum wheel movement per report
         }
     }
 }


### PR DESCRIPTION
Documentation of these settings states:

    - mouse_key_interval: Mouse key interval in milliseconds, default value is 20. This parameter controls the mouse movement speed; lower values result in faster movement.
    - mouse_wheel_interval: Mouse wheel interval in milliseconds, default value is 80. This parameter controls the scrolling speed; lower values result in faster scrolling. 

These settings are currently unused, however - and do nothing at all.

This PR changes that by using the user's settings instead of hard-coded defaults