### PR TITLE
feat: add configurable one-shot modifier behaviors

### DIFF
--- a/docs/docs/main/docs/configuration/appendix.md
+++ b/docs/docs/main/docs/configuration/appendix.md
@@ -123,6 +123,9 @@ one_shot = {
 # One Shot Modifiers configuration
 one_shot_modifiers = {
   activate_on_keypress = false,
+  tap_on_timeout = false,
+  tap_on_double_press = false,
+  retap_cancel = false,
 }
 
 [behavior.morse]

--- a/docs/docs/main/docs/configuration/behavior.md
+++ b/docs/docs/main/docs/configuration/behavior.md
@@ -50,18 +50,41 @@ By default, one-shot modifiers do not activate on keypress and will be sent only
 You can change this behavior by setting `activate_on_keypress` to `true`.
 This behavior is also known as One-Shot Sticky Modifiers (OSSM).
 
-If you press One-Shot Modifier again, it will be sent as a normal modifier key press and, therefore, released.
+### Re-press behavior
+
+When you press the same OSM key again while one-shot is active, the behavior depends on these options:
+
+- `tap_on_double_press` (default: `false`) — send a bare modifier tap to the host and consume the one-shot state. Useful for intentionally firing the modifier by itself (e.g., tapping LGui twice to open the Start menu).
+- `retap_cancel` (default: `false`) — cancel the one-shot silently without sending anything.
+
+If neither is enabled, re-pressing the same OSM key has no effect (the one-shot remains active). If both are enabled, `retap_cancel` takes priority.
+
+Pressing a *different* OSM key while one-shot is active will stack the modifiers (e.g., OSM-Shift then OSM-Ctrl applies both to the next key).
+
+### Timeout behavior
+
+- `tap_on_timeout` (default: `false`) — when the one-shot timeout expires with no follow-up key, send a bare modifier tap to the host instead of silently cancelling. Useful for triggering OS actions tied to a lone modifier press (e.g., tapping LGui to open the Start menu).
 
 Default values:
 ```toml
 [behavior.one_shot_modifiers]
 activate_on_keypress = false
+tap_on_timeout = false
+tap_on_double_press = false
+retap_cancel = false
 ```
 
 OSSM example:
 ```toml
 [behavior.one_shot_modifiers]
 activate_on_keypress = true
+```
+
+Example with re-press and timeout behaviors:
+```toml
+[behavior.one_shot_modifiers]
+tap_on_timeout = true
+tap_on_double_press = true
 ```
 
 ## Combo

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -600,6 +600,9 @@ pub(crate) struct OneShotConfig {
 #[serde(deny_unknown_fields)]
 pub struct OneShotModifiersConfig {
     pub activate_on_keypress: Option<bool>,
+    pub tap_on_timeout: Option<bool>,
+    pub tap_on_double_press: Option<bool>,
+    pub retap_cancel: Option<bool>,
 }
 
 /// Configurations for combos

--- a/rmk-config/src/resolved/behavior.rs
+++ b/rmk-config/src/resolved/behavior.rs
@@ -13,6 +13,9 @@ pub struct Behavior {
 
 pub struct OneShot {
     pub activate_on_keypress: Option<bool>,
+    pub tap_on_timeout: Option<bool>,
+    pub tap_on_double_press: Option<bool>,
+    pub retap_cancel: Option<bool>,
 }
 
 pub struct Combos {
@@ -103,6 +106,9 @@ impl crate::KeyboardTomlConfig {
 
         let one_shot_modifiers = toml_behavior.one_shot_modifiers.map(|o| OneShot {
             activate_on_keypress: o.activate_on_keypress,
+            tap_on_timeout: o.tap_on_timeout,
+            tap_on_double_press: o.tap_on_double_press,
+            retap_cancel: o.retap_cancel,
         });
 
         let combos = toml_behavior.combo.map(|c| Combos {

--- a/rmk-macro/src/codegen/behavior.rs
+++ b/rmk-macro/src/codegen/behavior.rs
@@ -48,9 +48,27 @@ fn expand_one_shot_modifiers(one_shot_modifiers: &Option<OneShot>) -> proc_macro
                 None => quote! {},
             };
 
+            let tap_on_timeout = match one_shot_modifier.tap_on_timeout {
+                Some(value) => quote! { tap_on_timeout: #value, },
+                None => quote! {},
+            };
+
+            let tap_on_double_press = match one_shot_modifier.tap_on_double_press {
+                Some(value) => quote! { tap_on_double_press: #value, },
+                None => quote! {},
+            };
+
+            let retap_cancel = match one_shot_modifier.retap_cancel {
+                Some(value) => quote! { retap_cancel: #value, },
+                None => quote! {},
+            };
+
             quote! {
                 ::rmk::config::OneShotModifiersConfig {
                     #activate_on_keypress
+                    #tap_on_timeout
+                    #tap_on_double_press
+                    #retap_cancel
                     ..Default::default()
                 }
             }

--- a/rmk/src/config/behavior.rs
+++ b/rmk/src/config/behavior.rs
@@ -78,6 +78,12 @@ impl Default for OneShotConfig {
 pub struct OneShotModifiersConfig {
     /// Should modifiers be active from keypress (sticky modifiers)
     pub activate_on_keypress: bool,
+    /// When timeout expires with no follow-up key, send a bare tap of the modifier
+    pub tap_on_timeout: bool,
+    /// When OSM key is pressed again while one-shot is active, send a bare tap of the modifier
+    pub tap_on_double_press: bool,
+    /// When OSM key is pressed again while one-shot is active, cancel silently
+    pub retap_cancel: bool,
 }
 
 /// Config for combo behavior

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1480,6 +1480,13 @@ impl<'a> Keyboard<'a> {
 
     /// Process mouse key action with acceleration support.
     async fn process_action_mouse(&mut self, key: HidKeyCode, event: KeyboardEvent) {
+        // Mouse reports don't carry keyboard modifiers. When an OSM modifier
+        // is active and a mouse button is pressed, send a keyboard report with
+        // the modifier first so the host applies it to the click (Ctrl+Click).
+        if event.pressed && self.osm_state.value().is_some() {
+            self.send_keyboard_report_with_resolved_modifiers(true).await;
+        }
+
         let action = {
             let config = self.keymap.mouse_key_config();
             self.mouse.process(key, event.pressed, &config)

--- a/rmk/src/keyboard/oneshot.rs
+++ b/rmk/src/keyboard/oneshot.rs
@@ -181,7 +181,7 @@ impl<'a> Keyboard<'a> {
         }
     }
 
-    pub(crate) fn update_osm(&mut self, event: KeyboardEvent) {
+    pub(crate) fn update_osm(&mut self, _event: KeyboardEvent) {
         match self.osm_state {
             OneShotState::Initial(m) => self.osm_state = OneShotState::Held(m),
             OneShotState::Single(_) => {

--- a/rmk/src/keyboard/oneshot.rs
+++ b/rmk/src/keyboard/oneshot.rs
@@ -31,41 +31,46 @@ impl<T> OneShotState<T> {
 
 impl<'a> Keyboard<'a> {
     pub(crate) async fn process_action_osm(&mut self, new_modifiers: ModifierCombination, event: KeyboardEvent) {
-        let activate_on_keypress = self.keymap.one_shot_modifiers_config().activate_on_keypress;
+        let osm_config = self.keymap.one_shot_modifiers_config();
+        let activate_on_keypress = osm_config.activate_on_keypress;
 
         // Update one shot state
         if event.pressed {
-            let mut was_active = false;
+            // Check for re-press of same OSM key (modifier bits overlap with active one-shot)
+            if let Some(&active_mods) = self.osm_state.value() {
+                let is_repress = active_mods & new_modifiers == new_modifiers;
+                if is_repress {
+                    if osm_config.retap_cancel {
+                        // Cancel one-shot silently
+                        self.unprocessed_events.retain(|e| e.pos != event.pos);
+                        self.osm_state = OneShotState::None;
+                        if activate_on_keypress {
+                            self.send_keyboard_report_with_resolved_modifiers(false).await;
+                        }
+                        return;
+                    } else if osm_config.tap_on_double_press {
+                        // Send bare modifier tap and consume one-shot
+                        self.unprocessed_events.retain(|e| e.pos != event.pos);
+                        self.send_keyboard_report_with_resolved_modifiers(true).await;
+                        self.osm_state = OneShotState::None;
+                        self.send_keyboard_report_with_resolved_modifiers(false).await;
+                        return;
+                    }
+                }
+            }
+
             // Add new modifier combination to existing one shot or init if none
             self.osm_state = match self.osm_state {
                 OneShotState::None => OneShotState::Initial(new_modifiers),
                 OneShotState::Initial(cur_modifiers) => OneShotState::Initial(cur_modifiers | new_modifiers),
-                OneShotState::Single(cur_modifiers) => {
-                    was_active = cur_modifiers & new_modifiers == new_modifiers;
-
-                    if was_active {
-                        let result = cur_modifiers & !new_modifiers;
-                        // Remove the matching event from unprocessed_events queue
-                        self.unprocessed_events.retain(|e| e.pos != event.pos);
-                        // Send report for current osm_state modifiers
-                        self.send_keyboard_report_with_resolved_modifiers(true).await;
-
-                        if result.into_bits() == 0 {
-                            OneShotState::None
-                        } else {
-                            OneShotState::Single(result)
-                        }
-                    } else {
-                        OneShotState::Single(cur_modifiers | new_modifiers)
-                    }
-                }
+                OneShotState::Single(cur_modifiers) => OneShotState::Single(cur_modifiers | new_modifiers),
                 OneShotState::Held(cur_modifiers) => OneShotState::Held(cur_modifiers | new_modifiers),
             };
 
             self.update_osl(event);
 
             // Send report for updated osm_state modifiers
-            if was_active || activate_on_keypress {
+            if activate_on_keypress {
                 self.send_keyboard_report_with_resolved_modifiers(true).await;
             }
         } else {
@@ -75,13 +80,29 @@ impl<'a> Keyboard<'a> {
                     let timeout = Timer::after(self.keymap.one_shot_timeout());
                     match select(timeout, self.keyboard_event_subscriber.next_message_pure()).await {
                         Either::First(_) => {
-                            // Timeout, release modifiers
-                            self.update_osl(event);
-                            self.osm_state = OneShotState::None;
-
-                            // Send release report because modifiers were held
-                            if activate_on_keypress {
-                                self.send_keyboard_report_with_resolved_modifiers(false).await;
+                            // Timeout fired. Guard against the select race where
+                            // the timer is polled first and wins even though a key
+                            // event arrived at the subscriber at the same instant.
+                            if let Some(e) = self.keyboard_event_subscriber.try_next_message_pure() {
+                                // A key event was pending — one-shot is consumed, not timed out
+                                if self.unprocessed_events.push(e).is_err() {
+                                    warn!("Unprocessed event queue is full, dropping event");
+                                }
+                            } else {
+                                // Genuinely timed out with no pending key event
+                                self.update_osl(event);
+                                if osm_config.tap_on_timeout {
+                                    // Send bare modifier tap before clearing state
+                                    self.send_keyboard_report_with_resolved_modifiers(true).await;
+                                    self.osm_state = OneShotState::None;
+                                    self.send_keyboard_report_with_resolved_modifiers(false).await;
+                                } else {
+                                    self.osm_state = OneShotState::None;
+                                    // Send release report because modifiers were held
+                                    if activate_on_keypress {
+                                        self.send_keyboard_report_with_resolved_modifiers(false).await;
+                                    }
+                                }
                             }
                         }
                         Either::Second(e) => {
@@ -164,9 +185,12 @@ impl<'a> Keyboard<'a> {
         match self.osm_state {
             OneShotState::Initial(m) => self.osm_state = OneShotState::Held(m),
             OneShotState::Single(_) => {
-                if !event.pressed {
-                    self.osm_state = OneShotState::None;
-                }
+                // Once any key is pressed or released after an OSM tap,
+                // the one-shot is consumed. On press, the modifier was already
+                // included in the HID report (resolve_modifiers runs before
+                // update_osm), so clearing here is safe and prevents the
+                // state from lingering as Single between key press and release.
+                self.osm_state = OneShotState::None;
             }
             _ => (),
         }

--- a/rmk/tests/keyboard_one_shot_test.rs
+++ b/rmk/tests/keyboard_one_shot_test.rs
@@ -549,5 +549,127 @@ mod one_shot_test {
                 ]
             };
         }
+
+        /// OSM tap_on_timeout: when timeout expires, send bare modifier tap
+        #[test]
+        fn test_osm_tap_on_timeout() {
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_behavior_config(
+                    BehaviorConfig {
+                        one_shot: OneShotConfig {
+                            timeout: Duration::from_millis(100),
+                            ..OneShotConfig::default()
+                        },
+                        one_shot_modifiers: OneShotModifiersConfig {
+                            tap_on_timeout: true,
+                            ..OneShotModifiersConfig::default()
+                        },
+                        ..BehaviorConfig::default()
+                    }
+                ),
+                sequence: [
+                    [0, 0, true, 10],   // Press OSM LShift
+                    [0, 0, false, 10],  // Release OSM LShift
+                    [0, 2, true, 150],  // Press A after timeout (delay > 100ms)
+                    [0, 2, false, 10],  // Release A
+                ],
+                expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]], // Bare modifier press (tap_on_timeout)
+                    [0, [0, 0, 0, 0, 0, 0]],          // Modifier released
+                    [0, [kc_to_u8!(A), 0, 0, 0, 0, 0]], // A without modifier
+                    [0, [0, 0, 0, 0, 0, 0]],          // All released
+                ]
+            };
+        }
+
+        /// OSM tap_on_double_press: re-pressing same OSM sends bare modifier tap
+        #[test]
+        fn test_osm_tap_on_double_press() {
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_behavior_config(
+                    BehaviorConfig {
+                        one_shot: OneShotConfig {
+                            timeout: Duration::from_millis(100),
+                            ..OneShotConfig::default()
+                        },
+                        one_shot_modifiers: OneShotModifiersConfig {
+                            tap_on_double_press: true,
+                            ..OneShotModifiersConfig::default()
+                        },
+                        ..BehaviorConfig::default()
+                    }
+                ),
+                sequence: [
+                    [0, 0, true, 10],   // Press OSM LShift
+                    [0, 0, false, 10],  // Release OSM LShift (Single state)
+                    [0, 0, true, 50],   // Press OSM LShift again (before 100ms timeout)
+                    [0, 0, false, 10],  // Release (no-op, state cleared)
+                ],
+                expected_reports: [
+                    [KC_LSHIFT, [0, 0, 0, 0, 0, 0]], // Bare modifier press (double tap)
+                    [0, [0, 0, 0, 0, 0, 0]],          // Modifier released
+                ]
+            };
+        }
+
+        /// OSM retap_cancel: re-pressing same OSM cancels silently
+        #[test]
+        fn test_osm_retap_cancel() {
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_behavior_config(
+                    BehaviorConfig {
+                        one_shot: OneShotConfig {
+                            timeout: Duration::from_millis(100),
+                            ..OneShotConfig::default()
+                        },
+                        one_shot_modifiers: OneShotModifiersConfig {
+                            retap_cancel: true,
+                            ..OneShotModifiersConfig::default()
+                        },
+                        ..BehaviorConfig::default()
+                    }
+                ),
+                sequence: [
+                    [0, 0, true, 10],   // Press OSM LShift
+                    [0, 0, false, 10],  // Release OSM LShift (Single state)
+                    [0, 0, true, 50],   // Press OSM LShift again (cancels)
+                    [0, 0, false, 10],  // Release (no-op)
+                    [0, 2, true, 10],   // Press A (no modifier)
+                    [0, 2, false, 10],  // Release A
+                ],
+                expected_reports: [
+                    [0, [kc_to_u8!(A), 0, 0, 0, 0, 0]], // A without modifier (OSM was cancelled)
+                    [0, [0, 0, 0, 0, 0, 0]],             // All released
+                ]
+            };
+        }
+
+        /// tap_on_double_press with different OSM still stacks modifiers
+        #[test]
+        fn test_osm_double_press_different_modifier_still_stacks() {
+            key_sequence_test! {
+                keyboard: create_test_keyboard_with_behavior_config(
+                    BehaviorConfig {
+                        one_shot_modifiers: OneShotModifiersConfig {
+                            tap_on_double_press: true,
+                            ..OneShotModifiersConfig::default()
+                        },
+                        ..BehaviorConfig::default()
+                    }
+                ),
+                sequence: [
+                    [0, 0, true, 10],   // Press OSM LShift
+                    [0, 0, false, 10],  // Release OSM LShift (Single state)
+                    [0, 4, true, 50],   // Press OSM LCtrl (different modifier, should stack)
+                    [0, 4, false, 10],  // Release OSM LCtrl
+                    [0, 2, true, 10],   // Press A
+                    [0, 2, false, 10],  // Release A
+                ],
+                expected_reports: [
+                    [KC_LSHIFT | KC_LCTRL, [kc_to_u8!(A), 0, 0, 0, 0, 0]], // A with both modifiers
+                    [0, [0, 0, 0, 0, 0, 0]],             // All released
+                ]
+            };
+        }
     }
 }


### PR DESCRIPTION
Again, I'm trying to replicate all the features I was using previously on KMK. I've only got one more after this. I think I tested this fairly extensively on my own keyboard, and almost everything worked perfectly. I add this so that it is much easier to send a bare one-shot key to the OS than it was before. This allows you to double tap a one-shot key to immediately send that one-shot key to the os with no other keys. It also allows for sending the one-shot key once after tapping it when the timeout is reached. This is useful for using the gui (start) key which I couldn't use on its own to get to the start menu (on Windows and similar on Linux) while keeping the one-shot functionality. Thanks again.

Add three new configuration options for one-shot modifiers (OSM) and fix OSM interaction with mouse keys.

### New OSM configuration options

All options default to `false`, preserving existing behavior for current users.

**Re-press behavior** — what happens when you press the same OSM key again while one-shot is active:

- `tap_on_double_press` — send a bare modifier tap to the host and consume the one-shot state. Useful for intentionally firing the modifier by itself (e.g., tapping LGui twice to open the Start menu).
- `retap_cancel` — cancel the one-shot silently without sending anything. Takes priority over `tap_on_double_press` if both are enabled.

**Timeout behavior:**

- `tap_on_timeout` — when the one-shot timeout expires with no follow-up key, send a bare modifier tap instead of silently cancelling. Useful for triggering OS actions tied to a lone modifier press.

```toml
[behavior.one_shot_modifiers]
tap_on_timeout = true
tap_on_double_press = true
```

### Behavior change: unconditional unstick-on-repress removed

The `main` branch (post-v0.8.2) added unconditional logic in `process_action_osm()` where re-pressing the same OSM key always removed the matching modifier bits and sent a report pair. This PR replaces that unconditional behavior with the explicit `tap_on_double_press` and `retap_cancel` options above.

Since the unstick behavior was added after v0.8.2 and has not been in a published release, this should not affect any released users. Users who adopted the behavior from `main` can restore it by adding `tap_on_double_press = true` to their config.

### Bug fixes

**OSM + mouse click:** Mouse HID reports don't carry keyboard modifier bits. When an OSM modifier was active and a mouse button was pressed, the host received the click without modifier context, so combinations like Ctrl+Click didn't work. Fixed by sending a keyboard report with resolved OSM modifiers before the mouse report in `process_action_mouse`.

**Select race in OSM timeout:** Guard against the `select` race where the timer wins even though a key event arrived at the subscriber simultaneously. Now checks `try_next_message_pure()` before treating a timeout as genuine.

**update_osm timing:** Clear `Single` state on any key event (press or release), not just release. Since `resolve_modifiers` runs before `update_osm`, the modifier is already included in the HID report by the time `update_osm` executes, so clearing on press prevents the state from lingering between key press and release.

### Tests

Four new tests covering the configurable behaviors:
- `test_osm_tap_on_timeout` — bare modifier tap on timeout expiry
- `test_osm_tap_on_double_press` — bare modifier tap on re-press
- `test_osm_retap_cancel` — silent cancellation on re-press
- `test_osm_double_press_different_modifier_still_stacks` — stacking different OSM modifiers still works with `tap_on_double_press` enabled

### Context

I'm using a Sofle V2 split keyboard with sticky modifier keys (OSM) and needed these behaviors to match what I had in KMK firmware (`KC.SK` with `retap_cancel=True` and timeout tap). The mouse fix was discovered during daily use — Ctrl+Click for opening links in new tabs wasn't working with OSM-Ctrl.

### Changes

- `rmk/src/keyboard/oneshot.rs` — core OSM state machine changes
- `rmk/src/keyboard.rs` — mouse + OSM modifier fix
- `rmk/src/config/behavior.rs` — new config struct fields
- `rmk-config/src/lib.rs` — TOML deserialization
- `rmk-config/src/resolved/behavior.rs` — resolved config
- `rmk-macro/src/codegen/behavior.rs` — proc macro codegen
- `rmk/tests/keyboard_one_shot_test.rs` — 4 new tests
- `docs/docs/main/docs/configuration/behavior.md` — user-facing docs
- `docs/docs/main/docs/configuration/appendix.md` — full config reference

### Minor Issue with Windows

The one "issue" is something that I'm pretty sure is an OS issue (with Windows gui+arrow keys) anyway. It works normally but when tapping (once) the one-shot gui key then layer key (MO) then tap an arrow key with another tap. It sends the correct combination but it also sends the gui key (seemingly independently). I realized that my KMK firmware also acted weird when doing this as well. This does not occur with any other key as far as I can tell (e.g. I tried using the exact same sequence but with the `a` key and it worked perfectly).

So again the only reason I came across it was due to trying to be comprehensive in my testing so it doesn't effect me but I figured I would be transparent. I tired to fix it for a while but couldn't figure out anything that worked. If anyone wants to take a stab at it feel free.
