### PR TITLE
fix delayed modifier oled updates

### DIFF
--- a/rmk/src/display/mod.rs
+++ b/rmk/src/display/mod.rs
@@ -372,6 +372,7 @@ where
 
     async fn on_modifier_event(&mut self, event: ModifierEvent) {
         self.ctx.modifiers = event.modifier;
+        self.render().await;
     }
 
     async fn on_sleep_state_event(&mut self, event: SleepStateEvent) {


### PR DESCRIPTION
The symptom I would see is that when I hit shift, there was no change on press, but the icon was underlined on release. The next keypress would release the underline.