### PR TITLE
test ux improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,15 +20,17 @@ The `scripts` directory contains useful scripts for checking/formatting code
 ## Commands
 
 ### Testing
-Run from the `rmk/` directory:
 
+Dev loop — one feature set, from `rmk/` (requires `cargo nextest`):
 ```bash
-cargo test --no-default-features --features=split,vial,storage,async_matrix,_ble
+cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble
 ```
 
-Run macro tests from `rmk-macro/` (requires `cargo-expand`):
+Run macro tests from `rmk-macro/` (requires `cargo expand`).
+
+Full feature matrix (what CI runs, ~40 s when clean):
 ```bash
-cargo test
+sh scripts/test_all.sh
 ```
 
 ### Building examples

--- a/rmk-macro/.config/nextest.toml
+++ b/rmk-macro/.config/nextest.toml
@@ -1,0 +1,1 @@
+../../.config/nextest.toml

--- a/rmk-types/.config/nextest.toml
+++ b/rmk-types/.config/nextest.toml
@@ -1,0 +1,1 @@
+../../.config/nextest.toml

--- a/rmk/.config/nextest.toml
+++ b/rmk/.config/nextest.toml
@@ -1,0 +1,1 @@
+../../.config/nextest.toml

--- a/rmk/src/test_support.rs
+++ b/rmk/src/test_support.rs
@@ -15,6 +15,26 @@ use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 use embassy_time::{Duration, MockDriver};
 
+// `embassy-time`'s MockDriver is a process-global singleton, so running the
+// suite under plain `cargo test` lets tests race on it and hang at the 60 s
+// virtual-time kill switch below. Abort at test-binary startup with a pointer
+// to the right runner instead of making the user wait for that timeout.
+#[ctor::ctor]
+fn require_nextest() {
+    if std::env::var_os("NEXTEST").is_none() {
+        eprintln!(
+            "\nrmk tests must run under cargo-nextest (embassy-time's MockDriver \
+             is a process-global singleton and needs per-test process isolation).\n\
+             \n  cargo install cargo-nextest --locked\n\n\
+             Then from rmk/:\n\n  \
+             cargo nextest run --no-default-features \
+             --features=split,vial,storage,async_matrix,_ble\n\n\
+             Or for the full feature matrix: `sh scripts/test_all.sh` from the repo root.\n"
+        );
+        std::process::exit(1);
+    }
+}
+
 const STEP: Duration = Duration::from_micros(100);
 const MAX_ITERS: usize = 60_000_000; // 60 s of virtual time
 

--- a/rmk/tests/common/mod.rs
+++ b/rmk/tests/common/mod.rs
@@ -20,6 +20,27 @@ use rmk::types::action::KeyAction;
 use rmk::types::modifier::ModifierCombination;
 use rmk::{KeymapData, a, k, layer, lt, mo, shifted, th, wm};
 
+// `embassy-time`'s MockDriver is a process-global singleton, so running the
+// suite under plain `cargo test` lets tests race on it and hang at the 60 s
+// virtual-time kill switch in `test_block_on`. Abort at test-binary startup
+// with a pointer to the right runner instead of making the user wait for that
+// timeout.
+#[ctor::ctor]
+fn require_nextest() {
+    if std::env::var_os("NEXTEST").is_none() {
+        eprintln!(
+            "\nrmk tests must run under cargo-nextest (embassy-time's MockDriver \
+             is a process-global singleton and needs per-test process isolation).\n\
+             \n  cargo install cargo-nextest --locked\n\n\
+             Then from rmk/:\n\n  \
+             cargo nextest run --no-default-features \
+             --features=split,vial,storage,async_matrix,_ble\n\n\
+             Or for the full feature matrix: `sh scripts/test_all.sh` from the repo root.\n"
+        );
+        std::process::exit(1);
+    }
+}
+
 // Init logger for tests
 #[ctor::ctor]
 pub fn init_log() {


### PR DESCRIPTION
It looks like standard `cargo test` fails since ab3ad91c with some failures and timeouts. Improve the experience of landing in the repo and running tests:

* make `cargo test` fail-fast with instructions to use `cargo nextest` instead
* update `CLAUDE.md` instructions to use `cargo nextest`
* add symlinks so you don't need to specify the path to the nextest config in the `rmk`, `rmk-types`, and `rmk-macros` crates