### PR TITLE
watchdog: Add runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,10 +116,14 @@ jobs:
       - name: Build
         working-directory: ${{ matrix.dir }}
         run: |
+          # Deny warnings so a stray lint (e.g. an unused import) fails CI here
+          # instead of slipping through. For bloat examples an undenied warning
+          # gets replayed onto stdout by `cargo size` and corrupts the size parser.
+          export RUSTFLAGS="-D warnings"
           # For bloat examples, remap source paths so the absolute workspace
           # prefix doesn't affect binary size (panic messages embed file!() paths).
           if [[ "${{ matrix.bloat }}" == "true" ]]; then
-            export RUSTFLAGS="--remap-path-prefix=$GITHUB_WORKSPACE=/rmk-build"
+            export RUSTFLAGS="$RUSTFLAGS --remap-path-prefix=$GITHUB_WORKSPACE=/rmk-build"
           fi
           cargo build --release
 
@@ -160,7 +164,10 @@ jobs:
           # virtual prefix.  Without this, absolute paths embedded by panic
           # messages (file!() macro) differ in length between $GITHUB_WORKSPACE
           # and the temp worktree, producing false size diffs in .rodata/.text.
-          head_remap="--remap-path-prefix=$GITHUB_WORKSPACE=/rmk-build"
+          # HEAD also keeps `-D warnings` so RUSTFLAGS matches the Build step
+          # above and cargo reuses the binary; BASE uses the default lint level
+          # so a pre-existing warning on main doesn't fail this PR.
+          head_remap="-D warnings --remap-path-prefix=$GITHUB_WORKSPACE=/rmk-build"
           base_remap="--remap-path-prefix=$worktree=/rmk-build"
 
           base_dir="$worktree/${{ matrix.dir }}"

--- a/examples/use_rust/nrf52832_ble/src/main.rs
+++ b/examples/use_rust/nrf52832_ble/src/main.rs
@@ -27,6 +27,7 @@ use rmk::host::HostService;
 use rmk::keyboard::Keyboard;
 use rmk::matrix::Matrix;
 use rmk::processor::builtin::wpm::WpmProcessor;
+use rmk::watchdog::Nrf52Watchdog;
 use rmk::{HostResources, KeymapData, initialize_keymap_and_storage, run_all};
 use static_cell::StaticCell;
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
@@ -165,5 +166,16 @@ async fn main(spawner: Spawner) {
     let mut ble_transport = BleTransport::new(&stack, rmk_config).await;
     let mut wpm_processor = WpmProcessor::new();
 
-    run_all!(matrix, storage, ble_transport, wpm_processor, keyboard, host_service).await;
+    let mut watchdog_runner = Nrf52Watchdog::default_runner(p.WDT);
+
+    run_all!(
+        matrix,
+        storage,
+        ble_transport,
+        wpm_processor,
+        keyboard,
+        host_service,
+        watchdog_runner
+    )
+    .await;
 }

--- a/examples/use_rust/nrf52840_ble/src/main.rs
+++ b/examples/use_rust/nrf52840_ble/src/main.rs
@@ -37,6 +37,7 @@ use rmk::keyboard::Keyboard;
 use rmk::matrix::Matrix;
 use rmk::processor::builtin::wpm::WpmProcessor;
 use rmk::usb::UsbTransport;
