### PR TITLE
feat: Plover HID stenography support

### DIFF
--- a/docs/docs/main/docs/features/_meta.json
+++ b/docs/docs/main/docs/features/_meta.json
@@ -12,5 +12,6 @@
   "processor",
   "input_device",
   "display",
+  "steno",
   "binary_size_optimization"
 ]

--- a/docs/docs/main/docs/features/steno.md
+++ b/docs/docs/main/docs/features/steno.md
@@ -1,0 +1,71 @@
+# Stenography (Plover HID)
+
+RMK supports [Plover](https://opensteno.org/plover/) stenography over
+USB HID. When the `steno` feature is enabled, the keyboard registers as a
+stenography machine that Plover (v5.1+) connects to via the
+[plover-machine-hid](https://github.com/dnaq/plover-machine-hid) plugin,
+without serial emulation.
+
+Steno keys are mapped in your layout like any other key. RMK sends the live
+state of all held steno keys to the host on every key press and release,
+matching the [Plover HID protocol](https://github.com/dnaq/plover-machine-hid).
+Chord detection happens entirely in Plover: by default chords fire when all
+keys are released, but Plover's "first-up chord send" and "auto-repeat"
+options also work because the firmware reports every state change.
+
+## Setup
+
+### 1. Enable the feature
+
+Add the `steno` feature to your `Cargo.toml`:
+
+```toml
+rmk = { version = "...", features = ["steno"] }
+```
+
+### 2. Map steno keys in your layout
+
+#### keyboard.toml
+
+Use `STN(key)` in your layer keys:
+
+```toml
+[[layer]]
+keys = [
+    "STN(NUM1)",  "STN(NUM1)",  "STN(NUM1)",  "STN(NUM1)",  "STN(NUM1)",   "STN(NUM1)",  "STN(NUM1)",  "STN(NUM1)",  "STN(NUM1)",  "STN(NUM1)",
+    "STN(S1)",    "STN(T)",     "STN(P)",     "STN(H)",     "STN(STAR1)",  "STN(STAR1)", "STN(RF)",    "STN(RP)",    "STN(RL)",    "STN(RT)",
+    "STN(S1)",    "STN(K)",     "STN(W)",     "STN(R)",     "STN(STAR1)",  "STN(STAR1)", "STN(RR)",    "STN(RB)",    "STN(RG)",    "STN(RS)",
+    "STN(A)",     "STN(O)",     "_",          "_",          "_",           "_",          "_",          "_",          "STN(RE)",    "STN(RU)",
+]
+```
+
+#### Rust API
+
+Use the `steno!` macro:
+
+```rust
+use rmk::{a, steno};
+
+let keymap = [
+    steno!(NUM1), steno!(NUM1), steno!(NUM1), steno!(NUM1), steno!(NUM1),  steno!(NUM1), steno!(NUM1), steno!(NUM1), steno!(NUM1), steno!(NUM1),
+    steno!(S1),   steno!(T),    steno!(P),    steno!(H),    steno!(STAR1), steno!(STAR1),steno!(RF),   steno!(RP),   steno!(RL),   steno!(RT),
+    steno!(S1),   steno!(K),    steno!(W),    steno!(R),    steno!(STAR1), steno!(STAR1),steno!(RR),   steno!(RB),   steno!(RG),   steno!(RS),
+    steno!(A),    steno!(O),    a!(No),       a!(No),       a!(No),        a!(No),       a!(No),       a!(No),       steno!(RE),   steno!(RU),
+];
+```
+
+## Connecting Plover
+
+1. Flash your keyboard with the `steno` feature enabled.
+2. Open Plover and go to **Configure > Machine**.
+3. Select **Plover HID** as the machine type.
+4. Click **Connect**. Plover finds your keyboard by its HID usage page
+   (`0xFF50`).
+5. Test a chord with Plover paper tape.
+
+## Limitations
+
+- USB only. BLE does not support steno because the standard HID-over-GATT
+  service has no stenography characteristic.
+- No dictionary on the keyboard. RMK sends raw steno chords to the host;
+  translation to text happens in Plover.

--- a/rmk-macro/src/codegen/action_parser.rs
+++ b/rmk-macro/src/codegen/action_parser.rs
@@ -391,6 +391,17 @@ pub(crate) fn parse_key(
                 ::rmk::td!(#index)
             }
         }
+        s if s.to_lowercase().starts_with("stn(") => {
+            let prefix = s.get(0..4).unwrap();
+            if let Some(internal) = s.trim_start_matches(prefix).strip_suffix(")") {
+                let key_ident = format_ident!("{}", internal.trim().to_uppercase());
+                quote! { ::rmk::steno!(#key_ident) }
+            } else {
+                panic!(
+                    "\n\u{274c} keyboard.toml: STN(key) invalid - use a StenoKey name like STN(S1), STN(T), STN(STAR1), etc."
+                );
+            }
+        }
         s if s.to_lowercase().starts_with("user") => {
             // Support both User(X) and UserX formats
             let number_str = if s.to_lowercase().starts_with("user(") {

--- a/rmk-types/Cargo.toml
+++ b/rmk-types/Cargo.toml
@@ -48,3 +48,5 @@ _ble = []
 split = []
 display = []
 passkey_entry = []
+# Stenography (Plover HID) support: `StenoKey` + `Action::Steno` variant.
+steno = []

--- a/rmk-types/src/action/mod.rs
+++ b/rmk-types/src/action/mod.rs
@@ -28,6 +28,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::keycode::{KeyCode, SpecialKey};
 use crate::modifier::ModifierCombination;
+#[cfg(feature = "steno")]
+use crate::steno::StenoKey;
 
 /// A single basic action that a keyboard can execute.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, MaxSize)]
@@ -73,4 +75,9 @@ pub enum Action {
     Special(SpecialKey),
     /// User Keys
     User(u8),
+    /// A Plover HID stenography key. Press/release of this key updates the
+    /// in-progress steno chord; on first release the accumulated chord is
+    /// sent to the host as a vendor HID report.
+    #[cfg(feature = "steno")]
+    Steno(StenoKey),
 }

--- a/rmk-types/src/lib.rs
+++ b/rmk-types/src/lib.rs
@@ -44,6 +44,8 @@ pub mod modifier;
 pub mod morse;
 pub mod mouse_button;
 pub mod protocol;
+#[cfg(feature = "steno")]
+pub mod steno;
 
 /// Compute the maximum varint-encoded length for a given max value.
 /// Mirrors `postcard`'s internal `varint_size`.

--- a/rmk-types/src/steno.rs
+++ b/rmk-types/src/steno.rs
@@ -1,0 +1,107 @@
+//! Stenography (Plover HID) key identifiers.
+//!
+//! Each [`StenoKey`] is an index 0..=63 into the 64-bit chord bitmap that
+//! Plover HID delivers to the host. The order of the chart matches the
+//! canonical Plover HID specification at
+//! <https://github.com/dnaq/plover-machine-hid>: index 0 is `S1-` and is
+//! the most significant bit of byte 1 of the wire report; index 63 (`X26`)
+//! is the least significant bit of byte 8.
+//!
+//! The standard Ward-Stone-Ireland keys come first (`S1-` through `#1`,
+//! indices 0-22), followed by the extended steno keys (`S2-`, `*2`-`*4`,
+//! `#2`-`#C`, indices 23-37), followed by 26 vendor-defined "extra" keys
+//! `X1`..`X26` (indices 38-63).
+
+use postcard::experimental::max_size::MaxSize;
+#[cfg(feature = "rmk_protocol")]
+use postcard_schema::Schema;
+use serde::{Deserialize, Serialize};
+
+/// A single steno key, identified by its position (0..=63) in the canonical
+/// Plover HID key chart. See module docs for the full list.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, MaxSize)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "rmk_protocol", derive(Schema))]
+pub struct StenoKey(pub u8);
+
+impl StenoKey {
+    // Standard Ward-Stone-Ireland keys (chart indices 0-22)
+    pub const S1: Self = Self(0);
+    pub const T: Self = Self(1);
+    pub const K: Self = Self(2);
+    pub const P: Self = Self(3);
+    pub const W: Self = Self(4);
+    pub const H: Self = Self(5);
+    // Left-hand R; right-hand keys are prefixed `R` (e.g. `RR` = right R).
+    pub const R: Self = Self(6);
+    pub const A: Self = Self(7);
+    pub const O: Self = Self(8);
+    pub const STAR1: Self = Self(9);
+    pub const RE: Self = Self(10);
+    pub const RU: Self = Self(11);
+    pub const RF: Self = Self(12);
+    pub const RR: Self = Self(13);
+    pub const RP: Self = Self(14);
+    pub const RB: Self = Self(15);
+    pub const RL: Self = Self(16);
+    pub const RG: Self = Self(17);
+    pub const RT: Self = Self(18);
+    pub const RS: Self = Self(19);
+    pub const RD: Self = Self(20);
+    pub const RZ: Self = Self(21);
+    pub const NUM1: Self = Self(22);
+
+    // Extended steno keys (chart indices 23-37)
+    pub const S2: Self = Self(23);
+    pub const STAR2: Self = Self(24);
+    pub const STAR3: Self = Self(25);
+    pub const STAR4: Self = Self(26);
+    pub const NUM2: Self = Self(27);
+    pub const NUM3: Self = Self(28);
+    pub const NUM4: Self = Self(29);
+    pub const NUM5: Self = Self(30);
+    pub const NUM6: Self = Self(31);
+    pub const NUM7: Self = Self(32);
+    pub const NUM8: Self = Self(33);
+    pub const NUM9: Self = Self(34);
+    pub const NUMA: Self = Self(35);
+    pub const NUMB: Self = Self(36);
+    pub const NUMC: Self = Self(37);
+
+    // Extra vendor-defined keys X1..X26 (chart indices 38-63)
+    pub const X1: Self = Self(38);
+    pub const X2: Self = Self(39);
+    pub const X3: Self = Self(40);
+    pub const X4: Self = Self(41);
+    pub const X5: Self = Self(42);
+    pub const X6: Self = Self(43);
+    pub const X7: Self = Self(44);
+    pub const X8: Self = Self(45);
+    pub const X9: Self = Self(46);
+    pub const X10: Self = Self(47);
+    pub const X11: Self = Self(48);
+    pub const X12: Self = Self(49);
+    pub const X13: Self = Self(50);
+    pub const X14: Self = Self(51);
+    pub const X15: Self = Self(52);
+    pub const X16: Self = Self(53);
+    pub const X17: Self = Self(54);
+    pub const X18: Self = Self(55);
+    pub const X19: Self = Self(56);
+    pub const X20: Self = Self(57);
+    pub const X21: Self = Self(58);
+    pub const X22: Self = Self(59);
+    pub const X23: Self = Self(60);
+    pub const X24: Self = Self(61);
+    pub const X25: Self = Self(62);
+    pub const X26: Self = Self(63);
+
+    /// Alias for the most commonly used asterisk bit.
+    pub const STAR: Self = Self::STAR1;
+
+    /// Returns the chart index (0..=63) of this key.
+    #[inline]
+    pub const fn chart_index(self) -> u8 {
+        self.0
+    }
+}

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -204,6 +204,10 @@ adafruit_bl = ["_nrf_ble"]
 ## Enable feature if you're using the ZSA Voyager ignition DFU bootloader
 zsa_voyager_bl = []
 
+## Enable Plover HID stenography support: adds the steno HID descriptor,
+## the steno USB writer endpoint, and the `Action::Steno` variant.
+steno = ["rmk-types/steno"]
+
 ## Internal feature that indicates no USB is used, this feature will be auto-activated for some chips
 _no_usb = []
 

--- a/rmk/src/ble/ble_server.rs
+++ b/rmk/src/ble/ble_server.rs
@@ -146,6 +146,14 @@ impl<P: PacketPool> HidWriterTrait for BleHidServer<'_, '_, '_, P> {
                 })?;
                 Ok(n)
             }
+            // Plover HID over BLE is not supported: the stock HID-over-GATT service
+            // has no stenography characteristic. Log so the user can see why their
+            // steno strokes aren't reaching the host, then drop.
+            #[cfg(feature = "steno")]
+            Report::StenoReport(_) => {
+                warn!("Steno chord dropped: Plover HID over BLE is not supported");
+                Ok(0)
+            }
         }
     }
 }

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -44,6 +44,8 @@ use crate::ble::profile::{ProfileInfo, ProfileManager, UPDATED_CCCD_TABLE, UPDAT
 use crate::channel::{KEYBOARD_REPORT_CHANNEL, LED_SIGNAL};
 use crate::config::RmkConfig;
 use crate::event::{BleStatusChangeEvent, ConnectionChangeEvent, ConnectionType, publish_event};
+#[cfg(all(not(feature = "_no_usb"), feature = "steno"))]
+use crate::hid::StenoReport;
 use crate::hid::{DummyWriter, RunnableHidWriter};
 #[cfg(feature = "split")]
 use crate::split::ble::central::CENTRAL_SLEEP;
@@ -238,6 +240,9 @@ pub(crate) async fn run_ble<
         (usb_builder, keyboard_reader, keyboard_writer, other_writer)
     };
 
+    #[cfg(all(not(feature = "_no_usb"), feature = "steno"))]
+    let mut steno_writer = add_usb_writer!(&mut _usb_builder, StenoReport, 9, 16);
+
     #[cfg(all(not(feature = "_no_usb"), feature = "host"))]
     let mut host_reader_writer = add_usb_reader_writer!(&mut _usb_builder, ViaReport, 32, 32, 32);
 
@@ -390,7 +395,12 @@ pub(crate) async fn run_ble<
                                     rmk_config.vial_config,
                                     wait_until_usb_disabled(),
                                     UsbLedReader::new(&mut keyboard_reader),
-                                    UsbKeyboardWriter::new(&mut keyboard_writer, &mut other_writer),
+                                    UsbKeyboardWriter::new(
+                                        &mut keyboard_writer,
+                                        &mut other_writer,
+                                        #[cfg(feature = "steno")]
+                                        &mut steno_writer,
+                                    ),
                                 );
                                 select(usb_fut, profile_manager.update_profile()).await;
                             }
