### PR TITLE
feat: add combo.prior_idle_time cooldown window

### DIFF
--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -629,6 +629,7 @@ pub struct OneShotModifiersConfig {
 pub(crate) struct CombosConfig {
     pub combos: Vec<ComboConfig>,
     pub timeout: Option<DurationMillis>,
+    pub require_prior_idle_ms: Option<u64>,
 }
 
 /// Configurations for combo

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -629,7 +629,7 @@ pub struct OneShotModifiersConfig {
 pub(crate) struct CombosConfig {
     pub combos: Vec<ComboConfig>,
     pub timeout: Option<DurationMillis>,
-    pub require_prior_idle_ms: Option<u64>,
+    pub prior_idle_time: Option<DurationMillis>,
 }
 
 /// Configurations for combo

--- a/rmk-config/src/resolved/behavior.rs
+++ b/rmk-config/src/resolved/behavior.rs
@@ -18,6 +18,7 @@ pub struct OneShot {
 pub struct Combos {
     pub combos: Vec<Combo>,
     pub timeout_ms: Option<u64>,
+    pub require_prior_idle_ms: Option<u64>,
 }
 
 pub struct Combo {
@@ -116,6 +117,7 @@ impl crate::KeyboardTomlConfig {
                 })
                 .collect(),
             timeout_ms: c.timeout.map(|t| t.0),
+            require_prior_idle_ms: c.require_prior_idle_ms,
         });
 
         let macros = toml_behavior.macros.map(|m| Macros {

--- a/rmk-config/src/resolved/behavior.rs
+++ b/rmk-config/src/resolved/behavior.rs
@@ -18,7 +18,7 @@ pub struct OneShot {
 pub struct Combos {
     pub combos: Vec<Combo>,
     pub timeout_ms: Option<u64>,
-    pub require_prior_idle_ms: Option<u64>,
+    pub prior_idle_time_ms: Option<u64>,
 }
 
 pub struct Combo {
@@ -117,7 +117,7 @@ impl crate::KeyboardTomlConfig {
                 })
                 .collect(),
             timeout_ms: c.timeout.map(|t| t.0),
-            require_prior_idle_ms: c.require_prior_idle_ms,
+            prior_idle_time_ms: c.prior_idle_time.map(|t| t.0),
         });
 
         let macros = toml_behavior.macros.map(|m| Macros {

--- a/rmk-macro/src/codegen/behavior.rs
+++ b/rmk-macro/src/codegen/behavior.rs
@@ -150,9 +150,9 @@ fn expand_combos(
                 None => quote! {},
             };
 
-            let require_prior_idle = match &combos.require_prior_idle_ms {
+            let prior_idle_time = match &combos.prior_idle_time_ms {
                 Some(millis) => {
-                    quote! { require_prior_idle_ms: ::core::option::Option::Some(::embassy_time::Duration::from_millis(#millis)), }
+                    quote! { prior_idle_time: ::core::option::Option::Some(::embassy_time::Duration::from_millis(#millis)), }
                 }
                 None => quote! {},
             };
@@ -170,7 +170,7 @@ fn expand_combos(
                         })
                     },
                     #timeout
-                    #require_prior_idle
+                    #prior_idle_time
                     ..Default::default()
                 }
             }

--- a/rmk-macro/src/codegen/behavior.rs
+++ b/rmk-macro/src/codegen/behavior.rs
@@ -150,6 +150,13 @@ fn expand_combos(
                 None => quote! {},
             };
 
+            let require_prior_idle = match &combos.require_prior_idle_ms {
+                Some(millis) => {
+                    quote! { require_prior_idle_ms: ::core::option::Option::Some(::embassy_time::Duration::from_millis(#millis)), }
+                }
+                None => quote! {},
+            };
+
             quote! {
                 ::rmk::config::CombosConfig {
                     combos: {
@@ -163,6 +170,7 @@ fn expand_combos(
                         })
                     },
                     #timeout
+                    #require_prior_idle
                     ..Default::default()
                 }
             }

--- a/rmk/src/config/behavior.rs
+++ b/rmk/src/config/behavior.rs
@@ -84,6 +84,9 @@ pub struct OneShotModifiersConfig {
 pub struct CombosConfig {
     pub combos: [Option<Combo>; COMBO_MAX_NUM],
     pub timeout: Duration,
+    /// Cooldown after any key press before a combo can start recording.
+    /// `None` = no idle check (backward compatible). Equivalent to ZMK `require-prior-idle-ms`.
+    pub require_prior_idle_ms: Option<Duration>,
 }
 
 impl Default for CombosConfig {
@@ -91,6 +94,7 @@ impl Default for CombosConfig {
         Self {
             timeout: Duration::from_millis(50),
             combos: core::array::from_fn(|_| None),
+            require_prior_idle_ms: None,
         }
     }
 }

--- a/rmk/src/config/behavior.rs
+++ b/rmk/src/config/behavior.rs
@@ -86,7 +86,7 @@ pub struct CombosConfig {
     pub timeout: Duration,
     /// Cooldown after any key press before a combo can start recording.
     /// `None` = no idle check (backward compatible). Equivalent to ZMK `require-prior-idle-ms`.
-    pub require_prior_idle_ms: Option<Duration>,
+    pub prior_idle_time: Option<Duration>,
 }
 
 impl Default for CombosConfig {
@@ -94,7 +94,7 @@ impl Default for CombosConfig {
         Self {
             timeout: Duration::from_millis(50),
             combos: core::array::from_fn(|_| None),
-            require_prior_idle_ms: None,
+            prior_idle_time: None,
         }
     }
 }

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1027,21 +1027,32 @@ impl<'a> Keyboard<'a> {
                 return (None, true);
             }
         }
+        // Combo idle cooldown: skip combo recording if within idle window
+        // Equivalent to ZMK's require-prior-idle-ms. Key still dispatches normally.
+        let skip_combo = event.pressed
+            && self
+                .keymap
+                .combo_require_prior_idle()
+                .is_some_and(|idle_time| self.last_press_time.elapsed() < idle_time);
 
-        let max_size_of_updated_combo = self.keymap.with_combos_mut(|combos| {
-            combos
-                .iter_mut()
-                .filter_map(|c| c.as_mut())
-                .map(|c| {
-                    if c.update(key_action, event, current_layer) {
-                        info!("Updated combo: {:?}", c);
-                        c.size()
-                    } else {
-                        0
-                    }
-                })
-                .max()
-        });
+        let max_size_of_updated_combo = if skip_combo {
+            None
+        } else {
+            self.keymap.with_combos_mut(|combos| {
+                combos
+                    .iter_mut()
+                    .filter_map(|c| c.as_mut())
+                    .map(|c| {
+                        if c.update(key_action, event, current_layer) {
+                            info!("Updated combo: {:?}", c);
+                            c.size()
+                        } else {
+                            0
+                        }
+                    })
+                    .max()
+            })
+        };
 
         if event.pressed
             && let Some(max_size) = max_size_of_updated_combo

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1032,7 +1032,7 @@ impl<'a> Keyboard<'a> {
         let skip_combo = event.pressed
             && self
                 .keymap
-                .combo_require_prior_idle()
+                .combo_prior_idle_time()
                 .is_some_and(|idle_time| self.last_press_time.elapsed() < idle_time);
 
         let max_size_of_updated_combo = if skip_combo {

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -504,6 +504,10 @@ impl<'a> KeyMap<'a> {
         self.inner.borrow().behavior.combo.timeout
     }
 
+    pub(crate) fn combo_require_prior_idle(&self) -> Option<Duration> {
+        self.inner.borrow().behavior.combo.require_prior_idle_ms
+    }
+
     pub(crate) fn one_shot_timeout(&self) -> Duration {
         self.inner.borrow().behavior.one_shot.timeout
     }

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -504,8 +504,8 @@ impl<'a> KeyMap<'a> {
         self.inner.borrow().behavior.combo.timeout
     }
 
-    pub(crate) fn combo_require_prior_idle(&self) -> Option<Duration> {
-        self.inner.borrow().behavior.combo.require_prior_idle_ms
+    pub(crate) fn combo_prior_idle_time(&self) -> Option<Duration> {
+        self.inner.borrow().behavior.combo.prior_idle_time
     }
 
     pub(crate) fn one_shot_timeout(&self) -> Duration {

--- a/rmk/tests/keyboard_combo_test.rs
+++ b/rmk/tests/keyboard_combo_test.rs
@@ -75,6 +75,7 @@ pub fn get_combos_config() -> CombosConfig {
             None,
         ],
         timeout: Duration::from_millis(100),
+        require_prior_idle_ms: None,
     }
 }
 
@@ -322,6 +323,7 @@ fn test_taphold_with_combo() {
                         ))), None, None, None, None, None, None, None
                     ],
                     timeout: Duration::from_millis(50),
+                    require_prior_idle_ms: None,
                 },
                 ..Default::default()
             };
@@ -364,6 +366,7 @@ fn test_re_press_combo_key_while_triggered_does_not_leak_to_hid() {
             None,
         ],
         timeout: Duration::from_millis(40),
+        require_prior_idle_ms: None,
     };
     key_sequence_test! {
         keyboard: create_test_keyboard_with_config(BehaviorConfig {
@@ -420,6 +423,7 @@ fn test_overlapping_triggered_combos_release_all_outputs() {
             None,
         ],
         timeout: Duration::from_millis(40),
+        require_prior_idle_ms: None,
     };
     key_sequence_test! {
         keyboard: create_test_keyboard_with_config(BehaviorConfig {

--- a/rmk/tests/keyboard_combo_test.rs
+++ b/rmk/tests/keyboard_combo_test.rs
@@ -75,7 +75,7 @@ pub fn get_combos_config() -> CombosConfig {
             None,
         ],
         timeout: Duration::from_millis(100),
-        require_prior_idle_ms: None,
+        prior_idle_time: None,
     }
 }
 
@@ -323,7 +323,7 @@ fn test_taphold_with_combo() {
                         ))), None, None, None, None, None, None, None
                     ],
                     timeout: Duration::from_millis(50),
-                    require_prior_idle_ms: None,
+                    prior_idle_time: None,
                 },
                 ..Default::default()
             };
@@ -366,7 +366,7 @@ fn test_re_press_combo_key_while_triggered_does_not_leak_to_hid() {
             None,
         ],
         timeout: Duration::from_millis(40),
-        require_prior_idle_ms: None,
+        prior_idle_time: None,
     };
     key_sequence_test! {
         keyboard: create_test_keyboard_with_config(BehaviorConfig {
@@ -423,7 +423,7 @@ fn test_overlapping_triggered_combos_release_all_outputs() {
             None,
         ],
         timeout: Duration::from_millis(40),
-        require_prior_idle_ms: None,
+        prior_idle_time: None,
     };
     key_sequence_test! {
         keyboard: create_test_keyboard_with_config(BehaviorConfig {

--- a/rmk/tests/keyboard_morse_hold_on_other_press_test.rs
+++ b/rmk/tests/keyboard_morse_hold_on_other_press_test.rs
@@ -78,6 +78,7 @@ fn create_hold_on_other_key_press_keyboard_with_combo() -> Keyboard<'static> {
                 None,
             ],
             timeout: Duration::from_millis(50),
+            require_prior_idle_ms: None,
         },
         ..BehaviorConfig::default()
     })

--- a/rmk/tests/keyboard_morse_hold_on_other_press_test.rs
+++ b/rmk/tests/keyboard_morse_hold_on_other_press_test.rs
@@ -78,7 +78,7 @@ fn create_hold_on_other_key_press_keyboard_with_combo() -> Keyboard<'static> {
                 None,
             ],
             timeout: Duration::from_millis(50),
-            require_prior_idle_ms: None,
+            prior_idle_time: None,
         },
         ..BehaviorConfig::default()
     })

