### PR TITLE
feat(usb): advertise boot keyboard protocol on primary HID interface

### DIFF
--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -215,7 +215,15 @@ pub(crate) async fn run_ble<
     #[cfg(not(feature = "_no_usb"))]
     let (mut _usb_builder, mut keyboard_reader, mut keyboard_writer, mut other_writer) = {
         let mut usb_builder: embassy_usb::Builder<'_, D> = new_usb_builder(usb_driver, rmk_config.device_config);
-        let keyboard_reader_writer = add_usb_reader_writer!(&mut usb_builder, KeyboardReport, 1, 8, 8);
+        let keyboard_reader_writer = add_usb_reader_writer!(
+            &mut usb_builder,
+            KeyboardReport,
+            1,
+            8,
+            8,
+            ::embassy_usb::class::hid::HidSubclass::Boot,
+            ::embassy_usb::class::hid::HidBootProtocol::Keyboard
+        );
         let other_writer = add_usb_writer!(&mut usb_builder, CompositeReport, 9, 16);
         let (keyboard_reader, keyboard_writer) = keyboard_reader_writer.split();
         (usb_builder, keyboard_reader, keyboard_writer, other_writer)

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -198,7 +198,15 @@ pub async fn run_rmk<
     #[cfg(all(not(feature = "_no_usb"), not(feature = "_ble")))]
     {
         let mut usb_builder: embassy_usb::Builder<'_, D> = new_usb_builder(usb_driver, rmk_config.device_config);
-        let keyboard_reader_writer = add_usb_reader_writer!(&mut usb_builder, KeyboardReport, 1, 8, 8);
+        let keyboard_reader_writer = add_usb_reader_writer!(
+            &mut usb_builder,
+            KeyboardReport,
+            1,
+            8,
+            8,
+            ::embassy_usb::class::hid::HidSubclass::Boot,
+            ::embassy_usb::class::hid::HidBootProtocol::Keyboard
+        );
         let mut other_writer = add_usb_writer!(&mut usb_builder, CompositeReport, 9, 16);
         #[cfg(feature = "steno")]
         let mut steno_writer = add_usb_writer!(&mut usb_builder, StenoReport, 9, 16);

--- a/rmk/src/usb/mod.rs
+++ b/rmk/src/usb/mod.rs
@@ -240,9 +240,14 @@ macro_rules! add_usb_reader_writer {
         $crate::usb::add_usb_reader_writer!($usb_builder, $descriptor, $read_n, $write_n, 64)
     };
     // Size $max_packet to the actual report to conserve Packet Memory Area on tight parts.
-    ($usb_builder:expr, $descriptor:ty, $read_n:expr, $write_n:expr, $max_packet:expr) => {{
-        // Initialize hid reader writer
-        // Current implementation requires the static STATE, so we need to use the paste crate to generate the static variable name.
+    ($usb_builder:expr, $descriptor:ty, $read_n:expr, $write_n:expr, $max_packet:expr) => {
+        $crate::usb::add_usb_reader_writer!(
+            $usb_builder, $descriptor, $read_n, $write_n, $max_packet,
+            ::embassy_usb::class::hid::HidSubclass::No,
+            ::embassy_usb::class::hid::HidBootProtocol::None
+        )
+    };
+    ($usb_builder:expr, $descriptor:ty, $read_n:expr, $write_n:expr, $max_packet:expr, $subclass:expr, $protocol:expr) => {{
         use usbd_hid::descriptor::SerializedDescriptor;
         paste::paste! {
             static [<$descriptor:snake:upper _STATE>]: ::static_cell::StaticCell<::embassy_usb::class::hid::State> = ::static_cell::StaticCell::new();
@@ -257,8 +262,8 @@ macro_rules! add_usb_reader_writer {
             request_handler: Some(request_handler),
             poll_ms: 1,
             max_packet_size: $max_packet,
-            hid_subclass: ::embassy_usb::class::hid::HidSubclass::No,
-            hid_boot_protocol: ::embassy_usb::class::hid::HidBootProtocol::None,
+            hid_subclass: $subclass,
+            hid_boot_protocol: $protocol,
         };
 
         let rw: ::embassy_usb::class::hid::HidReaderWriter<_, $read_n, $write_n> = ::embassy_usb::class::hid::HidReaderWriter::new($usb_builder, state, hid_config);


### PR DESCRIPTION
## Problem

Linux requires `power/wakeup=enabled` in sysfs for USB remote wakeup to work. RMK keyboards get `power/wakeup=disabled` by default, requiring a per-VID udev rule. QMK keyboards get `enabled` automatically with no udev rule.

## Root cause

The Linux `usbhid` driver auto-enables wakeup when it probes a HID interface with `bInterfaceSubClass=1` (Boot) and `bInterfaceProtocol=1` (Keyboard):

```c
// drivers/hid/usbhid/hid-core.c:1205
if (interface->desc.bInterfaceSubClass == USB_INTERFACE_SUBCLASS_BOOT &&
    interface->desc.bInterfaceProtocol == USB_INTERFACE_PROTOCOL_KEYBOARD)
    device_set_wakeup_enable(&dev->dev, 1);
```

QMK sets these fields. RMK (embassy-usb) leaves them at 0/0.

## Fix

Pass `HidSubclass::Boot` and `HidBootProtocol::Keyboard` when constructing the primary keyboard HID interface, in both the USB-only and BLE+USB paths.

Extends `add_usb_reader_writer!` with optional subclass/protocol parameters. The default (No/None) is unchanged for non-keyboard interfaces like the composite report and steno endpoints.

## Testing

Confirmed with `lsusb -v` that the keyboard interface now shows `bInterfaceSubClass=1, bInterfaceProtocol=1`, and `cat /sys/bus/usb/devices/.../power/wakeup` reads `enabled` on plug-in without any udev rule. Tested on kernel 6.18.