@@ -445,7 +455,12 @@ pub(crate) async fn run_ble<
                             rmk_config.vial_config,
                             core::future::pending::<()>(), // Run forever until BLE connected
                             UsbLedReader::new(&mut keyboard_reader),
-                            UsbKeyboardWriter::new(&mut keyboard_writer, &mut other_writer),
+                            UsbKeyboardWriter::new(
+                                &mut keyboard_writer,
+                                &mut other_writer,
+                                #[cfg(feature = "steno")]
+                                &mut steno_writer,
+                            ),
                         );
                         match select3(adv_fut, usb_fut, profile_manager.update_profile()).await {
                             Either3::First(Ok(conn)) => {

--- a/rmk/src/hid.rs
+++ b/rmk/src/hid.rs
@@ -83,6 +83,60 @@ impl CompositeReportType {
     }
 }
 
+/// Plover HID stenography report.
+///
+/// Plover (v5.1+) enumerates the keyboard as a stenography machine when it
+/// finds an HID device exposing usage page `0xFF50` / usage `0x4C56`; the
+/// pair encodes the ASCII string `"STN"` (`0xFF`, `'S'`, `'T'`, `'N'`).
+/// Once connected, Plover reads 9-byte reports (`[report_id=0x50, k0, k1,
+/// ..., k7]`) where the eight payload bytes are a 64-bit big-endian bitmap
+/// of the live steno chord, one bit per [`crate::types::steno::StenoKey`],
+/// where `StenoKey::S1` (chart index 0) is the most significant bit of `k0`
+/// and `StenoKey::X26` (chart index 63) is the least significant bit of
+/// `k7`.
+///
+/// The descriptor is the same as the Plover HID project's reference: a
+/// Logical collection containing 64 single-bit Ordinal usages.
+///
+/// Reference: <https://github.com/dnaq/plover-machine-hid>
+#[cfg(feature = "steno")]
+#[gen_hid_descriptor(
+    (collection = LOGICAL, usage_page = 0xFF50, usage = 0x4C56) = {
+        (report_id = 0x50, usage_page = 0x0A, usage_min = 0x0, usage_max = 0x3F, logical_min = 0x0) = {
+            #[packed_bits = 64] #[item_settings(data,variable,absolute)] keys=input;
+        };
+    }
+)]
+#[derive(Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct StenoReport {
+    pub keys: [u8; 8],
+}
+
+#[cfg(all(test, feature = "steno"))]
+mod steno_tests {
+    use usbd_hid::descriptor::SerializedDescriptor;
+
+    use super::StenoReport;
+
+    #[test]
+    fn descriptor_advertises_plover_identifiers() {
+        let desc = StenoReport::desc();
+        fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+            haystack.windows(needle.len()).any(|w| w == needle)
+        }
+        assert!(contains(desc, &[0x06, 0x50, 0xff]), "missing UsagePage 0xFF50");
+        assert!(contains(desc, &[0x0a, 0x56, 0x4c]), "missing Usage 0x4C56");
+        assert!(contains(desc, &[0xa1, 0x02]), "missing Logical collection");
+        assert!(contains(desc, &[0x85, 0x50]), "missing ReportID 0x50");
+        assert!(contains(desc, &[0x75, 0x01]), "missing ReportSize 1");
+        assert!(contains(desc, &[0x95, 0x40]), "missing ReportCount 64");
+        assert!(contains(desc, &[0x05, 0x0a]), "missing Ordinal UsagePage");
+        assert!(contains(desc, &[0x19, 0x00]), "missing UsageMin 0");
+        assert!(contains(desc, &[0x29, 0x3f]), "missing UsageMax 63");
+    }
+}
+
 /// A composite hid report which contains mouse, consumer, system reports.
 /// Report id is used to distinguish from them.
 #[gen_hid_descriptor(

