### PR TITLE
feat(state): expand ConnectionState from bool to u8 enum and add USB suspend support

### DIFF
--- a/rmk/src/hid.rs
+++ b/rmk/src/hid.rs
@@ -69,8 +69,7 @@ pub trait RunnableHidWriter: HidWriterTrait {
                 // Get report to send
                 let report = self.get_report().await;
                 // Only send the report after the connection is established.
-                if CONNECTION_STATE.load(Ordering::Acquire)
-                    == <ConnectionState as Into<bool>>::into(ConnectionState::Connected)
+                if ConnectionState::from(CONNECTION_STATE.load(Ordering::Acquire)) != ConnectionState::Disconnected
                     && let Err(e) = self.write_report(report.clone()).await
                 {
                     error!("Failed to send report: {:?}", e);

--- a/rmk/src/host/via/mod.rs
+++ b/rmk/src/host/via/mod.rs
@@ -1,3 +1,5 @@
+use core::sync::atomic::Ordering;
+
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use embassy_time::{Instant, Timer};
 use embassy_usb::class::hid::HidReaderWriter;
@@ -55,7 +57,8 @@ impl<'a, RW: HidWriterTrait<ReportType = ViaReport> + HidReaderTrait<ReportType 
             match self.process().await {
                 Ok(_) => continue,
                 Err(e) => {
-                    if ConnectionState::Disconnected == ConnectionState::from(&CONNECTION_STATE) {
+                    if ConnectionState::Disconnected == ConnectionState::from(CONNECTION_STATE.load(Ordering::Acquire))
+                    {
                         Timer::after_millis(1000).await;
                     } else {
                         error!("Process vial error: {:?}", e);

--- a/rmk/src/host/via/mod.rs
+++ b/rmk/src/host/via/mod.rs
@@ -57,8 +57,10 @@ impl<'a, RW: HidWriterTrait<ReportType = ViaReport> + HidReaderTrait<ReportType 
             match self.process().await {
                 Ok(_) => continue,
                 Err(e) => {
-                    if ConnectionState::Disconnected == ConnectionState::from(CONNECTION_STATE.load(Ordering::Acquire))
-                    {
+                    if matches!(
+                        ConnectionState::from(CONNECTION_STATE.load(Ordering::Acquire)),
+                        ConnectionState::Disconnected | ConnectionState::Suspended
+                    ) {
                         Timer::after_millis(1000).await;
                     } else {
                         error!("Process vial error: {:?}", e);

--- a/rmk/src/matrix.rs
+++ b/rmk/src/matrix.rs
@@ -83,7 +83,7 @@ impl MatrixState {
 pub trait MatrixTrait<const ROW: usize, const COL: usize>: InputDevice {
     // Wait for USB or BLE really connected
     async fn wait_for_connected(&self) {
-        while CONNECTION_STATE.load(Ordering::Acquire) == Into::<bool>::into(ConnectionState::Disconnected) {
+        while ConnectionState::from(CONNECTION_STATE.load(Ordering::Acquire)) == ConnectionState::Disconnected {
             embassy_time::Timer::after_millis(100).await;
         }
         info!("Connected, start scanning matrix");

--- a/rmk/src/split/ble/central.rs
+++ b/rmk/src/split/ble/central.rs
@@ -18,6 +18,7 @@ use crate::event::{PeripheralConnectedEvent, SleepStateEvent, publish_event};
 use crate::split::ble::PeerAddress;
 use crate::split::driver::{PeripheralManager, SplitDriverError, SplitReader, SplitWriter};
 use crate::split::{SPLIT_MESSAGE_MAX_SIZE, SplitMessage};
+use crate::state::ConnectionState;
 use crate::storage::{FlashOperationMessage, Storage};
 use crate::{CONNECTION_STATE, SPLIT_CENTRAL_SLEEP_TIMEOUT_SECONDS};
 
@@ -411,7 +412,7 @@ pub(crate) struct BleSplitCentralDriver<'a, 'b, 'c, C: Controller + ControllerCm
     // Client
     client: &'c GattClient<'a, C, P, 10>,
     // Cached connection state
-    connection_state: bool,
+    connection_state: u8,
 }
 
 impl<'a, 'b, 'c, C: Controller + ControllerCmdAsync<LeSetPhy>, P: PacketPool> BleSplitCentralDriver<'a, 'b, 'c, C, P> {
@@ -543,25 +544,26 @@ async fn sleep_manager_task<
             info!("Entering sleep mode");
 
             // Connection parameters are different when central is broadcasting and connected to host
-            let conn_params = if CONNECTION_STATE.load(Ordering::Acquire) {
-                // Connected, the connection interval is 20ms
-                RequestedConnParams {
-                    min_connection_interval: Duration::from_millis(20),
-                    max_connection_interval: Duration::from_millis(20),
-                    max_latency: 200, // 4s
-                    supervision_timeout: Duration::from_secs(9),
-                    ..Default::default()
-                }
-            } else {
-                // Advertising ,the connection interval can be longer
-                RequestedConnParams {
-                    min_connection_interval: Duration::from_millis(200),
-                    max_connection_interval: Duration::from_millis(200),
-                    max_latency: 25, // 5s
-                    supervision_timeout: Duration::from_secs(11),
-                    ..Default::default()
-                }
-            };
+            let conn_params =
+                if ConnectionState::from(CONNECTION_STATE.load(Ordering::Acquire)) != ConnectionState::Disconnected {
+                    // Connected, the connection interval is 20ms
+                    RequestedConnParams {
+                        min_connection_interval: Duration::from_millis(20),
+                        max_connection_interval: Duration::from_millis(20),
+                        max_latency: 200, // 4s
+                        supervision_timeout: Duration::from_secs(9),
+                        ..Default::default()
+                    }
+                } else {
+                    // Advertising ,the connection interval can be longer
+                    RequestedConnParams {
+                        min_connection_interval: Duration::from_millis(200),
+                        max_connection_interval: Duration::from_millis(200),
+                        max_latency: 25, // 5s
+                        supervision_timeout: Duration::from_secs(11),
+                        ..Default::default()
+                    }
+                };
 
             // Update connection parameters
             update_conn_params(stack, conn, &conn_params).await;

--- a/rmk/src/split/ble/peripheral.rs
+++ b/rmk/src/split/ble/peripheral.rs
@@ -1,3 +1,5 @@
+use core::sync::atomic::Ordering;
+
 use bt_hci::cmd::le::LeSetPhy;
 use bt_hci::controller::ControllerCmdAsync;
 use embassy_futures::join::join;
@@ -12,6 +14,7 @@ use crate::event::{CentralConnectedEvent, KeyboardEvent, SubscribableEvent, publ
 use crate::split::driver::{SplitDriverError, SplitReader, SplitWriter};
 use crate::split::peripheral::SplitPeripheral;
 use crate::split::{SPLIT_MESSAGE_MAX_SIZE, SplitMessage};
+use crate::state::ConnectionState;
 
 /// Gatt service used in split peripheral to send split message to central
 #[gatt_service(uuid = "4dd5fbaa-18e5-4b07-bf0a-353698659946")]
@@ -52,7 +55,7 @@ impl<'stack, 'server, 'c, P: PacketPool> SplitReader for BleSplitPeripheralDrive
             match self.conn.next().await {
                 GattConnectionEvent::Disconnected { reason } => {
                     error!("Disconnected from central: {:?}", reason);
-                    CONNECTION_STATE.store(false, core::sync::atomic::Ordering::Release);
+                    CONNECTION_STATE.store(u8::from(ConnectionState::Disconnected), Ordering::Release);
                     return Err(SplitDriverError::Disconnected);
                 }
                 GattConnectionEvent::Gatt { event: gatt_event } => {
@@ -162,7 +165,7 @@ pub async fn initialize_nrf_ble_split_peripheral_and_run<
     let peri_task = async {
         let server = BleSplitPeripheralServer::new_default("rmk").unwrap();
         loop {
-            CONNECTION_STATE.store(false, core::sync::atomic::Ordering::Release);
+            CONNECTION_STATE.store(u8::from(ConnectionState::Disconnected), Ordering::Release);
             publish_event(CentralConnectedEvent { connected: false });
             match split_peripheral_advertise(id, central_addr, &mut peripheral, &server).await {
                 Ok(conn) => {

--- a/rmk/src/split/driver.rs
+++ b/rmk/src/split/driver.rs
@@ -9,6 +9,7 @@ use futures::FutureExt;
 use super::SplitMessage;
 use crate::CONNECTION_STATE;
 use crate::event::{KeyboardEvent, KeyboardEventPos, SubscribableEvent, publish_event, publish_event_async};
+use crate::state::ConnectionState;
 
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -170,7 +171,8 @@ impl<const ROW: usize, const COL: usize, const ROW_OFFSET: usize, const COL_OFFS
                         return;
                     }
 
-                    if CONNECTION_STATE.load(core::sync::atomic::Ordering::Acquire) {
+                    if ConnectionState::from(CONNECTION_STATE.load(Ordering::Acquire)) != ConnectionState::Disconnected
+                    {
                         // Only when the connection is established, send the key event.
                         let adjusted_key_event = KeyboardEvent::key(
                             key_pos.row + ROW_OFFSET as u8,
@@ -184,24 +186,27 @@ impl<const ROW: usize, const COL: usize, const ROW_OFFSET: usize, const COL_OFFS
                 }
                 _ => {
                     // For rotary encoder
-                    if CONNECTION_STATE.load(core::sync::atomic::Ordering::Acquire) {
+                    if ConnectionState::from(CONNECTION_STATE.load(Ordering::Acquire)) != ConnectionState::Disconnected
+                    {
                         // Only when the connection is established, send the key event.
                         publish_event_async(e).await;
                     }
                 }
             },
             // Process other split messages which requires connection to host
-            _ if CONNECTION_STATE.load(core::sync::atomic::Ordering::Acquire) => match split_message {
-                // Non-key events are drop-on-full to keep the split read loop responsive.
-                SplitMessage::Pointing(e) => publish_event(e),
-                #[cfg(feature = "_ble")]
-                SplitMessage::BatteryStatus(state) => {
-                    // Publish as PeripheralBatteryEvent with the full state
-                    use crate::event::PeripheralBatteryEvent;
-                    publish_event(PeripheralBatteryEvent { id: self.id, state })
+            _ if ConnectionState::from(CONNECTION_STATE.load(Ordering::Acquire)) != ConnectionState::Disconnected => {
+                match split_message {
+                    // Non-key events are drop-on-full to keep the split read loop responsive.
+                    SplitMessage::Pointing(e) => publish_event(e),
+                    #[cfg(feature = "_ble")]
+                    SplitMessage::BatteryStatus(state) => {
+                        // Publish as PeripheralBatteryEvent with the full state
+                        use crate::event::PeripheralBatteryEvent;
+                        publish_event(PeripheralBatteryEvent { id: self.id, state })
+                    }
+                    _ => warn!("{:?} should not come from peripheral", split_message),
                 }
-                _ => warn!("{:?} should not come from peripheral", split_message),
-            },
+            }
             _ => warn!(
                 "{:?} from peripheral is ignored because the connection is not established.",
                 split_message

--- a/rmk/src/split/mod.rs
+++ b/rmk/src/split/mod.rs
@@ -32,7 +32,7 @@ pub(crate) enum SplitMessage {
     LedState(bool),
     /// The central connection state, true if central has been connected to host.
     /// This message is sync from central to peripheral
-    ConnectionState(bool),
+    ConnectionState(u8),
     /// BLE Address, used in syncing address between central and peripheral
     Address([u8; 6]),
     /// Clear the saved peer info

--- a/rmk/src/split/mod.rs
+++ b/rmk/src/split/mod.rs
@@ -30,7 +30,7 @@ pub(crate) enum SplitMessage {
     Pointing(PointingEvent),
     /// Led state, on/off, from central to peripheral
     LedState(bool),
-    /// The central connection state, true if central has been connected to host.
+    /// The central connection state, serialized as a `u8` and synced from central to peripheral: `0 = Disconnected`, `1 = Connected`, `2 = Suspended`.
     /// This message is sync from central to peripheral
     ConnectionState(u8),
     /// BLE Address, used in syncing address between central and peripheral

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -1,3 +1,5 @@
+use core::sync::atomic::Ordering;
+
 #[cfg(feature = "_ble")]
 use bt_hci::{cmd::le::LeSetPhy, controller::ControllerCmdAsync};
 use embassy_futures::select::{Either, select};
@@ -80,7 +82,7 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
     /// The peripheral uses the general matrix, does scanning and send the key events through `SplitWriter`.
     /// If also receives split messages from the central through `SplitReader`.
     pub(crate) async fn run(&mut self) {
-        CONNECTION_STATE.store(ConnectionState::Connected.into(), core::sync::atomic::Ordering::Release);
+        CONNECTION_STATE.store(ConnectionState::Connected.into(), Ordering::Release);
 
         let mut key_sub = KeyboardEvent::subscriber();
         #[cfg(feature = "_ble")]
@@ -111,7 +113,7 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                     Ok(split_message) => match split_message {
                         SplitMessage::ConnectionState(state) => {
                             trace!("Received connection state update: {}", state);
-                            CONNECTION_STATE.store(state, core::sync::atomic::Ordering::Release);
+                            CONNECTION_STATE.store(state, Ordering::Release);
                         }
                         #[cfg(all(feature = "_ble", feature = "storage"))]
                         SplitMessage::ClearPeer => {
@@ -157,7 +159,8 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                 },
                 Either::Second(e) => {
                     // Only send the key event if the connection is established
-                    if CONNECTION_STATE.load(core::sync::atomic::Ordering::Acquire) {
+                    if ConnectionState::from(CONNECTION_STATE.load(Ordering::Acquire)) != ConnectionState::Disconnected
+                    {
                         debug!("Writing split message {:?} to central", e);
                         self.split_driver.write(&e).await.ok();
                     } else {

--- a/rmk/src/split/serial/mod.rs
+++ b/rmk/src/split/serial/mod.rs
@@ -191,7 +191,9 @@ mod tests {
     #[test]
     fn two_bundled_messages_do_not_trigger_extra_read() {
         let mut bundled = encode(&SplitMessage::LedState(true));
-        bundled.extend_from_slice(&encode(&SplitMessage::ConnectionState(false)));
+        bundled.extend_from_slice(&encode(&SplitMessage::ConnectionState(u8::from(
+            ConnectionState::Disconnected,
+        ))));
 
         let fake = FakeSerial::new([bundled]);
         let mut drv = SerialSplitDriver::new(fake);
@@ -200,7 +202,8 @@ mod tests {
         assert!(matches!(m1, SplitMessage::LedState(true)));
 
         let m2 = block_on(drv.read()).expect("second read should not touch serial");
-        assert!(matches!(m2, SplitMessage::ConnectionState(false)));
+        // 0 == ConnectionState::Disconnected
+        assert!(matches!(m2, SplitMessage::ConnectionState(0)));
 
         assert_eq!(drv.serial.read_calls, 1);
     }
@@ -212,7 +215,7 @@ mod tests {
     #[test]
     fn trailing_partial_message_is_carried_over() {
         let full1 = encode(&SplitMessage::LedState(true));
-        let full2 = encode(&SplitMessage::ConnectionState(true));
+        let full2 = encode(&SplitMessage::ConnectionState(u8::from(ConnectionState::Connected)));
         let (prefix, suffix) = full2.split_at(full2.len() / 2);
 
         let mut first_chunk = full1;
@@ -225,8 +228,8 @@ mod tests {
         assert!(matches!(m1, SplitMessage::LedState(true)));
 
         let m2 = block_on(drv.read()).expect("second read should succeed");
-        assert!(matches!(m2, SplitMessage::ConnectionState(true)));
-
+        // 1 == ConnectionState::Connected
+        assert!(matches!(m2, SplitMessage::ConnectionState(1)));
         assert_eq!(drv.serial.read_calls, 2);
     }
 }

--- a/rmk/src/split/serial/mod.rs
+++ b/rmk/src/split/serial/mod.rs
@@ -1,6 +1,7 @@
 use embedded_io_async::{Read, Write};
 
 use super::driver::SplitDriverError;
+use crate::ConnectionState;
 use crate::split::driver::{PeripheralManager, SplitReader, SplitWriter};
 use crate::split::{SPLIT_MESSAGE_MAX_SIZE, SplitMessage};
 
@@ -202,8 +203,11 @@ mod tests {
         assert!(matches!(m1, SplitMessage::LedState(true)));
 
         let m2 = block_on(drv.read()).expect("second read should not touch serial");
-        // 0 == ConnectionState::Disconnected
-        assert!(matches!(m2, SplitMessage::ConnectionState(0)));
+        assert!(matches!(
+            m2,
+            SplitMessage::ConnectionState(state)
+                if state == u8::from(ConnectionState::Disconnected)
+        ));
 
         assert_eq!(drv.serial.read_calls, 1);
     }
@@ -228,8 +232,11 @@ mod tests {
         assert!(matches!(m1, SplitMessage::LedState(true)));
 
         let m2 = block_on(drv.read()).expect("second read should succeed");
-        // 1 == ConnectionState::Connected
-        assert!(matches!(m2, SplitMessage::ConnectionState(1)));
+        assert!(matches!(
+            m2,
+            SplitMessage::ConnectionState(state)
+                if state == u8::from(ConnectionState::Connected)
+        ));
         assert_eq!(drv.serial.read_calls, 2);
     }
 }

--- a/rmk/src/state.rs
+++ b/rmk/src/state.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use core::sync::atomic::{AtomicU8, Ordering};
 
 use rmk_types::connection::ConnectionType;
 
@@ -7,21 +7,29 @@ use rmk_types::connection::ConnectionType;
 /// - 1: BLE
 /// - Other: reserved
 pub(crate) static CONNECTION_TYPE: AtomicU8 = AtomicU8::new(0);
-pub(crate) static CONNECTION_STATE: AtomicBool = AtomicBool::new(false);
+pub(crate) static CONNECTION_STATE: AtomicU8 = AtomicU8::new(0);
 
-#[derive(Debug, PartialEq, Eq)]
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConnectionState {
-    Disconnected,
-    Connected,
+    Disconnected = 0,
+    Connected = 1,
+    Suspended = 2,
 }
 
-impl ConnectionState {
-    pub(crate) fn from(state: &AtomicBool) -> Self {
-        if state.load(Ordering::Acquire) {
-            Self::Connected
-        } else {
-            Self::Disconnected
+impl From<u8> for ConnectionState {
+    fn from(value: u8) -> Self {
+        match value {
+            1 => ConnectionState::Connected,
+            2 => ConnectionState::Suspended,
+            _ => ConnectionState::Disconnected,
         }
+    }
+}
+
+impl From<ConnectionState> for u8 {
+    fn from(state: ConnectionState) -> u8 {
+        state as u8
     }
 }
 
@@ -31,23 +39,4 @@ pub fn get_connection_type() -> ConnectionType {
 
 pub fn get_connection_state() -> ConnectionState {
     CONNECTION_STATE.load(Ordering::Acquire).into()
-}
-
-impl From<bool> for ConnectionState {
-    fn from(value: bool) -> Self {
-        if value {
-            ConnectionState::Connected
-        } else {
-            ConnectionState::Disconnected
-        }
-    }
-}
-
-impl From<ConnectionState> for bool {
-    fn from(state: ConnectionState) -> bool {
-        match state {
-            ConnectionState::Connected => true,
-            ConnectionState::Disconnected => false,
-        }
-    }
 }

--- a/rmk/src/usb/mod.rs
+++ b/rmk/src/usb/mod.rs
@@ -285,15 +285,19 @@ impl Handler for UsbDeviceHandler {
     fn suspended(&mut self, suspended: bool) {
         // When no logging feature is enabled, `info!` expands to a no-op and
         // both arms collapse to identical empty blocks — suppress the lint.
-        #[allow(clippy::if_same_then_else)]
+        #[cfg_attr(feature = "_ble", allow(clippy::if_same_then_else))]
         if suspended {
             info!(
                 "Device suspended, the Vbus current limit is 500µA (or 2.5mA for high-power devices with remote wakeup enabled)."
             );
+            #[cfg(not(feature = "_ble"))]
+            CONNECTION_STATE.store(ConnectionState::Suspended.into(), Ordering::Release);
         } else {
             info!(
                 "Device resumed, the Vbus current limit is 500µA (or 2.5mA for high-power devices with remote wakeup enabled)."
             );
+            #[cfg(not(feature = "_ble"))]
+            CONNECTION_STATE.store(ConnectionState::Connected.into(), Ordering::Release);
         }
     }
 


### PR DESCRIPTION
Previously, suspend was indistinguishable from disconnect, causing the remote wakeup path to be skipped when the host suspended the bus. Tracking suspend as a distinct state preserves the Suspended->Connected wakeup path and unlocks suspend-aware firmware features, such as turning off the backlight when the host suspends the bus.

Replace AtomicBool CONNECTION_STATE with AtomicU8 and add a Suspended variant to ConnectionState (Disconnected=0, Connected=1, Suspended=2).