### PR TITLE
fix(usb): update CONNECTION_STATE on USB suspend and resume

### DIFF
--- a/rmk/src/usb/mod.rs
+++ b/rmk/src/usb/mod.rs
@@ -285,15 +285,19 @@ impl Handler for UsbDeviceHandler {
     fn suspended(&mut self, suspended: bool) {
         // When no logging feature is enabled, `info!` expands to a no-op and
         // both arms collapse to identical empty blocks — suppress the lint.
-        #[allow(clippy::if_same_then_else)]
+        #[cfg_attr(feature = "_ble", allow(clippy::if_same_then_else))]
         if suspended {
             info!(
                 "Device suspended, the Vbus current limit is 500µA (or 2.5mA for high-power devices with remote wakeup enabled)."
             );
+            #[cfg(not(feature = "_ble"))]
+            CONNECTION_STATE.store(ConnectionState::Disconnected.into(), Ordering::Release);
         } else {
             info!(
                 "Device resumed, the Vbus current limit is 500µA (or 2.5mA for high-power devices with remote wakeup enabled)."
             );
+            #[cfg(not(feature = "_ble"))]
+            CONNECTION_STATE.store(ConnectionState::Connected.into(), Ordering::Release);
         }
     }
 


### PR DESCRIPTION
Adds USB suspend/resume tracking via `CONNECTION_STATE`, gated behind `#[cfg(not(feature = "_ble"))]` since BLE manages its own connection lifecycle independently and this change should only affect USB-only keyboards.

- Sets `CONNECTION_STATE` to `Disconnected` on suspend
- Sets `CONNECTION_STATE` to `Connected` on resume

Allows firmware to check `CONNECTION_STATE` and act on host suspend/shutdown, e.g. turning off LED backlight when the host sleeps.