--- a/rmk/src/hid.rs
+++ b/rmk/src/hid.rs
@@ -113,6 +113,21 @@ pub struct StenoReport {
     pub keys: [u8; 8],
 }
 
+// `gen_hid_descriptor` skips the `AsInputReport` impl when a `report_id`
+// is present, so the wire format must be assembled by hand: byte 0 is the
+// Plover HID report ID (0x50) followed by the eight chord-bitmap bytes.
+#[cfg(feature = "steno")]
+impl usbd_hid::descriptor::AsInputReport for StenoReport {
+    fn serialize(&self, buffer: &mut [u8]) -> Result<usize, usbd_hid::descriptor::BufferOverflow> {
+        if buffer.len() < 9 {
+            return Err(usbd_hid::descriptor::BufferOverflow);
+        }
+        buffer[0] = 0x50;
+        buffer[1..9].copy_from_slice(&self.keys);
+        Ok(9)
+    }
+}
+
 #[cfg(all(test, feature = "steno"))]
 mod steno_tests {
     use usbd_hid::descriptor::SerializedDescriptor;
@@ -201,6 +216,9 @@ pub enum Report {
     MediaKeyboardReport(MediaKeyboardReport),
     /// System control report
     SystemControlReport(SystemControlReport),
+    /// Plover HID stenography chord report
+    #[cfg(feature = "steno")]
+    StenoReport(StenoReport),
 }
 
 impl AsInputReport for Report {
@@ -210,6 +228,8 @@ impl AsInputReport for Report {
             Report::MouseReport(r) => r.serialize(buffer),
             Report::MediaKeyboardReport(r) => r.serialize(buffer),
             Report::SystemControlReport(r) => r.serialize(buffer),
+            #[cfg(feature = "steno")]
+            Report::StenoReport(r) => r.serialize(buffer),
         }
     }
 }

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -42,6 +42,8 @@ pub(crate) mod held_buffer;
 pub(crate) mod morse;
 pub(crate) mod mouse;
 pub(crate) mod oneshot;
