### PR TITLE
fix(core): only record press timestamp for morse keys

### DIFF
--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix stuck key when a combo key is re-pressed while the combo is still held. Previously the re-press overwrote the combo output's HID slot, and on combo release the output couldn't be unregistered, leaving the re-pressed key stuck on the host.
 - Fix stuck combo output when overlapping triggered combos share a key (e.g. `M+,` and `,+.` both containing Comma). Releasing the shared key now dispatches the release of every fully-unwound combo output, not just the first.
 - Fix `unregister_keycode` choosing the wrong HID slot when a combo output and another pressed key share a position. Slot lookup now prefers a `(pos, keycode)` match and falls back to keycode-only.
+- Fix spurious "Timer buffer full" warns after 16 distinct key positions are pressed. The per-position timer `LinearMap` is gone; press time is now threaded as a parameter through the morse-press dispatch.
 
 ## [0.8.2] - 2025-12-18
 

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -361,27 +361,32 @@ impl<'a> Keyboard<'a> {
         #[cfg(feature = "host_security")]
         self.keymap.update_matrix_state(&event);
 
-        // Matrix should process key pressed event first, record the timestamp of key changes
-        if event.pressed {
-            self.set_timer_value(event, Some(Instant::now()));
-        }
         // Update activity time for BLE split central sleep management
         #[cfg(all(feature = "split", feature = "_ble"))]
         update_activity_time();
+
+        // Capture the event time once per event and thread it through.
+        let event_time = Instant::now();
 
         // Process key
         let key_action = &self.keymap.get_action_with_layer_cache(event);
 
         if self.combo_on {
-            if let (Some(key_action), is_combo) = self.process_combo(key_action, event).await {
-                self.process_key_action(&key_action, event, is_combo).await
+            if let (Some(key_action), is_combo) = self.process_combo(key_action, event, event_time).await {
+                self.process_key_action(&key_action, event, is_combo, event_time).await
             }
         } else {
-            self.process_key_action(key_action, event, false).await
+            self.process_key_action(key_action, event, false, event_time).await
         }
     }
 
-    async fn process_key_action(&mut self, key_action: &KeyAction, event: KeyboardEvent, is_combo: bool) {
+    async fn process_key_action(
+        &mut self,
+        key_action: &KeyAction,
+        event: KeyboardEvent,
+        is_combo: bool,
+        event_time: Instant,
+    ) {
         // First, make the decision for current key and held keys
         let (decision_for_current_key, decisions) = self.make_decisions_for_keys(key_action, event);
 
@@ -406,21 +411,20 @@ impl<'a> Keyboard<'a> {
                 } else {
                     key_action
                 };
-                self.process_key_action_inner(key_action, event).await
+                self.process_key_action_inner(key_action, event, event_time).await
             }
             KeyBehaviorDecision::Buffer => {
                 debug!("Current key is buffered");
-                let press_time = Instant::now();
                 let timeout_time = if key_action.is_morse() {
-                    press_time + Self::morse_timeout(self.keymap, key_action, true)
+                    event_time + Self::morse_timeout(self.keymap, key_action, true)
                 } else {
-                    press_time
+                    event_time
                 };
                 self.held_buffer.push(HeldKey::new(
                     event,
                     *key_action,
                     KeyState::Pressed(MorsePattern::default()),
-                    press_time,
+                    event_time,
                     timeout_time,
                 ));
             }
@@ -433,7 +437,7 @@ impl<'a> Keyboard<'a> {
                 } else {
                     key_action
                 };
-                self.process_key_action_inner(key_action, event).await
+                self.process_key_action_inner(key_action, event, event_time).await
             }
             KeyBehaviorDecision::FlowTap => {
                 let action = Self::action_from_pattern(self.keymap, key_action, TAP); //tap action
@@ -622,7 +626,8 @@ impl<'a> Keyboard<'a> {
                         // Note: Morse like actions are not expected here.
                         assert!(!action.is_morse());
                         debug!("Tap Key {:?} now press down, action: {:?}", held_key.event, action);
-                        self.process_key_action_inner(&action, held_key.event).await;
+                        self.process_key_action_inner(&action, held_key.event, held_key.press_time)
+                            .await;
                     }
                 }
                 _ => (),
@@ -761,7 +766,12 @@ impl<'a> Keyboard<'a> {
         (decision_for_current_key, decisions)
     }
 
-    async fn process_key_action_inner(&mut self, original_key_action: &KeyAction, event: KeyboardEvent) {
+    async fn process_key_action_inner(
+        &mut self,
+        original_key_action: &KeyAction,
+        event: KeyboardEvent,
+        event_time: Instant,
+    ) {
         // Start forks
         let key_action = self.try_start_forks(original_key_action, event);
 
@@ -784,7 +794,7 @@ impl<'a> Keyboard<'a> {
                 _ => unreachable!(),
             }
         } else {
-            self.process_key_action_morse(&key_action, event).await;
+            self.process_key_action_morse(&key_action, event, event_time).await;
         }
         self.try_finish_forks(original_key_action, event);
     }
@@ -969,7 +979,7 @@ impl<'a> Keyboard<'a> {
 
             let mut new_event = event;
             new_event.pressed = true;
-            self.process_key_action(&action, new_event, true).await;
+            self.process_key_action(&action, new_event, true, Instant::now()).await;
             debug!("[Combo] {:?} triggered", action);
             embassy_time::Timer::after_millis(20).await;
             // Reset other combos' state
@@ -993,7 +1003,12 @@ impl<'a> Keyboard<'a> {
     /// Check combo before process keys.
     ///
     /// This function returns key action after processing combo, and a boolean indicates that if current returned key action is a combo output
-    async fn process_combo(&mut self, key_action: &KeyAction, event: KeyboardEvent) -> (Option<KeyAction>, bool) {
+    async fn process_combo(
+        &mut self,
+        key_action: &KeyAction,
+        event: KeyboardEvent,
+        event_time: Instant,
+    ) -> (Option<KeyAction>, bool) {
         let current_layer = self.keymap.get_activated_layer();
 
         // First, when releasing a key, check whether there's untriggered combo, if so, triggerer it first
@@ -1043,13 +1058,12 @@ impl<'a> Keyboard<'a> {
             && max_size > 0
         {
             // If the max_size > 0, there's at least one combo is updated
-            let pressed_time = self.get_timer_value(event).unwrap_or(Instant::now());
             self.held_buffer.push(HeldKey::new(
                 event,
                 *key_action,
                 KeyState::WaitingCombo,
-                pressed_time,
-                pressed_time + self.keymap.combo_timeout(),
+                event_time,
+                event_time + self.keymap.combo_timeout(),
             ));
 
             // Only one combo is updated, and triggered
@@ -1107,7 +1121,7 @@ impl<'a> Keyboard<'a> {
                 //   held), which consumes the release event without sending anything.
                 if releasing_triggered_combo {
                     for output in &combo_outputs {
-                        self.process_key_action(output, event, true).await;
+                        self.process_key_action(output, event, true, event_time).await;
                     }
                     return (None, true);
                 }
@@ -1129,7 +1143,8 @@ impl<'a> Keyboard<'a> {
             if self.held_buffer.keys[i].state == KeyState::WaitingCombo {
                 let key = self.held_buffer.keys.swap_remove(i);
                 debug!("[Combo] Dispatching combo: {:?}", key);
-                self.process_key_action(&key.action, key.event, false).await;
+                self.process_key_action(&key.action, key.event, false, key.press_time)
+                    .await;
             } else {
                 i += 1;
             }
@@ -1732,16 +1747,6 @@ impl<'a> Keyboard<'a> {
         } else {
             self.unregister_keycode(key, event);
         }
-    }
-
-    /// Set the timer value for a key event
-    fn set_timer_value(&mut self, event: KeyboardEvent, value: Option<Instant>) {
-        self.keymap.set_timer(event.pos, value);
-    }
-
-    /// Get the timer value for a key event, if the key event is not in the timer, return the current time
-    fn get_timer_value(&self, event: KeyboardEvent) -> Option<Instant> {
-        self.keymap.get_timer(event.pos)
     }
 
     /// Register a key to be sent in hid report.

--- a/rmk/src/keyboard/morse.rs
+++ b/rmk/src/keyboard/morse.rs
@@ -62,22 +62,26 @@ impl<'a> Keyboard<'a> {
         self.fire_held_non_morse_keys().await;
     }
 
-    pub(crate) async fn process_key_action_morse(&mut self, key_action: &KeyAction, event: KeyboardEvent) {
+    pub(crate) async fn process_key_action_morse(
+        &mut self,
+        key_action: &KeyAction,
+        event: KeyboardEvent,
+        event_time: Instant,
+    ) {
         debug!("Processing morse keys: {:?}", event);
         assert!(key_action.is_morse());
 
         // Process the morse key
         if event.pressed {
             // Pressed, check the held buffer, update the tap state
-            let pressed_time = self.get_timer_value(event).unwrap_or(Instant::now());
-            let timeout_time = pressed_time + Self::morse_timeout(self.keymap, key_action, true);
+            let timeout_time = event_time + Self::morse_timeout(self.keymap, key_action, true);
             match self.held_buffer.find_pos_mut(event.pos) {
                 Some(k) => {
                     // The current key is already in the buffer, update its state
                     match k.state {
                         KeyState::Released(pattern) | KeyState::EarlyFired(pattern) => {
                             k.state = KeyState::Pressed(pattern);
-                            k.press_time = pressed_time;
+                            k.press_time = event_time;
                             k.timeout_time = timeout_time;
                         }
                         _ => {}
@@ -89,7 +93,7 @@ impl<'a> Keyboard<'a> {
                         event,
                         *key_action,
                         KeyState::Pressed(MorsePattern::default()),
-                        pressed_time,
+                        event_time,
                         timeout_time,
                     ));
                 }
@@ -188,8 +192,6 @@ impl<'a> Keyboard<'a> {
                         // Process the release action
                         debug!("[morse] Releasing morse key: {:?}", event);
                         self.process_key_action_normal(action, event).await;
-                        // Clear timer
-                        self.set_timer_value(event, None);
                     }
                     _ => {}
                 };

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -1,7 +1,6 @@
 use core::cell::RefCell;
 
-use embassy_time::{Duration, Instant};
-use heapless::LinearMap;
+use embassy_time::Duration;
 use rmk_types::action::{EncoderAction, KeyAction};
 use rmk_types::fork::Fork;
 use rmk_types::morse::MorseProfile;
@@ -106,8 +105,6 @@ struct KeyMapInner<'a> {
     hand: &'a [Hand],
     /// Mouse button state
     mouse_buttons: u8,
-    /// Timer for held keys (bounded by hold buffer size)
-    timer: LinearMap<KeyboardEventPos, Instant, HOLD_BUFFER_SIZE>,
     /// Matrix state for vial lock
     #[cfg(feature = "host_security")]
     matrix_state: MatrixState,
@@ -367,7 +364,6 @@ impl<'a> KeyMap<'a> {
                 behavior,
                 hand,
                 mouse_buttons: 0,
-                timer: LinearMap::new(),
                 #[cfg(feature = "host_security")]
                 matrix_state: MatrixState::new(ROW, COL),
             }),
@@ -692,26 +688,6 @@ impl<'a> KeyMap<'a> {
 
     pub(crate) fn get_macro_sequences(&self) -> [u8; MACRO_SPACE_SIZE] {
         self.inner.borrow().behavior.keyboard_macros.macro_sequences
-    }
-
-    // ── Timers (moved from Keyboard) ──
-
-    pub(crate) fn set_timer(&self, pos: KeyboardEventPos, value: Option<Instant>) {
-        let mut inner = self.inner.borrow_mut();
-        match value {
-            Some(instant) => {
-                if inner.timer.insert(pos, instant).is_err() {
-                    warn!("Timer buffer full, dropping timer for {:?}", pos);
-                }
-            }
-            None => {
-                inner.timer.remove(&pos);
-            }
-        }
-    }
-
-    pub(crate) fn get_timer(&self, pos: KeyboardEventPos) -> Option<Instant> {
-        self.inner.borrow().timer.get(&pos).copied()
     }
 
     // ── Matrix state (host_security) ──


### PR DESCRIPTION
`Keyboard::process_inner` wrote every press into the bounded timer LinearMap (HOLD_BUFFER_SIZE = 16), but only the morse-press path consumes that value. Non-morse non-combo presses filled slots no one reads, so after 16 distinct positions the map saturated and `set_timer` began logging "Timer buffer full, dropping timer for ...".

Gate the write on `key_action.is_morse()`. The combo-press path in `process_combo` still reads the timer and now falls back to `Instant::now()` for non-morse inputs, which is indistinguishable within the same synchronous chain.