### PR TITLE
rust 1.95 clippy fixes

### DIFF
--- a/rmk/src/host/via/mod.rs
+++ b/rmk/src/host/via/mod.rs
@@ -100,20 +100,13 @@ impl<'a, RW: HidWriterTrait<ReportType = ViaReport> + HidReaderTrait<ReportType 
                             let layout_option: u32 = 0;
                             BigEndian::write_u32(&mut report.input_data[2..6], layout_option);
                         }
+                        #[cfg(not(feature = "vial_lock"))]
                         ViaKeyboardInfo::SwitchMatrixState => {
-                            #[cfg(feature = "vial_lock")]
-                            {
-                                #[cfg(not(feature = "vial_lock"))]
-                                {
-                                    self.keymap.read_matrix_state(&mut report.input_data[2..]);
-                                    error!("It is not secure to use matrix tester without vial lock");
-                                }
-
-                                #[cfg(feature = "vial_lock")]
-                                if self.locker.is_unlocked() {
-                                    self.keymap.read_matrix_state(&mut report.input_data[2..]);
-                                }
-                            }
+                            error!("It is not secure to use matrix tester without vial lock");
+                        }
+                        #[cfg(feature = "vial_lock")]
+                        ViaKeyboardInfo::SwitchMatrixState if self.locker.is_unlocked() => {
+                            self.keymap.read_matrix_state(&mut report.input_data[2..]);
                         }
                         ViaKeyboardInfo::FirmwareVersion => {
                             BigEndian::write_u32(&mut report.input_data[2..6], VIA_FIRMWARE_VERSION);

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -334,19 +334,17 @@ impl<'a> Keyboard<'a> {
                     }
                 }
             }
-            KeyState::Pressed(_) | KeyState::Released(_) | KeyState::EarlyFired(_) => {
-                if key.action.is_morse() {
-                    // Wait for timeout or new key event
-                    info!("Waiting morse key: {:?}", key.action);
-                    match with_deadline(key.timeout_time, self.keyboard_event_subscriber.next_message_pure()).await {
-                        Ok(event) => {
-                            debug!("Buffered morse key interrupted by a new key event: {:?}", event);
-                            self.process_inner(event).await;
-                        }
-                        Err(_timeout) => {
-                            debug!("Buffered morse key timeout");
-                            self.handle_morse_timeout(&key).await;
-                        }
+            KeyState::Pressed(_) | KeyState::Released(_) | KeyState::EarlyFired(_) if key.action.is_morse() => {
+                // Wait for timeout or new key event
+                info!("Waiting morse key: {:?}", key.action);
+                match with_deadline(key.timeout_time, self.keyboard_event_subscriber.next_message_pure()).await {
+                    Ok(event) => {
+                        debug!("Buffered morse key interrupted by a new key event: {:?}", event);
+                        self.process_inner(event).await;
+                    }
+                    Err(_timeout) => {
+                        debug!("Buffered morse key timeout");
+                        self.handle_morse_timeout(&key).await;
                     }
                 }
             }

--- a/rmk/src/keyboard/oneshot.rs
+++ b/rmk/src/keyboard/oneshot.rs
@@ -163,10 +163,8 @@ impl<'a> Keyboard<'a> {
     pub(crate) fn update_osm(&mut self, event: KeyboardEvent) {
         match self.osm_state {
             OneShotState::Initial(m) => self.osm_state = OneShotState::Held(m),
-            OneShotState::Single(_) => {
-                if !event.pressed {
-                    self.osm_state = OneShotState::None;
-                }
+            OneShotState::Single(_) if !event.pressed => {
+                self.osm_state = OneShotState::None;
             }
             _ => (),
         }
@@ -175,11 +173,9 @@ impl<'a> Keyboard<'a> {
     pub(crate) fn update_osl(&mut self, event: KeyboardEvent) {
         match self.osl_state {
             OneShotState::Initial(l) => self.osl_state = OneShotState::Held(l),
-            OneShotState::Single(layer_num) => {
-                if !event.pressed {
-                    self.keymap.deactivate_layer(layer_num);
-                    self.osl_state = OneShotState::None;
-                }
+            OneShotState::Single(layer_num) if !event.pressed => {
+                self.keymap.deactivate_layer(layer_num);
+                self.osl_state = OneShotState::None;
             }
             _ => (),
         }


### PR DESCRIPTION
Note the `src/host/via/mod.rs` is a behavior change: the `#[cfg(not(feature = "vial_lock"))]` path was within a `#[cfg(feature = "vial_lock"))]` path before.