+#[cfg(feature = "steno")]
+pub(crate) mod steno;
 
 use crate::keymap::HOLD_BUFFER_SIZE;
 
@@ -232,6 +234,10 @@ pub struct Keyboard<'a> {
     /// Used for temporarily disabling combos
     combo_on: bool,
 
+    /// Plover HID stenography chord accumulator
+    #[cfg(feature = "steno")]
+    steno: crate::keyboard::steno::StenoChord,
+
     /// Passkey entry state for BLE pairing
     #[cfg(feature = "passkey_entry")]
     passkey_entry_state: crate::ble::passkey::PasskeyEntryState,
@@ -261,6 +267,8 @@ impl<'a> Keyboard<'a> {
             system_control_report: SystemControlReport { usage_id: 0 },
             last_key_code: KeyCode::Hid(HidKeyCode::No),
             combo_on: true,
+            #[cfg(feature = "steno")]
+            steno: crate::keyboard::steno::StenoChord::new(),
             #[cfg(feature = "passkey_entry")]
             passkey_entry_state: crate::ble::passkey::PasskeyEntryState::new(),
         }
@@ -1262,6 +1270,12 @@ impl<'a> Keyboard<'a> {
                 // Tri-layer upper, turn layer 2 on and update layer state
                 self.process_action_layer_switch(2, event);
                 self.keymap.update_fn_layer_state();
+            }
+            #[cfg(feature = "steno")]
+            Action::Steno(key) => {
+                if let Some(report) = self.steno.on_event(key, event.pressed) {
+                    crate::keyboard::steno::try_send(report);
+                }
             }
             _ => warn!("Action variant not supported: {:?}", action),
         }

