### PR TITLE
fix(config): serde default for CombosConfig.combos

### DIFF
--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -627,6 +627,7 @@ pub struct OneShotModifiersConfig {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct CombosConfig {
+    #[serde(default)]
     pub combos: Vec<ComboConfig>,
     pub timeout: Option<DurationMillis>,
     pub prior_idle_time: Option<DurationMillis>,


### PR DESCRIPTION
I don't have combos defined in my `keyboard.toml`, so without this, a `[behavior.combo]` section that only sets timeout or prior_idle_time (no combos defined) fails to deserialise with "missing configuration field behavior.combo.combos".