### PR TITLE
fix(usb): shrink HID endpoint max_packet_size to fit tight PMA

### DIFF
--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -232,14 +232,14 @@ pub(crate) async fn run_ble<
     #[cfg(not(feature = "_no_usb"))]
     let (mut _usb_builder, mut keyboard_reader, mut keyboard_writer, mut other_writer) = {
         let mut usb_builder: embassy_usb::Builder<'_, D> = new_usb_builder(usb_driver, rmk_config.device_config);
-        let keyboard_reader_writer = add_usb_reader_writer!(&mut usb_builder, KeyboardReport, 1, 8);
-        let other_writer = add_usb_writer!(&mut usb_builder, CompositeReport, 9);
+        let keyboard_reader_writer = add_usb_reader_writer!(&mut usb_builder, KeyboardReport, 1, 8, 8);
+        let other_writer = add_usb_writer!(&mut usb_builder, CompositeReport, 9, 16);
         let (keyboard_reader, keyboard_writer) = keyboard_reader_writer.split();
         (usb_builder, keyboard_reader, keyboard_writer, other_writer)
     };
 
     #[cfg(all(not(feature = "_no_usb"), feature = "host"))]
-    let mut host_reader_writer = add_usb_reader_writer!(&mut _usb_builder, ViaReport, 32, 32);
+    let mut host_reader_writer = add_usb_reader_writer!(&mut _usb_builder, ViaReport, 32, 32, 32);
 
     // Optional usb logger initialization
     #[cfg(all(feature = "usb_log", not(feature = "_no_usb")))]

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -211,10 +211,10 @@ pub async fn run_rmk<
     #[cfg(all(not(feature = "_no_usb"), not(feature = "_ble")))]
     {
         let mut usb_builder: embassy_usb::Builder<'_, D> = new_usb_builder(usb_driver, rmk_config.device_config);
-        let keyboard_reader_writer = add_usb_reader_writer!(&mut usb_builder, KeyboardReport, 1, 8);
-        let mut other_writer = add_usb_writer!(&mut usb_builder, CompositeReport, 9);
+        let keyboard_reader_writer = add_usb_reader_writer!(&mut usb_builder, KeyboardReport, 1, 8, 8);
+        let mut other_writer = add_usb_writer!(&mut usb_builder, CompositeReport, 9, 16);
         #[cfg(feature = "host")]
-        let mut host_reader_writer = add_usb_reader_writer!(&mut usb_builder, ViaReport, 32, 32);
+        let mut host_reader_writer = add_usb_reader_writer!(&mut usb_builder, ViaReport, 32, 32, 32);
 
         let (mut keyboard_reader, mut keyboard_writer) = keyboard_reader_writer.split();
 

--- a/rmk/src/usb/mod.rs
+++ b/rmk/src/usb/mod.rs
@@ -174,7 +174,11 @@ macro_rules! add_usb_logger {
 }
 
 macro_rules! add_usb_writer {
-    ($usb_builder:expr, $descriptor:ty, $n:expr) => {{
+    ($usb_builder:expr, $descriptor:ty, $n:expr) => {
+        $crate::usb::add_usb_writer!($usb_builder, $descriptor, $n, 64)
+    };
+    // Size $max_packet to the actual report to conserve Packet Memory Area on tight parts.
+    ($usb_builder:expr, $descriptor:ty, $n:expr, $max_packet:expr) => {{
         // Initialize hid writer
         // Current implementation requires the static STATE, so we need to use the paste crate to generate the static variable name.
         use usbd_hid::descriptor::SerializedDescriptor;
@@ -190,7 +194,7 @@ macro_rules! add_usb_writer {
             report_descriptor: <$descriptor>::desc(),
             request_handler: Some(request_handler),
             poll_ms: 1,
-            max_packet_size: 64,
+            max_packet_size: $max_packet,
             hid_subclass: ::embassy_usb::class::hid::HidSubclass::No,
             hid_boot_protocol: ::embassy_usb::class::hid::HidBootProtocol::None,
         };
@@ -201,7 +205,11 @@ macro_rules! add_usb_writer {
 }
 
 macro_rules! add_usb_reader_writer {
-    ($usb_builder:expr, $descriptor:ty, $read_n:expr, $write_n:expr) => {{
+    ($usb_builder:expr, $descriptor:ty, $read_n:expr, $write_n:expr) => {
+        $crate::usb::add_usb_reader_writer!($usb_builder, $descriptor, $read_n, $write_n, 64)
+    };
+    // Size $max_packet to the actual report to conserve Packet Memory Area on tight parts.
+    ($usb_builder:expr, $descriptor:ty, $read_n:expr, $write_n:expr, $max_packet:expr) => {{
         // Initialize hid reader writer
         // Current implementation requires the static STATE, so we need to use the paste crate to generate the static variable name.
         use usbd_hid::descriptor::SerializedDescriptor;
@@ -217,7 +225,7 @@ macro_rules! add_usb_reader_writer {
             report_descriptor: <$descriptor>::desc(),
             request_handler: Some(request_handler),
             poll_ms: 1,
-            max_packet_size: 64,
+            max_packet_size: $max_packet,
             hid_subclass: ::embassy_usb::class::hid::HidSubclass::No,
             hid_boot_protocol: ::embassy_usb::class::hid::HidBootProtocol::None,
         };


### PR DESCRIPTION
The `add_usb_writer!` and `add_usb_reader_writer!` macros hardcode `max_packet_size` 64 for every HID endpoint. Each endpoint reserves that many bytes per direction in the USB  controller's Packet Memory Area (PMA).

Whilst enabling a stenography HID on the ZSA Voyager (which has a 512-byte PMA), this new HID caused embassy-usb to panic at endpoint allocation - the four HID interfaces  at 64 bytes each exceeded the available packet memory. The PMA budget is tight because EP0 and the endpoint descriptor table already consume a number of bytes before any HID endpoints are allocated. Right-sizing each endpoint to its actual report frees enough PMA for the additional interface.

The current endpoints update like this:

  ```
  ┌───────────────────────┬─────────────┬──────────────────────┬─────────────────┐
  │       Endpoint        │ Report size │ Previous reservation │ New reservation │
  ├───────────────────────┼─────────────┼──────────────────────┼─────────────────┤
  │ Keyboard (IN+OUT)     │ 8 B         │ 128 B                │ 16 B            │
  ├───────────────────────┼─────────────┼──────────────────────┼─────────────────┤
  │ Composite (IN)        │ 16 B        │ 64 B                 │ 16 B            │
  ├───────────────────────┼─────────────┼──────────────────────┼─────────────────┤
  │ Vial (IN+OUT)         │ 32 B        │ 128 B                │ 64 B            │
  └───────────────────────┴─────────────┴──────────────────────┴─────────────────┘
  ```

The future steno HID has a report size of 9B with a 16B reservation.

The existing 3-argument call syntax is preserved with a default of 64, so no downstream breakage.