--- a/rmk/src/keyboard/steno.rs
+++ b/rmk/src/keyboard/steno.rs
@@ -1,0 +1,186 @@
+//! Plover HID stenography live-state reporter.
+//!
+//! The Plover HID protocol sends the full bitmap of currently-held steno
+//! keys on every state change (press or release). Chord detection happens
+//! on the host side: Plover accumulates pressed keys and fires the chord
+//! according to its own policy (all-up by default, or first-up when
+//! configured).
+//!
+//! Wire-format ordering matches the Plover HID spec: chart index
+//! 0 (`StenoKey::S1`) is the most significant bit of byte 1 of the report,
+//! chart index 63 (`StenoKey::X26`) is the least significant bit of byte 8.
+
+use rmk_types::steno::StenoKey;
+
+use crate::channel::KEYBOARD_REPORT_CHANNEL;
+use crate::hid::{Report, StenoReport};
+
+#[derive(Debug, Default)]
+pub(crate) struct StenoChord {
+    /// Live bitmap of currently-held steno keys. Stored such that
+    /// `state.to_be_bytes()` already has the wire-format bit order:
+    /// chart index 0 = MSB of the first byte.
+    state: u64,
+}
+
+impl StenoChord {
+    pub(crate) const fn new() -> Self {
+        Self { state: 0 }
+    }
+
+    /// Update live state for a steno key event. Returns a report reflecting
+    /// the new state of all held keys (sent on every change).
+    pub(crate) fn on_event(&mut self, key: StenoKey, pressed: bool) -> Option<Report> {
+        let idx = key.chart_index();
+        if idx >= 64 {
+            return None;
+        }
+        let mask = 1u64 << (63 - idx);
+        if pressed {
+            self.state |= mask;
+        } else {
+            self.state &= !mask;
+        }
+        Some(Report::StenoReport(StenoReport {
+            keys: self.state.to_be_bytes(),
+        }))
+    }
+}
+
+/// Try to send a steno report without blocking. The Plover HID writer drains
+/// the report channel; if it can't keep up we drop the report rather than
+/// stall the keyboard task - a missed chord is recoverable, a stalled
+/// keyboard is not.
+pub(crate) fn try_send(report: Report) {
+    let _ = KEYBOARD_REPORT_CHANNEL.try_send(report);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report_bytes(report: Option<Report>) -> [u8; 8] {
+        match report.expect("expected a report") {
+            Report::StenoReport(r) => r.keys,
+            _ => panic!("expected StenoReport"),
+        }
+    }
+
+    fn bitmap(report: Option<Report>) -> u64 {
+        u64::from_be_bytes(report_bytes(report))
+    }
+
+    fn msb_bit(key: StenoKey) -> u64 {
+        1u64 << (63 - key.chart_index())
+    }
+
+    #[test]
+    fn press_sends_live_state() {
+        let mut s = StenoChord::new();
+        let b = bitmap(s.on_event(StenoKey::S1, true));
+        assert_eq!(b, msb_bit(StenoKey::S1));
+
+        let b = bitmap(s.on_event(StenoKey::T, true));
+        assert_eq!(b, msb_bit(StenoKey::S1) | msb_bit(StenoKey::T));
+    }
+
+    #[test]
+    fn release_clears_bit() {
+        let mut s = StenoChord::new();
+        s.on_event(StenoKey::S1, true);
+        s.on_event(StenoKey::T, true);
+
+        let b = bitmap(s.on_event(StenoKey::T, false));
+        assert_eq!(b, msb_bit(StenoKey::S1), "T bit should be cleared");
+
+        let b = bitmap(s.on_event(StenoKey::S1, false));
+        assert_eq!(b, 0, "all bits should be cleared");
+    }
+
+    #[test]
+    fn every_event_produces_a_report() {
+        let mut s = StenoChord::new();
+        assert!(s.on_event(StenoKey::S1, true).is_some());
+        assert!(s.on_event(StenoKey::T, true).is_some());
+        assert!(s.on_event(StenoKey::T, false).is_some());
+        assert!(s.on_event(StenoKey::S1, false).is_some());
+    }
+
+    #[test]
+    fn s1_is_msb_of_first_byte() {
+        let mut s = StenoChord::new();
+        let bytes = report_bytes(s.on_event(StenoKey::S1, true));
+        assert_eq!(bytes[0], 0x80);
+        assert_eq!(&bytes[1..], &[0; 7]);
+    }
+
+    #[test]
+    fn x26_is_lsb_of_last_byte() {
+        let mut s = StenoChord::new();
+        let bytes = report_bytes(s.on_event(StenoKey::X26, true));
+        assert_eq!(&bytes[..7], &[0; 7]);
+        assert_eq!(bytes[7], 0x01);
+    }
+
+    #[test]
+    fn out_of_range_index_returns_none() {
+        let mut s = StenoChord::new();
+        assert!(s.on_event(StenoKey(64), true).is_none());
+    }
+
+    #[test]
+    fn repeated_chord_produces_zero_between() {
+        let mut s = StenoChord::new();
+        for _ in 0..3 {
+            s.on_event(StenoKey::S1, true);
+            s.on_event(StenoKey::T, true);
+            s.on_event(StenoKey::T, false);
+            let b = bitmap(s.on_event(StenoKey::S1, false));
+            assert_eq!(b, 0, "all-up must produce zero bitmap");
+        }
+    }
+
+    /// Press all keys, release all keys, return the final all-up bitmap
+    /// (should be zero) and collect the sequence of live-state bitmaps.
+    fn stroke(s: &mut StenoChord, keys: &[StenoKey]) -> u64 {
+        let mut peak = 0u64;
+        for &k in keys {
+            peak = bitmap(s.on_event(k, true));
+        }
+        for &k in keys {
+            s.on_event(k, false);
+        }
+        peak
+    }
+
+    /// "hello world" in Plover's default dictionary is three strokes:
+    ///   HEL  (H + E + -L)
+    ///   HRO  (H + R + O)
+    ///   WORLD (W + O + -R + -L + -D)
+    #[test]
+    fn hello_world_strokes() {
+        let mut s = StenoChord::new();
+
+        let hel = stroke(&mut s, &[StenoKey::H, StenoKey::RE, StenoKey::RL]);
+        assert_eq!(
+            hel,
+            msb_bit(StenoKey::H) | msb_bit(StenoKey::RE) | msb_bit(StenoKey::RL)
+        );
+
+        let hro = stroke(&mut s, &[StenoKey::H, StenoKey::R, StenoKey::O]);
+        assert_eq!(hro, msb_bit(StenoKey::H) | msb_bit(StenoKey::R) | msb_bit(StenoKey::O));
+
+        let world = stroke(
+            &mut s,
+            &[StenoKey::W, StenoKey::O, StenoKey::RR, StenoKey::RL, StenoKey::RD],
+        );
+        assert_eq!(
+            world,
+            msb_bit(StenoKey::W)
+                | msb_bit(StenoKey::O)
+                | msb_bit(StenoKey::RR)
+                | msb_bit(StenoKey::RL)
+                | msb_bit(StenoKey::RD)
+        );
+    }
+}