--- a/rmk/tests/keyboard_morse_hrm_test.rs
+++ b/rmk/tests/keyboard_morse_hrm_test.rs
@@ -87,7 +87,7 @@ fn create_hrm_keyboard_with_combo() -> Keyboard<'static> {
                     None,
                 ],
                 timeout: Duration::from_millis(50),
-                require_prior_idle_ms: None,
+                prior_idle_time: None,
             },
             ..BehaviorConfig::default()
         },

--- a/rmk/tests/keyboard_morse_hrm_test.rs
+++ b/rmk/tests/keyboard_morse_hrm_test.rs
@@ -87,6 +87,7 @@ fn create_hrm_keyboard_with_combo() -> Keyboard<'static> {
                     None,
                 ],
                 timeout: Duration::from_millis(50),
+                require_prior_idle_ms: None,
             },
             ..BehaviorConfig::default()
         },

--- a/rmk/tests/keyboard_morse_permissive_hold_test.rs
+++ b/rmk/tests/keyboard_morse_permissive_hold_test.rs
@@ -72,7 +72,7 @@ fn create_permissive_hold_keyboard_with_combo() -> Keyboard<'static> {
                 None,
             ],
             timeout: Duration::from_millis(50),
-            require_prior_idle_ms: None,
+            prior_idle_time: None,
         },
         ..BehaviorConfig::default()
     })