+use rmk::watchdog::Nrf52Watchdog;
 use rmk::{HostResources, KeymapData, initialize_keymap_and_storage, run_all};
 use static_cell::StaticCell;
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
@@ -218,6 +219,8 @@ async fn main(spawner: Spawner) {
     let mut ble_transport = BleTransport::new(&stack, rmk_config).await;
     let mut wpm_processor = WpmProcessor::new();
 
+    let mut watchdog_runner = Nrf52Watchdog::default_runner(p.WDT);
+
     run_all!(
         matrix,
         encoder,
@@ -228,7 +231,8 @@ async fn main(spawner: Spawner) {
         wpm_processor,
         batt_proc,
         keyboard,
-        host_service
+        host_service,
+        watchdog_runner
     )
     .await;
 }

--- a/examples/use_rust/nrf52840_ble_split/src/central.rs
+++ b/examples/use_rust/nrf52840_ble_split/src/central.rs
@@ -41,6 +41,7 @@ use rmk::processor::builtin::wpm::WpmProcessor;
 use rmk::split::ble::central::scan_peripherals;
 use rmk::split::central::run_peripheral_manager;
 use rmk::usb::UsbTransport;
+use rmk::watchdog::Nrf52Watchdog;
 use rmk::{HostResources, KeymapData, initialize_keymap_and_storage, run_all};
 use static_cell::StaticCell;
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
@@ -263,6 +264,8 @@ async fn main(spawner: Spawner) {
     let mut ble_transport = BleTransport::new(&stack, rmk_config).await;
     let mut wpm_processor = WpmProcessor::new();
 
+    let mut watchdog_runner = Nrf52Watchdog::default_runner(p.WDT);
+
     // Start
     join(
         run_all!(
@@ -277,7 +280,8 @@ async fn main(spawner: Spawner) {
             keyboard,
             host_service,
             capslock_led,
-            peripheral_battery_monitor
+            peripheral_battery_monitor,
+            watchdog_runner
         ),
         join(
             run_peripheral_manager::<4, 7, 4, 0, _>(0, &peripheral_addrs, &stack),

--- a/examples/use_rust/nrf52840_ble_split/src/peripheral.rs
+++ b/examples/use_rust/nrf52840_ble_split/src/peripheral.rs
@@ -29,6 +29,7 @@ use rmk::input_device::rotary_encoder::RotaryEncoder;
 use rmk::matrix::Matrix;
 use rmk::split::peripheral::run_rmk_split_peripheral;
 use rmk::storage::new_storage_for_split_peripheral;
+use rmk::watchdog::Nrf52Watchdog;
 use rmk::{HostResources, run_all};
 use static_cell::StaticCell;
 
@@ -167,9 +168,11 @@ async fn main(spawner: Spawner) {
     );
     let mut battery_processor = BatteryProcessor::new(2000, 2806);
 
+    let mut watchdog_runner = Nrf52Watchdog::default_runner(p.WDT);
+
     // Start
     join3(
-        run_all!(matrix, encoder, adc_device, storage),
+        run_all!(matrix, encoder, adc_device, storage, watchdog_runner),
         run_all!(battery_processor),
         run_rmk_split_peripheral(0, &stack),
     )

--- a/examples/use_rust/nrf52840_ble_split_dongle/src/central.rs
+++ b/examples/use_rust/nrf52840_ble_split_dongle/src/central.rs
@@ -42,6 +42,7 @@ use rmk::processor::builtin::wpm::WpmProcessor;
 use rmk::split::ble::central::scan_peripherals;
 use rmk::split::central::run_peripheral_manager;
 use rmk::usb::UsbTransport;
+use rmk::watchdog::Nrf52Watchdog;
 use rmk::{HostResources, KeymapData, initialize_keymap_and_storage, run_all};
 use static_cell::StaticCell;
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
@@ -265,6 +266,8 @@ async fn main(spawner: Spawner) {
     let mut ble_transport = BleTransport::new(&stack, rmk_config).await;
     let mut wpm_processor = WpmProcessor::new();
 
+    let mut watchdog_runner = Nrf52Watchdog::default_runner(p.WDT);
+
     // Start
     join(
         run_all!(
@@ -280,7 +283,8 @@ async fn main(spawner: Spawner) {
             wpm_processor,
             keyboard,
             capslock_led,
-            host_service
+            host_service,
+            watchdog_runner
         ),
         join(
             scan_peripherals(&stack, &peripheral_addrs),

--- a/examples/use_rust/nrf52840_ble_split_dongle/src/peripheral.rs
+++ b/examples/use_rust/nrf52840_ble_split_dongle/src/peripheral.rs
@@ -27,6 +27,7 @@ use rmk::input_device::rotary_encoder::RotaryEncoder;
 use rmk::matrix::Matrix;
 use rmk::split::peripheral::run_rmk_split_peripheral;
 use rmk::storage::new_storage_for_split_peripheral;
+use rmk::watchdog::Nrf52Watchdog;
 use rmk::{HostResources, run_all};
 use static_cell::StaticCell;
 
@@ -155,6 +156,12 @@ async fn main(spawner: Spawner) {
     let pin_b = Input::new(p.P1_04, embassy_nrf::gpio::Pull::None);
     let mut encoder = RotaryEncoder::with_resolution(pin_a, pin_b, 4, true, 1);
 
+    let mut watchdog_runner = Nrf52Watchdog::default_runner(p.WDT);
+
     // Start
-    join(run_all!(matrix, encoder, storage), run_rmk_split_peripheral(0, &stack)).await;
+    join(
+        run_all!(matrix, encoder, storage, watchdog_runner),
+        run_rmk_split_peripheral(0, &stack),
+    )
+    .await;
 }

--- a/examples/use_rust/nrf52840_ble_split_dongle/src/peripheral2.rs
+++ b/examples/use_rust/nrf52840_ble_split_dongle/src/peripheral2.rs
@@ -27,6 +27,7 @@ use rmk::input_device::rotary_encoder::RotaryEncoder;
 use rmk::matrix::Matrix;
 use rmk::split::peripheral::run_rmk_split_peripheral;
 use rmk::storage::new_storage_for_split_peripheral;
+use rmk::watchdog::Nrf52Watchdog;
 use rmk::{HostResources, run_all};
 use static_cell::StaticCell;
 
@@ -155,6 +156,12 @@ async fn main(spawner: Spawner) {
     let pin_b = Input::new(p.P1_04, embassy_nrf::gpio::Pull::None);
     let mut encoder = RotaryEncoder::with_resolution(pin_a, pin_b, 4, true, 1);
 
+    let mut watchdog_runner = Nrf52Watchdog::default_runner(p.WDT);
+
     // Start
-    join(run_all!(matrix, encoder, storage), run_rmk_split_peripheral(1, &stack)).await;
+    join(
+        run_all!(matrix, encoder, storage, watchdog_runner),
+        run_rmk_split_peripheral(1, &stack),
+    )
+    .await;
 }

--- a/examples/use_rust/pi_pico_w_ble/src/main.rs
+++ b/examples/use_rust/pi_pico_w_ble/src/main.rs
@@ -31,6 +31,7 @@ use rmk::keyboard::Keyboard;
 use rmk::matrix::Matrix;
 use rmk::processor::builtin::wpm::WpmProcessor;
 use rmk::usb::UsbTransport;
+use rmk::watchdog::Rp2040Watchdog;
 use rmk::{HostResources, KeymapData, initialize_keymap_and_storage, run_all};
 use static_cell::StaticCell;
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
@@ -162,6 +163,7 @@ async fn main(spawner: Spawner) {
     let mut usb_transport = UsbTransport::new(driver, rmk_config.device_config);
     let mut ble_transport = BleTransport::new(&stack, rmk_config).await;
     let mut wpm_processor = WpmProcessor::new();
+    let mut watchdog_runner = Rp2040Watchdog::default_runner(embassy_rp::watchdog::Watchdog::new(p.WATCHDOG));
 
     // Start
     run_all!(
@@ -171,7 +173,8 @@ async fn main(spawner: Spawner) {
         ble_transport,
         wpm_processor,
         keyboard,
-        host_service
+        host_service,
+        watchdog_runner
     )
     .await;
 }

--- a/examples/use_rust/pi_pico_w_ble_split/src/central.rs
+++ b/examples/use_rust/pi_pico_w_ble_split/src/central.rs
@@ -34,6 +34,7 @@ use rmk::processor::builtin::wpm::WpmProcessor;
 use rmk::split::ble::central::scan_peripherals;
 use rmk::split::central::run_peripheral_manager;
 use rmk::usb::UsbTransport;
+use rmk::watchdog::Rp2040Watchdog;
 use rmk::{HostResources, KeymapData, initialize_keymap_and_storage, run_all};
 use static_cell::StaticCell;
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
@@ -168,6 +169,7 @@ async fn main(spawner: Spawner) {
     let mut usb_transport = UsbTransport::new(driver, rmk_config.device_config);
     let mut ble_transport = BleTransport::new(&stack, rmk_config).await;
     let mut wpm_processor = WpmProcessor::new();
+    let mut watchdog_runner = Rp2040Watchdog::default_runner(embassy_rp::watchdog::Watchdog::new(p.WATCHDOG));
 
     // Start
     join(
@@ -178,7 +180,8 @@ async fn main(spawner: Spawner) {
             ble_transport,
             wpm_processor,
             keyboard,
-            host_service
+            host_service,
+            watchdog_runner
         ),
         join(
             run_peripheral_manager::<4, 7, 4, 0, _>(0, &peripheral_addrs, &stack),

--- a/examples/use_rust/pi_pico_w_ble_split/src/peripheral.rs
+++ b/examples/use_rust/pi_pico_w_ble_split/src/peripheral.rs
@@ -25,6 +25,7 @@ use rmk::futures::future::join;
 use rmk::matrix::Matrix;
 use rmk::split::peripheral::run_rmk_split_peripheral;
 use rmk::storage::new_storage_for_split_peripheral;
+use rmk::watchdog::Rp2040Watchdog;
 use rmk::{HostResources, run_all};
 use static_cell::StaticCell;
 
@@ -108,6 +109,12 @@ async fn main(spawner: Spawner) {
     let mut rng = rand_chacha::ChaCha12Rng::from_rng(&mut rosc_rng).unwrap();
 
     let stack = build_ble_stack(controller, ble_addr, &mut rng, &mut host_resources).await;
+    let mut watchdog_runner = Rp2040Watchdog::default_runner(embassy_rp::watchdog::Watchdog::new(p.WATCHDOG));
+
     // Start
-    join(run_all!(matrix, storage), run_rmk_split_peripheral(0, &stack)).await;
+    join(
+        run_all!(matrix, storage, watchdog_runner),
+        run_rmk_split_peripheral(0, &stack),
+    )
+    .await;
 }

--- a/examples/use_rust/rp2040/src/main.rs
+++ b/examples/use_rust/rp2040/src/main.rs
@@ -24,6 +24,7 @@ use rmk::keyboard::Keyboard;
 use rmk::matrix::Matrix;
 use rmk::processor::builtin::wpm::WpmProcessor;
 use rmk::usb::UsbTransport;
+use rmk::watchdog::Rp2040Watchdog;
 use rmk::{KeymapData, initialize_keymap_and_storage, run_all};
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
 
@@ -92,6 +93,17 @@ async fn main(_spawner: Spawner) {
     let mut usb_transport = UsbTransport::new(driver, rmk_config.device_config);
     let mut wpm_processor = WpmProcessor::new();
 
+    let mut watchdog_runner = Rp2040Watchdog::default_runner(embassy_rp::watchdog::Watchdog::new(p.WATCHDOG));
+
     // Start
-    run_all!(matrix, storage, usb_transport, wpm_processor, keyboard, host_service).await;
+    run_all!(
+        matrix,
+        storage,
+        usb_transport,
+        wpm_processor,
+        keyboard,
+        host_service,
+        watchdog_runner
+    )
+    .await;
 }

--- a/examples/use_rust/rp2040_split/src/central.rs
+++ b/examples/use_rust/rp2040_split/src/central.rs
@@ -27,6 +27,7 @@ use rmk::processor::builtin::wpm::WpmProcessor;
 use rmk::split::SPLIT_MESSAGE_MAX_SIZE;
 use rmk::split::central::run_peripheral_manager;
 use rmk::usb::UsbTransport;
+use rmk::watchdog::Rp2040Watchdog;
 use rmk::{KeymapData, initialize_keymap_and_storage, run_all};
 use static_cell::StaticCell;
 use vial::{VIAL_KEYBOARD_DEF, VIAL_KEYBOARD_ID};
@@ -102,9 +103,19 @@ async fn main(_spawner: Spawner) {
     let mut usb_transport = UsbTransport::new(driver, rmk_config.device_config);
     let mut wpm_processor = WpmProcessor::new();
 
+    let mut watchdog_runner = Rp2040Watchdog::default_runner(embassy_rp::watchdog::Watchdog::new(p.WATCHDOG));
+
     // Start
     join(
-        run_all!(matrix, storage, usb_transport, wpm_processor, keyboard, host_service),
+        run_all!(
+            matrix,
+            storage,
+            usb_transport,
+            wpm_processor,
+            keyboard,
+            host_service,
+            watchdog_runner
+        ),
         run_peripheral_manager::<2, 1, 2, 2, _>(0, uart_receiver),
     )
     .await;

--- a/examples/use_rust/rp2040_split/src/peripheral.rs
+++ b/examples/use_rust/rp2040_split/src/peripheral.rs
@@ -19,6 +19,7 @@ use rmk::matrix::Matrix;
 use rmk::run_all;
 use rmk::split::SPLIT_MESSAGE_MAX_SIZE;
 use rmk::split::peripheral::run_rmk_split_peripheral;
+use rmk::watchdog::Rp2040Watchdog;
 use static_cell::StaticCell;
 
 bind_interrupts!(struct Irqs {
@@ -45,6 +46,12 @@ async fn main(_spawner: Spawner) {
     let debouncer = DefaultDebouncer::new();
     let mut matrix = Matrix::<_, _, _, 2, 2, true>::new(row_pins, col_pins, debouncer);
 
+    let mut watchdog_runner = Rp2040Watchdog::default_runner(embassy_rp::watchdog::Watchdog::new(p.WATCHDOG));
+
     // Start
-    join(run_all!(matrix), run_rmk_split_peripheral(uart_instance)).await;
+    join(
+        run_all!(matrix, watchdog_runner),
+        run_rmk_split_peripheral(uart_instance),
+    )
+    .await;
 }

--- a/rmk-macro/Cargo.toml
+++ b/rmk-macro/Cargo.toml
@@ -19,6 +19,10 @@ darling = "0.23"
 cargo_toml = "0.22"
 strum = { version = "0.28", default-features = false, features = ["derive"] }
 
+[features]
+## Enable hardware watchdog code generation
+watchdog = []
+
 [lib]
 proc-macro = true
 doctest = false

--- a/rmk-macro/src/codegen/entry.rs
+++ b/rmk-macro/src/codegen/entry.rs
@@ -14,6 +14,7 @@ pub(crate) fn expand_rmk_entry(
     devices: Vec<TokenStream2>,
     processors: Vec<TokenStream2>,
     registered_processors: Vec<TokenStream2>,
+    watchdog_task: Option<TokenStream2>,
 ) -> TokenStream2 {
     // If there is a function with `#[Overwritten(entry)]`, override the entry
     if let Some((_, items)) = &item_mod.content {
@@ -34,9 +35,17 @@ pub(crate) fn expand_rmk_entry(
                 devices,
                 processors,
                 registered_processors,
+                watchdog_task,
             ))
     } else {
-        rmk_entry_select(hardware, host, devices, processors, registered_processors)
+        rmk_entry_select(
+            hardware,
+            host,
+            devices,
+            processors,
+            registered_processors,
+            watchdog_task,
+        )
     }
 }
 
@@ -53,6 +62,7 @@ pub(crate) fn rmk_entry_select(
     devices: Vec<TokenStream2>,
     processors: Vec<TokenStream2>,
     registered_processors: Vec<TokenStream2>,
+    watchdog_task: Option<TokenStream2>,
 ) -> TokenStream2 {
     let devices_task = {
         let mut devs = devices.clone();
@@ -96,6 +106,9 @@ pub(crate) fn rmk_entry_select(
                 tasks.push(t);
             }
             tasks.extend(transport_tasks);
+            if let Some(t) = &watchdog_task {
+                tasks.push(t.clone());
+            }
             if split_config.connection == "ble" {
                 if !processors.is_empty() {
                     tasks.push(processors_task);
@@ -170,6 +183,7 @@ pub(crate) fn rmk_entry_select(
             devices_task,
             processors_task,
             registered_processors,
+            watchdog_task,
         ),
     };
 
@@ -186,6 +200,7 @@ pub(crate) fn rmk_entry_unibody(
     devices_task: TokenStream2,
     processors_task: TokenStream2,
     registered_processors: Vec<TokenStream2>,
+    watchdog_task: Option<TokenStream2>,
 ) -> TokenStream2 {
     let keyboard_task = quote! {
         keyboard.run()
@@ -200,6 +215,9 @@ pub(crate) fn rmk_entry_unibody(
     }
     tasks.extend(registered_processors);
     tasks.extend(transport_tasks);
+    if let Some(t) = watchdog_task {
+        tasks.push(t);
+    }
     let joined = join_all_tasks(tasks);
     quote! {
         #transport_prelude

--- a/rmk-macro/src/codegen/mod.rs
+++ b/rmk-macro/src/codegen/mod.rs
@@ -13,5 +13,6 @@ pub(crate) mod orchestrator;
 pub(crate) mod override_helper;
 pub(crate) mod registered_processor;
 pub(crate) mod split;
+pub(crate) mod watchdog;
 
 pub(crate) use orchestrator::parse_keyboard_mod;

--- a/rmk-macro/src/codegen/orchestrator.rs
+++ b/rmk-macro/src/codegen/orchestrator.rs
@@ -22,6 +22,7 @@ use super::layout::expand_default_keymap;
 use super::matrix::{expand_bootmagic_check, expand_matrix_config};
 use super::registered_processor::expand_registered_processor_init;
 use super::split::central::expand_split_central_config;
+use super::watchdog::expand_watchdog_init;
 
 /// Parse keyboard mod and generate a valid RMK main function with all needed code
 pub(crate) fn parse_keyboard_mod(item_mod: syn::ItemMod) -> TokenStream2 {
@@ -259,6 +260,8 @@ fn expand_main(
         quote! {}
     };
 
+    let (watchdog_init, watchdog_task) = expand_watchdog_init(hardware);
+
     let run_rmk = expand_rmk_entry(
         hardware,
         host,
@@ -266,6 +269,7 @@ fn expand_main(
         devices,
         processors,
         registered_processors,
+        watchdog_task,
     );
 
     let vial_config = if host.vial_enabled {
@@ -359,6 +363,9 @@ fn expand_main(
 
             // Initialize split central config(if needed)
             #split_central_config
+
+            // Initialize watchdog
+            #watchdog_init
 
             // Start
             #run_rmk

--- a/rmk-macro/src/codegen/split/peripheral.rs
+++ b/rmk-macro/src/codegen/split/peripheral.rs
@@ -26,6 +26,7 @@ use crate::codegen::matrix::{
 };
 use crate::codegen::orchestrator::get_debouncer_type;
 use crate::codegen::registered_processor::expand_registered_processor_init;
+use crate::codegen::watchdog::expand_watchdog_init;
 
 /// Parse split peripheral mod and generate a valid RMK main function with all needed code
 pub(crate) fn parse_split_peripheral_mod(
@@ -377,8 +378,9 @@ fn expand_split_peripheral(
         quote! {}
     };
 
-    // Import Runnable trait so processor.run() calls compile
-    let processor_import = if !registered_processors.is_empty() {
+    let (watchdog_init, watchdog_task) = expand_watchdog_init(hardware);
+
+    let runnable_import = if !registered_processors.is_empty() || watchdog_task.is_some() {
         quote! { use ::rmk::core_traits::Runnable; }
     } else {
         quote! {}
@@ -392,11 +394,12 @@ fn expand_split_peripheral(
         devices,
         processors,
         registered_processors,
+        watchdog_task,
     );
 
     quote! {
         #imports
-        #processor_import
+        #runnable_import
         #chip_init
         #registered_processor_initializers
         #matrix_config
@@ -404,10 +407,12 @@ fn expand_split_peripheral(
         #output_config
         #device_initialization
         #display_init
+        #watchdog_init
         #run_rmk_peripheral
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn expand_split_peripheral_entry(
     id: usize,
     chip: &ChipModel,
@@ -416,6 +421,7 @@ fn expand_split_peripheral_entry(
     devices: Vec<TokenStream2>,
     processors: Vec<TokenStream2>,
     registered_processors: Vec<TokenStream2>,
+    watchdog_task: Option<TokenStream2>,
 ) -> TokenStream2 {
     // Add matrix to devices, and run all devices
     let mut devs = devices.clone();
@@ -454,6 +460,9 @@ fn expand_split_peripheral_entry(
         }
         tasks.push(peripheral_run);
         tasks.extend(registered_processors);
+        if let Some(t) = &watchdog_task {
+            tasks.push(t.clone());
+        }
         let run_rmk_peripheral = join_all_tasks(tasks);
         quote! {
             #run_rmk_peripheral
@@ -484,6 +493,9 @@ fn expand_split_peripheral_entry(
         };
         let mut tasks = vec![device_task, peripheral_run];
         tasks.extend(registered_processors);
+        if let Some(t) = &watchdog_task {
+            tasks.push(t.clone());
+        }
         let run_rmk_peripheral = join_all_tasks(tasks);
         quote! {
             #serial_init

--- a/rmk-macro/src/codegen/watchdog.rs
+++ b/rmk-macro/src/codegen/watchdog.rs
@@ -14,7 +14,12 @@ use rmk_config::resolved::hardware::ChipSeries;
 #[cfg(feature = "watchdog")]
 pub(crate) fn expand_watchdog_init(hardware: &Hardware) -> (TokenStream2, Option<TokenStream2>) {
     let init = match hardware.chip.series {
-        ChipSeries::Stm32 | ChipSeries::Rp2040 | ChipSeries::Nrf52 | ChipSeries::Esp32 => quote! {},
+        ChipSeries::Rp2040 => quote! {
+            let mut watchdog_runner = ::rmk::watchdog::Rp2040Watchdog::default_runner(
+                ::embassy_rp::watchdog::Watchdog::new(p.WATCHDOG),
+            );
+        },
+        ChipSeries::Stm32 | ChipSeries::Nrf52 | ChipSeries::Esp32 => quote! {},
     };
 
     if init.is_empty() {

--- a/rmk-macro/src/codegen/watchdog.rs
+++ b/rmk-macro/src/codegen/watchdog.rs
@@ -19,7 +19,11 @@ pub(crate) fn expand_watchdog_init(hardware: &Hardware) -> (TokenStream2, Option
                 ::embassy_rp::watchdog::Watchdog::new(p.WATCHDOG),
             );
         },
-        ChipSeries::Stm32 | ChipSeries::Nrf52 | ChipSeries::Esp32 => quote! {},
+        ChipSeries::Nrf52 => quote! {
+            let mut watchdog_runner =
+                ::rmk::watchdog::Nrf52Watchdog::default_runner(p.WDT);
+        },
+        ChipSeries::Stm32 | ChipSeries::Esp32 => quote! {},
     };
 
     if init.is_empty() {

--- a/rmk-macro/src/codegen/watchdog.rs
+++ b/rmk-macro/src/codegen/watchdog.rs
@@ -23,7 +23,21 @@ pub(crate) fn expand_watchdog_init(hardware: &Hardware) -> (TokenStream2, Option
             let mut watchdog_runner =
                 ::rmk::watchdog::Nrf52Watchdog::default_runner(p.WDT);
         },
-        ChipSeries::Stm32 | ChipSeries::Esp32 => quote! {},
+        ChipSeries::Esp32 => quote! {
+            let timg1 = ::esp_hal::timer::timg::TimerGroup::new(p.TIMG1);
+            let mut esp_wdt_inner = timg1.wdt;
+            esp_wdt_inner.set_timeout(
+                ::esp_hal::timer::timg::MwdtStage::Stage0,
+                ::esp_hal::time::Duration::from_secs(10),
+            );
+            esp_wdt_inner.enable();
+            let esp_wdt = ::rmk::watchdog::Esp32Watchdog::new(esp_wdt_inner);
+            let mut watchdog_runner = ::rmk::watchdog::WatchdogRunner::new(
+                esp_wdt,
+                ::rmk::embassy_time::Duration::from_secs(5),
+            );
+        },
+        ChipSeries::Stm32 => quote! {},
     };
 
     if init.is_empty() {

--- a/rmk-macro/src/codegen/watchdog.rs
+++ b/rmk-macro/src/codegen/watchdog.rs
@@ -1,0 +1,31 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use rmk_config::resolved::Hardware;
+#[cfg(feature = "watchdog")]
+use rmk_config::resolved::hardware::ChipSeries;
+
+/// Returns (init_tokens, run task) for the chip's hardware watchdog.
+///
+/// When a chip has watchdog codegen the init tokens declare and start
+/// `watchdog_runner`, and the task is `watchdog_runner.run()` which
+/// must be joined with the other tasks.
+///
+/// Chips without codegen return empty tokens and `None`.
+#[cfg(feature = "watchdog")]
+pub(crate) fn expand_watchdog_init(hardware: &Hardware) -> (TokenStream2, Option<TokenStream2>) {
+    let init = match hardware.chip.series {
+        ChipSeries::Stm32 | ChipSeries::Rp2040 | ChipSeries::Nrf52 | ChipSeries::Esp32 => quote! {},
+    };
+
+    if init.is_empty() {
+        (init, None)
+    } else {
+        (init, Some(quote! { watchdog_runner.run() }))
+    }
+}
+
+/// No-op when the `watchdog` feature is disabled; codegen emits nothing.
+#[cfg(not(feature = "watchdog"))]
+pub(crate) fn expand_watchdog_init(_hardware: &Hardware) -> (TokenStream2, Option<TokenStream2>) {
+    (quote! {}, None)
+}

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -105,7 +105,10 @@ features = ["split", "vial", "async_matrix", "_ble"]
 cortex-m = { version = "0.7" }
 
 [features]
-default = ["defmt", "storage", "vial", "vial_lock"]
+default = ["defmt", "storage", "vial", "vial_lock", "watchdog"]
+
+## Enable hardware watchdog support
+watchdog = ["rmk-macro/watchdog"]
 
 ## Enable host configurator support
 host = ["dep:byteorder"]

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -37,6 +37,7 @@ pub use embassy_futures;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex as RawMutex;
 #[cfg(cortex_m)]
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex as RawMutex;
+pub use embassy_time;
 pub use futures;
 pub use heapless;
 use keymap::KeyMap;
@@ -82,6 +83,8 @@ pub mod state;
 pub mod storage;
 #[cfg(not(feature = "_no_usb"))]
 pub mod usb;
+#[cfg(feature = "watchdog")]
+pub mod watchdog;
 
 // Test-only helper that drives `embassy-time/mock-driver` from the
 // `#[cfg(test)]` modules under `src/`. Mirrors the same helper at

--- a/rmk/src/watchdog/esp32.rs
+++ b/rmk/src/watchdog/esp32.rs
@@ -1,0 +1,18 @@
+use super::WatchdogFeed;
+
+/// ESP32 MWDT (Main Watchdog Timer) wrapper.
+pub struct Esp32Watchdog<TG: esp_hal::timer::timg::TimerGroupInstance> {
+    inner: esp_hal::timer::timg::Wdt<TG>,
+}
+
+impl<TG: esp_hal::timer::timg::TimerGroupInstance> Esp32Watchdog<TG> {
+    pub fn new(wdt: esp_hal::timer::timg::Wdt<TG>) -> Self {
+        Self { inner: wdt }
+    }
+}
+
+impl<TG: esp_hal::timer::timg::TimerGroupInstance + Send> WatchdogFeed for Esp32Watchdog<TG> {
+    fn feed(&mut self) {
+        self.inner.feed();
+    }
+}

--- a/rmk/src/watchdog/mod.rs
+++ b/rmk/src/watchdog/mod.rs
@@ -1,0 +1,35 @@
+use embassy_time::{Duration, Timer};
+
+use crate::core_traits::Runnable;
+
+/// Chip-agnostic watchdog feeding. Implement this for your platform's
+/// watchdog peripheral, then pass it to [`WatchdogRunner`].
+pub trait WatchdogFeed: Send {
+    fn feed(&mut self);
+}
+
+/// A [`Runnable`] that periodically feeds a hardware watchdog.
+///
+/// Pass this to `run_all!` alongside your keyboard and matrix. Because
+/// all runnables are joined cooperatively, a tight-loop stall in any
+/// sibling task will block this runner too, letting the hardware
+/// watchdog fire a reset.
+pub struct WatchdogRunner<W: WatchdogFeed> {
+    watchdog: W,
+    interval: Duration,
+}
+
+impl<W: WatchdogFeed> WatchdogRunner<W> {
+    pub fn new(watchdog: W, interval: Duration) -> Self {
+        Self { watchdog, interval }
+    }
+}
+
+impl<W: WatchdogFeed> Runnable for WatchdogRunner<W> {
+    async fn run(&mut self) -> ! {
+        loop {
+            self.watchdog.feed();
+            Timer::after(self.interval).await;
+        }
+    }
+}

--- a/rmk/src/watchdog/mod.rs
+++ b/rmk/src/watchdog/mod.rs
@@ -2,6 +2,11 @@ use embassy_time::{Duration, Timer};
 
 use crate::core_traits::Runnable;
 
+#[cfg(feature = "rp2040")]
+mod rp2040;
+#[cfg(feature = "rp2040")]
+pub use rp2040::Rp2040Watchdog;
+
 /// Chip-agnostic watchdog feeding. Implement this for your platform's
 /// watchdog peripheral, then pass it to [`WatchdogRunner`].
 pub trait WatchdogFeed: Send {

--- a/rmk/src/watchdog/mod.rs
+++ b/rmk/src/watchdog/mod.rs
@@ -2,11 +2,15 @@ use embassy_time::{Duration, Timer};
 
 use crate::core_traits::Runnable;
 
+#[cfg(feature = "_esp_ble")]
+mod esp32;
 #[cfg(all(feature = "_nrf_ble", not(any(feature = "nrf54l15_ble", feature = "nrf54lm20_ble"))))]
 mod nrf52;
 #[cfg(feature = "rp2040")]
 mod rp2040;
 
+#[cfg(feature = "_esp_ble")]
+pub use esp32::Esp32Watchdog;
 #[cfg(all(feature = "_nrf_ble", not(any(feature = "nrf54l15_ble", feature = "nrf54lm20_ble"))))]
 pub use nrf52::Nrf52Watchdog;
 #[cfg(feature = "rp2040")]

--- a/rmk/src/watchdog/mod.rs
+++ b/rmk/src/watchdog/mod.rs
@@ -2,8 +2,13 @@ use embassy_time::{Duration, Timer};
 
 use crate::core_traits::Runnable;
 
+#[cfg(all(feature = "_nrf_ble", not(any(feature = "nrf54l15_ble", feature = "nrf54lm20_ble"))))]
+mod nrf52;
 #[cfg(feature = "rp2040")]
 mod rp2040;
+
+#[cfg(all(feature = "_nrf_ble", not(any(feature = "nrf54l15_ble", feature = "nrf54lm20_ble"))))]
+pub use nrf52::Nrf52Watchdog;
 #[cfg(feature = "rp2040")]
 pub use rp2040::Rp2040Watchdog;
 

--- a/rmk/src/watchdog/nrf52.rs
+++ b/rmk/src/watchdog/nrf52.rs
@@ -1,0 +1,35 @@
+use embassy_nrf::Peri;
+use embassy_nrf::peripherals::WDT;
+use embassy_nrf::wdt::{self, WatchdogHandle};
+use embassy_time::Duration;
+
+use super::{WatchdogFeed, WatchdogRunner};
+
+/// nRF52 watchdog wrapper around a single [`WatchdogHandle`].
+///
+/// Create via [`embassy_nrf::wdt::Watchdog::try_new`] with `N = 1`,
+/// then pass the returned handle here.
+pub struct Nrf52Watchdog {
+    handle: WatchdogHandle,
+}
+
+impl Nrf52Watchdog {
+    pub fn new(handle: WatchdogHandle) -> Self {
+        Self { handle }
+    }
+
+    pub fn default_runner(wdt: Peri<'static, WDT>) -> WatchdogRunner<Self> {
+        let mut config = wdt::Config::default();
+        config.timeout_ticks = 327680; // 10s at 32768 Hz
+        config.action_during_debug_halt = wdt::HaltConfig::PAUSE;
+        config.action_during_sleep = wdt::SleepConfig::RUN;
+        let (_driver, [handle]) = wdt::Watchdog::try_new(wdt, config).expect("WDT already active");
+        WatchdogRunner::new(Self::new(handle), Duration::from_secs(5))
+    }
+}
+
+impl WatchdogFeed for Nrf52Watchdog {
+    fn feed(&mut self) {
+        self.handle.pet();
+    }
+}

--- a/rmk/src/watchdog/rp2040.rs
+++ b/rmk/src/watchdog/rp2040.rs
@@ -1,0 +1,36 @@
+use embassy_time::Duration;
+
+use super::{WatchdogFeed, WatchdogRunner};
+
+/// RP2040 watchdog wrapper that reloads the countdown on each feed.
+/// Hardware max timeout is ~8.3s (RP2040-E1 errata).
+pub struct Rp2040Watchdog {
+    inner: embassy_rp::watchdog::Watchdog,
+    timeout: Duration,
+}
+
+impl Rp2040Watchdog {
+    pub fn new(watchdog: embassy_rp::watchdog::Watchdog, timeout: Duration) -> Self {
+        Self {
+            inner: watchdog,
+            timeout,
+        }
+    }
+
+    pub fn start(&mut self) {
+        self.inner.pause_on_debug(true);
+        self.inner.start(self.timeout);
+    }
+
+    pub fn default_runner(watchdog: embassy_rp::watchdog::Watchdog) -> WatchdogRunner<Self> {
+        let mut wdt = Self::new(watchdog, Duration::from_secs(8));
+        wdt.start();
+        WatchdogRunner::new(wdt, Duration::from_secs(4))
+    }
+}
+
+impl WatchdogFeed for Rp2040Watchdog {
+    fn feed(&mut self) {
+        self.inner.feed(self.timeout);
+    }
+}


### PR DESCRIPTION
Adds a watchdog runner to the supported chipsets. This enables the hardware watchdog to reset the board automatically if Embassy on the device locks up.

I do not have hardware to test these other chipsets, but I used this as the basis for the watchdog on my ZSA Voyager.

Timeout it set to `8s` on RP2040 as that's a hardware limitation, the others run this at `10s`.