--- a/rmk/src/layout_macro.rs
+++ b/rmk/src/layout_macro.rs
@@ -667,3 +667,13 @@ macro_rules! special {
         ))
     };
 }
+
+#[cfg(feature = "steno")]
+#[macro_export]
+macro_rules! steno {
+    ($key: ident) => {
+        $crate::types::action::KeyAction::Single($crate::types::action::Action::Steno(
+            $crate::types::steno::StenoKey::$key,
+        ))
+    };
+}

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -51,11 +51,11 @@ use embassy_usb::driver::Driver;
 pub use futures;
 use futures::FutureExt;
 pub use heapless;
+#[cfg(all(not(feature = "_ble"), feature = "steno"))]
+use hid::StenoReport;
 #[cfg(not(feature = "_ble"))]
 use hid::{CompositeReport, KeyboardReport};
 use hid::{HidReaderTrait, RunnableHidWriter};
-#[cfg(all(not(feature = "_ble"), feature = "steno"))]
-use hid::StenoReport;
 use keymap::KeyMap;
 pub use keymap::KeymapData;
 use processor::PollingProcessor;

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -54,6 +54,8 @@ pub use heapless;
 #[cfg(not(feature = "_ble"))]
 use hid::{CompositeReport, KeyboardReport};
 use hid::{HidReaderTrait, RunnableHidWriter};
