### PR TITLE
fix(usb): complete remote wakeup for non-OTG peripherals

### DIFF
--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -306,10 +306,11 @@ pub(crate) async fn run_ble<
             match select(usb_device.wait_resume(), USB_REMOTE_WAKEUP.wait()).await {
                 Either::First(_) => continue,
                 Either::Second(_) => {
-                    info!("USB wakeup remote");
-                    if let Err(e) = usb_device.remote_wakeup().await {
-                        info!("USB wakeup remote error: {:?}", e)
+                    info!("USB remote wakeup requested");
+                    if usb_device.remote_wakeup().await.is_ok() {
+                        continue;
                     }
+                    usb_device.wait_resume().await;
                 }
             }
         }

--- a/rmk/src/hid.rs
+++ b/rmk/src/hid.rs
@@ -11,7 +11,7 @@ use crate::CONNECTION_STATE;
 use crate::channel::KEYBOARD_REPORT_CHANNEL;
 use crate::state::ConnectionState;
 #[cfg(not(feature = "_no_usb"))]
-use crate::usb::USB_REMOTE_WAKEUP;
+use crate::usb::{USB_REMOTE_WAKEUP, USB_SUSPENDED};
 
 /// KeyboardReport describes a report and its companion descriptor that can be
 /// used to send keyboard button presses to a host and receive the status of the
@@ -266,18 +266,21 @@ pub trait RunnableHidWriter: HidWriterTrait {
                 // Only send the report after the connection is established.
                 if CONNECTION_STATE.load(Ordering::Acquire)
                     == <ConnectionState as Into<bool>>::into(ConnectionState::Connected)
-                    && let Err(e) = self.write_report(report.clone()).await
                 {
-                    error!("Failed to send report: {:?}", e);
                     #[cfg(not(feature = "_no_usb"))]
-                    // If the USB endpoint is disabled, try wakeup
-                    if let HidError::UsbEndpointError(EndpointError::Disabled) = e {
+                    if USB_SUSPENDED.load(Ordering::Acquire) {
                         USB_REMOTE_WAKEUP.signal(());
-                        // Wait 200ms for the wakeup, then send the report again
-                        // Ignore the error for the second send
-                        embassy_time::Timer::after_millis(200).await;
-                        if let Err(e) = self.write_report(report).await {
-                            error!("Failed to send report after wakeup: {:?}", e);
+                    }
+
+                    if let Err(e) = self.write_report(report.clone()).await {
+                        error!("Failed to send report: {:?}", e);
+                        #[cfg(not(feature = "_no_usb"))]
+                        if let HidError::UsbEndpointError(EndpointError::Disabled) = e {
+                            USB_REMOTE_WAKEUP.signal(());
+                            embassy_time::Timer::after_millis(500).await;
+                            if let Err(e) = self.write_report(report).await {
+                                error!("Failed to send report after wakeup: {:?}", e);
+                            }
                         }
                     }
                 };

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -236,7 +236,11 @@ pub async fn run_rmk<
                         match select(usb_device.wait_resume(), USB_REMOTE_WAKEUP.wait()).await {
                             Either::First(_) => continue,
                             Either::Second(_) => {
-                                info!("USB wakeup remote");
+                                info!("USB remote wakeup requested");
+                                if usb_device.remote_wakeup().await.is_ok() {
+                                    continue;
+                                }
+                                usb_device.wait_resume().await;
                             }
                         }
                     }

--- a/rmk/src/usb/mod.rs
+++ b/rmk/src/usb/mod.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::Ordering;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use embassy_sync::signal::Signal;
 use embassy_sync::watch::{Watch, WatchBehavior};
@@ -16,6 +16,7 @@ use crate::state::ConnectionState;
 use crate::{CONNECTION_STATE, RawMutex};
 
 pub(crate) static USB_REMOTE_WAKEUP: Signal<RawMutex, ()> = Signal::new();
+pub(crate) static USB_SUSPENDED: AtomicBool = AtomicBool::new(false);
 
 /// USB state
 #[repr(u8)]
@@ -321,6 +322,7 @@ impl Handler for UsbDeviceHandler {
     }
 
     fn suspended(&mut self, suspended: bool) {
+        USB_SUSPENDED.store(suspended, Ordering::Release);
         // When no logging feature is enabled, `info!` expands to a no-op and
         // both arms collapse to identical empty blocks — suppress the lint.
         #[allow(clippy::if_same_then_else)]


### PR DESCRIPTION
USB remote wakeup doesn't work on non-OTG STM32/GD32 parts:

Two gaps in the current implementation:

1. The USB-only suspend loop in lib.rs never calls usb_device.remote_wakeup(). Only the BLE+USB path in ble/mod.rs had the call.
2. The HID writer only signals USB_REMOTE_WAKEUP after getting EndpointError::Disabled from a failed write. On non-OTG peripherals, endpoints stay NAK/VALID during suspend, so that error never fires and the wakeup signal never gets sent.

Fix:

- Track bus suspend state via a USB_SUSPENDED atomic, updated from the Handler::suspended() callback.
- When a report is pending and the bus is suspended, signal USB_REMOTE_WAKEUP before attempting the write. This wakes the host proactively.
- Call usb_device.remote_wakeup() in the USB-only suspend loop. On failure, fall back to wait_resume() (host-initiated resume still works).
- Keep the EndpointError::Disabled retry path for OTG peripherals where Disabled is the correct suspend indicator.

Testing: Tested on a ZSA Voyager (GD32F303). Keyboard reliably wakes the host on keypress after suspend. The companion embassy-stm32 driver fix (non-OTG Bus::remote_wakeup()) is at: https://github.com/embassy-rs/embassy/pull/5978