--- a/rmk/tests/keyboard_morse_permissive_hold_test.rs
+++ b/rmk/tests/keyboard_morse_permissive_hold_test.rs
@@ -72,6 +72,7 @@ fn create_permissive_hold_keyboard_with_combo() -> Keyboard<'static> {
                 None,
             ],
             timeout: Duration::from_millis(50),
+            require_prior_idle_ms: None,
         },
         ..BehaviorConfig::default()
     })

--- a/rmk/tests/keyboard_morse_test.rs
+++ b/rmk/tests/keyboard_morse_test.rs
@@ -733,6 +733,7 @@ fn test_morse_with_combo() {
                         ))), None, None, None, None, None, None, None
                     ],
                     timeout: Duration::from_millis(50),
+                    require_prior_idle_ms: None,
                 },
                 ..BehaviorConfig::default()
             }),
@@ -765,6 +766,7 @@ fn test_morse_with_combo_2() {
                         ))), None, None, None, None, None, None, None
                     ],
                     timeout: Duration::from_millis(50),
+                    require_prior_idle_ms: None,
                 },
                 ..BehaviorConfig::default()
             }),

--- a/rmk/tests/keyboard_morse_test.rs
+++ b/rmk/tests/keyboard_morse_test.rs
@@ -733,7 +733,7 @@ fn test_morse_with_combo() {
                         ))), None, None, None, None, None, None, None
                     ],
                     timeout: Duration::from_millis(50),
-                    require_prior_idle_ms: None,
+                    prior_idle_time: None,
                 },
                 ..BehaviorConfig::default()
             }),
@@ -766,7 +766,7 @@ fn test_morse_with_combo_2() {
                         ))), None, None, None, None, None, None, None
                     ],
                     timeout: Duration::from_millis(50),
-                    require_prior_idle_ms: None,
+                    prior_idle_time: None,
                 },
                 ..BehaviorConfig::default()
             }),


### PR DESCRIPTION
Added a configurable cooldown window (require_prior_idle_ms) that prevents combo recording when a key is pressed within the idle period after the previous key. This is equivalent to ZMK's per-combo require-prior-idle-ms, but implemented as a global setting under [behavior.combo].

Tested on nrf52840_split with require_prior_idle_ms = 150 — fast typing no longer triggers combo false-positives, and keystrokes are never swallowed.

When a key press falls within the idle window, combo update is skipped while the key still dispatches normally — fast typists won't lose keystrokes, only combo false-positives are prevented.

Configuration example:
  [behavior.combo]
  require_prior_idle_ms = 150  # 150ms cooldown

Default is no cooldown (backward compatible).