### PR TITLE
fix stuck keys on combo edge cases

### DIFF
--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimize the timing for motion read and sending reports on the PMW3610
 - Correct the delay length of PMW3610 to the precise value
 
+### Fixed
+
+- Fix stuck key when a combo key is re-pressed while the combo is still held. Previously the re-press overwrote the combo output's HID slot, and on combo release the output couldn't be unregistered, leaving the re-pressed key stuck on the host.
+- Fix stuck combo output when overlapping triggered combos share a key (e.g. `M+,` and `,+.` both containing Comma). Releasing the shared key now dispatches the release of every fully-unwound combo output, not just the first.
+- Fix `unregister_keycode` choosing the wrong HID slot when a combo output and another pressed key share a position. Slot lookup now prefers a `(pos, keycode)` match and falls back to keycode-only.
+
 ## [0.8.2] - 2025-12-18
 
 ### Added

--- a/rmk/src/combo.rs
+++ b/rmk/src/combo.rs
@@ -67,6 +67,26 @@ impl Combo {
         action_idx.is_some()
     }
 
+    /// Re-assert a combo key's bit in the state of an already-triggered combo.
+    ///
+    /// Covers the case where the user releases one key of a held chord and presses
+    /// it again while the other combo key is still down. The re-press must not
+    /// leak to HID (it would overwrite the combo output's slot), and the eventual
+    /// release must still complete the combo — so we re-set the bit here.
+    ///
+    /// Returns true iff this combo is triggered and `key_action` is one of its
+    /// actions, i.e. the caller should swallow the press.
+    pub(crate) fn reassert_if_triggered(&mut self, key_action: &KeyAction) -> bool {
+        if !self.is_triggered {
+            return false;
+        }
+        if let Some(i) = self.config.find_key_action_index(key_action) {
+            self.state |= 1 << i;
+            return true;
+        }
+        false
+    }
+
     /// Update the combo's state when a key is released
     /// When the combo is fully released from triggered state, this function returns true
     pub(crate) fn update_released(&mut self, key_action: &KeyAction) -> bool {

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -36,7 +36,7 @@ use crate::keymap::KeyMap;
 use crate::morse::{MorsePattern, TAP};
 #[cfg(all(feature = "split", feature = "_ble"))]
 use crate::split::ble::central::update_activity_time;
-use crate::{FORK_MAX_NUM, MACRO_SPACE_SIZE, boot};
+use crate::{COMBO_MAX_NUM, FORK_MAX_NUM, MACRO_SPACE_SIZE, boot};
 
 pub(crate) mod combo;
 pub(crate) mod held_buffer;
@@ -1001,6 +1001,28 @@ impl<'a> Keyboard<'a> {
             self.trigger_delayed_combo(key_action, event).await;
         }
 
+        // If this is a re-press of a key belonging to an already-triggered combo
+        // (the user released one chord key and pressed it again while the other
+        // is still down), reassert its bit in the combo state and swallow the
+        // press. Otherwise the press would reach `register_keycode` at the same
+        // pos where the combo output was registered and overwrite it in the
+        // HID report, stranding the re-pressed key after the combo completes.
+        if event.pressed {
+            let reasserted = self.keymap.with_combos_mut(|combos| {
+                let mut any = false;
+                for combo in combos.iter_mut().filter_map(|c| c.as_mut()) {
+                    if combo.reassert_if_triggered(key_action) {
+                        any = true;
+                    }
+                }
+                any
+            });
+            if reasserted {
+                debug!("[Combo] re-press of triggered-combo key swallowed: {:?}", key_action);
+                return (None, true);
+            }
+        }
+
         let max_size_of_updated_combo = self.keymap.with_combos_mut(|combos| {
             combos
                 .iter_mut()
@@ -1055,7 +1077,11 @@ impl<'a> Keyboard<'a> {
             if !event.pressed {
                 info!("Releasing keys in combo: {:?} {:?}", event, key_action);
 
-                let mut combo_output = None;
+                // Overlapping triggered combos can each fully release on the same key
+                // (e.g. `M+,` and `,+.` both sharing Comma), so collect every combo
+                // output that unwinds — not just the first — otherwise the others
+                // stay stuck on the host.
+                let mut combo_outputs: Vec<KeyAction, COMBO_MAX_NUM> = Vec::new();
                 let mut releasing_triggered_combo = false;
 
                 self.keymap.with_combos_mut(|combos| {
@@ -1067,19 +1093,23 @@ impl<'a> Keyboard<'a> {
 
                             // Release the combo key, check whether the combo is fully released
                             if combo.update_released(key_action) {
-                                // If the combo is fully released, update the combo output
                                 debug!("[Combo] {:?} is released", combo.config.output);
-                                combo_output = combo_output.or(Some(combo.config.output));
+                                let _ = combo_outputs.push(combo.config.output);
                             }
                         }
                     }
                 });
 
-                // Releasing a triggered combo
-                // - Return the output of the triggered combo when the combo is fully released
-                // - Return None when the combo is not fully released yet
+                // Releasing a triggered combo:
+                // - Dispatch every combo output whose combo fully unwound, in iteration
+                //   order. Returning `None` tells the caller not to dispatch again.
+                // - Return `(None, true)` on a partial release too (combo output still
+                //   held), which consumes the release event without sending anything.
                 if releasing_triggered_combo {
-                    return (combo_output, true);
+                    for output in &combo_outputs {
+                        self.process_key_action(output, event, true).await;
+                    }
+                    return (None, true);
                 }
             }
 
@@ -1738,26 +1768,26 @@ impl<'a> Keyboard<'a> {
 
     /// Unregister a key from hid report.
     fn unregister_keycode(&mut self, key: HidKeyCode, event: KeyboardEvent) {
-        // First, find the key event slot according to the position
+        // Prefer a slot whose recorded pos AND keycode both match. Combo outputs are
+        // registered under the triggering key's pos, so a pos-only match can hit a
+        // slot that holds a different keycode — and clear the wrong combo output,
+        // leaving the intended one stuck on the host.
         let slot = self.registered_keys.iter().enumerate().find_map(|(i, k)| {
             if let Some(e) = k
                 && event.pos == e.pos
+                && self.held_keycodes[i] == key
             {
                 return Some(i);
             }
             None
         });
 
-        // If the slot is found, update the key in the slot
+        // Fall back to any slot holding the same keycode.
+        let slot = slot.or_else(|| self.held_keycodes.iter().position(|&k| k == key));
+
         if let Some(index) = slot {
             self.held_keycodes[index] = HidKeyCode::No;
             self.registered_keys[index] = None;
-        } else {
-            // Otherwise, release the first same key
-            if let Some(index) = self.held_keycodes.iter().position(|&k| k == key) {
-                self.held_keycodes[index] = HidKeyCode::No;
-                self.registered_keys[index] = None;
-            }
         }
     }
 

--- a/rmk/tests/keyboard_combo_test.rs
+++ b/rmk/tests/keyboard_combo_test.rs
@@ -341,3 +341,107 @@ fn test_taphold_with_combo() {
         ]
     };
 }
+// Reproduces a single-combo stuck-key bug: re-pressing a combo key while the
+// combo is still held (one key of the chord was released, same key pressed
+// again) leaked the re-press into the HID report and overwrote the combo
+// output's slot. When the other combo key finally released, the combo output
+// release couldn't find its slot, leaving the re-pressed key stuck.
+#[test]
+fn test_re_press_combo_key_while_triggered_does_not_leak_to_hid() {
+    let combos = CombosConfig {
+        combos: [
+            Some(Combo::new(ComboConfig::new(
+                [k!(Comma), k!(Dot)].to_vec(),
+                k!(Backspace),
+                Some(0),
+            ))),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        timeout: Duration::from_millis(40),
+    };
+    key_sequence_test! {
+        keyboard: create_test_keyboard_with_config(BehaviorConfig {
+            combo: combos,
+            ..Default::default()
+        }),
+        sequence: [
+            [3, 8, true, 10],   // Comma press
+            [3, 9, true, 10],   // Dot press -> `,+.` triggers -> Backspace pressed
+            [3, 9, false, 10],  // Dot release (partial release, swallowed)
+            [3, 9, true, 10],   // Dot re-press while combo still held
+            [3, 9, false, 10],  // Dot re-release (still part of combo)
+            [3, 8, false, 10],  // Comma release -> combo fully releases -> Backspace released
+        ],
+        expected_reports: [
+            [0, [kc_to_u8!(Backspace), 0, 0, 0, 0, 0]],
+            [0, [0; 6]],
+        ]
+    }
+}
+
+// Reproduces a stuck combo-output bug on overlapping triggered combos.
+//
+// Config: `M+,` → RightBracket, `,+.` → Equal. The two combos share Comma.
+//
+// Sequence: typing that ends with two triggered combos whose state bits overlap
+// through Comma. When Comma is finally released, both combo outputs must
+// unregister from the HID report. Previously only one did — the other got
+// stuck on the host until the user pressed another key.
+//
+// The cascade specifically relies on state bits surviving across a prior combo
+// trigger: pressing Dot+Comma triggers `,+.` (→ Equal) but leaves Comma's bit
+// set in `M+,`, so a subsequent M press immediately completes `M+,` without
+// re-pressing Comma.
+#[test]
+fn test_overlapping_triggered_combos_release_all_outputs() {
+    let combos = CombosConfig {
+        combos: [
+            Some(Combo::new(ComboConfig::new(
+                [k!(M), k!(Comma)].to_vec(),
+                k!(RightBracket),
+                Some(0),
+            ))),
+            Some(Combo::new(ComboConfig::new(
+                [k!(Comma), k!(Dot)].to_vec(),
+                k!(Equal),
+                Some(0),
+            ))),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        timeout: Duration::from_millis(40),
+    };
+    key_sequence_test! {
+        keyboard: create_test_keyboard_with_config(BehaviorConfig {
+            combo: combos,
+            ..Default::default()
+        }),
+        sequence: [
+            [3, 9, true, 10],   // Dot press
+            [3, 8, true, 10],   // Comma press -> `,+.` triggers -> Equal pressed
+            [3, 9, false, 10],  // Dot release (partial release of triggered combo)
+            [3, 7, true, 10],   // M press -> `M+,` triggers (stale Comma bit) -> RightBracket pressed
+            [3, 7, false, 10],  // M release (partial release of triggered combo)
+            [3, 8, false, 10],  // Comma release -> must release BOTH combo outputs
+        ],
+        expected_reports: [
+            [0, [kc_to_u8!(Equal), 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(Equal), kc_to_u8!(RightBracket), 0, 0, 0, 0]],
+            // Releasing Comma fully unwinds both triggered combos.
+            // Order of the two release reports depends on combo iteration order;
+            // `M+,` is index 0 so its output (RightBracket) releases first.
+            [0, [kc_to_u8!(Equal), 0, 0, 0, 0, 0]],
+            [0, [0; 6]],
+        ]
+    }
+}


### PR DESCRIPTION
Note the new behavior matches QMK's `COMBO_PROCESS_KEY_REPRESS` described on their [combos page](https://docs.qmk.fm/features/combo). I don't feel strongly about that; I just don't want to leave stuck keys!