+#[cfg(all(not(feature = "_ble"), feature = "steno"))]
+use hid::StenoReport;
 use keymap::KeyMap;
 pub use keymap::KeymapData;
 use processor::PollingProcessor;
@@ -212,6 +214,8 @@ pub async fn run_rmk<
         let mut usb_builder: embassy_usb::Builder<'_, D> = new_usb_builder(usb_driver, rmk_config.device_config);
         let keyboard_reader_writer = add_usb_reader_writer!(&mut usb_builder, KeyboardReport, 1, 8, 8);
         let mut other_writer = add_usb_writer!(&mut usb_builder, CompositeReport, 9, 16);
+        #[cfg(feature = "steno")]
+        let mut steno_writer = add_usb_writer!(&mut usb_builder, StenoReport, 9, 16);
         #[cfg(feature = "host")]
         let mut host_reader_writer = add_usb_reader_writer!(&mut usb_builder, ViaReport, 32, 32, 32);
 
@@ -263,7 +267,12 @@ pub async fn run_rmk<
                     rmk_config.vial_config,
                     usb_task,
                     UsbLedReader::new(&mut keyboard_reader),
-                    UsbKeyboardWriter::new(&mut keyboard_writer, &mut other_writer),
+                    UsbKeyboardWriter::new(
+                        &mut keyboard_writer,
+                        &mut other_writer,
+                        #[cfg(feature = "steno")]
+                        &mut steno_writer,
+                    ),
                 )
                 .await;
             }

--- a/rmk/src/usb/mod.rs
+++ b/rmk/src/usb/mod.rs
@@ -43,12 +43,20 @@ impl From<u8> for UsbState {
 pub(crate) struct UsbKeyboardWriter<'a, 'd, D: Driver<'d>> {
     pub(crate) keyboard_writer: &'a mut HidWriter<'d, D, 8>,
     pub(crate) other_writer: &'a mut HidWriter<'d, D, 9>,
+    #[cfg(feature = "steno")]
+    pub(crate) steno_writer: &'a mut HidWriter<'d, D, 9>,
 }
 impl<'a, 'd, D: Driver<'d>> UsbKeyboardWriter<'a, 'd, D> {
-    pub(crate) fn new(keyboard_writer: &'a mut HidWriter<'d, D, 8>, other_writer: &'a mut HidWriter<'d, D, 9>) -> Self {
+    pub(crate) fn new(
+        keyboard_writer: &'a mut HidWriter<'d, D, 8>,
+        other_writer: &'a mut HidWriter<'d, D, 9>,
+        #[cfg(feature = "steno")] steno_writer: &'a mut HidWriter<'d, D, 9>,
+    ) -> Self {
         Self {
             keyboard_writer,
             other_writer,
+            #[cfg(feature = "steno")]
+            steno_writer,
         }
     }
 }
@@ -112,6 +120,28 @@ impl<'d, D: Driver<'d>> HidWriterTrait for UsbKeyboardWriter<'_, 'd, D> {
                     .map_err(HidError::UsbEndpointError)?;
                 Ok(n)
             }
+            #[cfg(feature = "steno")]
+            Report::StenoReport(steno_report) => {
+                // `AsInputReport` for `StenoReport` emits 9 bytes: report id (0x50) + 8 payload bytes.
+                let mut buf: [u8; 9] = [0; 9];
+                let n = steno_report
+                    .serialize(&mut buf)
+                    .map_err(|_| HidError::ReportSerializeError)?;
+                // The USB host only polls the steno IN endpoint when Plover is running.
+                // Without a timeout, write() blocks forever when Plover is absent, which
+                // starves all subsequent keyboard reports and stalls the keyboard.
+                match embassy_time::with_timeout(
+                    embassy_time::Duration::from_millis(5),
+                    self.steno_writer.write(&buf[0..n]),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => return Err(HidError::UsbEndpointError(e)),
+                    Err(_) => {} // Plover not reading; drop this report and continue
+                }
+                Ok(n)
+            }
         }
     }
 }
