### PR TITLE
hid: fix system control array descriptor so system sleep key works

### DIFF
--- a/rmk/src/hid.rs
+++ b/rmk/src/hid.rs
@@ -189,7 +189,7 @@ mod steno_tests {
     },
     (collection = APPLICATION, usage_page = GENERIC_DESKTOP, usage = SYSTEM_CONTROL) = {
         (report_id = 0x03,) = {
-            (usage_min = 0x81, usage_max = 0xB7, logical_min = 1) = {
+            (usage_min = 0x01, usage_max = 0xB7, logical_min = 1) = {
                 #[item_settings(data,array,absolute,not_null)] system_usage_id=input;
             };
         };


### PR DESCRIPTION
I noticed that pressing the system sleep key on my keymap did nothing. The HID system control descriptor had usage_min = 0x81 with logical_min = 1, which caused the host to resolve the sleep usage ID to an out-of-range value and discard it.

Fix is a one-byte descriptor change: usage_min = 0x01. No behaviour change for any other report type.

Tested with a Linux desktop.