@@ -132,9 +162,10 @@ pub(crate) fn new_usb_builder<'d, D: Driver<'d>>(driver: D, keyboard_config: Dev
     usb_config.device_protocol = 0x01;
     usb_config.composite_with_iads = true;
 
-    #[cfg(feature = "usb_log")]
+    // Extra HID interfaces (usb_log, steno) overflow the 128-byte config descriptor buffer.
+    #[cfg(any(feature = "usb_log", feature = "steno"))]
     const USB_BUF_SIZE: usize = 256;
-    #[cfg(not(feature = "usb_log"))]
+    #[cfg(not(any(feature = "usb_log", feature = "steno")))]
     const USB_BUF_SIZE: usize = 128;
 
     // Create embassy-usb DeviceBuilder using the driver and config.

--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -19,6 +19,7 @@ nx=(nextest run --config-file "$repo_root/.config/nextest.toml")
 # snapshot tests under src/protocol/rmk/snapshots/).
 cargo "${nx[@]}" --manifest-path rmk-types/Cargo.toml
 cargo "${nx[@]}" --manifest-path rmk-types/Cargo.toml --features host
+cargo "${nx[@]}" --manifest-path rmk-types/Cargo.toml --features steno
 
 cargo "${nx[@]}" --manifest-path rmk/Cargo.toml --no-default-features --features "split,vial,async_matrix,_ble"
 cargo "${nx[@]}" --manifest-path rmk/Cargo.toml --no-default-features --features "split,vial,async_matrix"
@@ -29,6 +30,10 @@ cargo "${nx[@]}" --manifest-path rmk/Cargo.toml --no-default-features --features
 cargo "${nx[@]}" --manifest-path rmk/Cargo.toml --no-default-features --features "vial,_ble"
 cargo "${nx[@]}" --manifest-path rmk/Cargo.toml --no-default-features --features "passkey_entry"
 cargo "${nx[@]}" --manifest-path rmk/Cargo.toml --no-default-features --features "split,vial,storage,passkey_entry"
+# Steno (Plover HID): USB-only path runs the chord/descriptor unit tests;
+# the _ble combo verifies the BLE silent-drop arm compiles.
+cargo "${nx[@]}" --manifest-path rmk/Cargo.toml --no-default-features --features "vial,storage,steno"
+cargo "${nx[@]}" --manifest-path rmk/Cargo.toml --no-default-features --features "split,vial,storage,async_matrix,_ble,steno"
 cargo "${nx[@]}" --manifest-path rmk/Cargo.toml --no-default-features
 
 # Doctests: nextest doesn't run them. rmk/ has `doctest = false` so only


### PR DESCRIPTION
Adds Plover HID stenography to RMK behind a new `steno` Cargo feature. A keyboard with steno-mapped keys shows up as a stenography machine to [Plover](https://www.openstenoproject.org/plover/) (v5.1+) over USB, without serial emulation. [plover-machine-hid](https://github.com/dnaq/plover-machine-hid) must be installed for the integration.

Validated on my ZSA Voyager. Should also work well on RP2040-based steno boards like the ones at https://stenokeyboards.com/

https://lim.au/#/software/plover-hid can be used to test this as well.

## What this does

- `StenoKey` type + `Action::Steno` variant (rmk-types): 64 steno keys matching the Plover HID chart, one bit each in the chord bitmap.

- Plover HID descriptor (rmk/src/hid.rs): the vendor usage page and report ID tuple that Plover's hidapi scan matches on.

- Live-state reporter (rmk/src/keyboard/steno.rs): sends the full bitmap of held steno keys on every press and release, matching the plover-machine-hid protocol. Chord detection happens in Plover, which supports both all-up and first-up policies.

- USB HID interface: a third HID interface on the USB device when steno is enabled, with Report::StenoReport routed through UsbKeyboardWriter. USB_BUF_SIZE bumped to 256 when steno or usb_log is active so the config descriptor does not get truncated.

- `STN(key)` macro syntax (rmk-macro): steno keys in keyboard.tomlaction expressions.

- `steno!` layout macro: expands to `KeyAction::Single(Action::Steno(StenoKey::$key))` for Rust keymap declarations.

## BLE

BLE drops StenoReport. The standard HID-over-GATT service has no stenography characteristic (and I have no way of testing this).

## Testing

- Unit tests cover live-state press/release, bit positions, repeated chords, and a hello-world stroke sequence.
- Descriptor tests verify the Plover identifier tuple, report ID, and bit layout.
- CI (test_all.sh) adds two feature combos: `vial,storage,steno` and `split,vial,storage,async_matrix,_ble,steno`.
- Hardware-tested on a ZSA Voyager. Plover enumerates the device and accepts chords.