### PR TITLE
fix: flush buffered keys after early-fired morse tap

### DIFF
--- a/docs/docs/main/docs/configuration/behavior.md
+++ b/docs/docs/main/docs/configuration/behavior.md
@@ -233,8 +233,8 @@ A profile contains the following fields:
   - `hold_on_other_press`: Enables hold-on-other-key-press mode. When enabled, hold action will be triggered immediately when any other non-tap-hold key is pressed while a tap-hold key is being held. This provides faster modifier activation without waiting for the timeout. Defaults to `false`.
   - `normal_mode` : this is the default mode, when nor the `permissive_hold` nor the `hold_on_other_press` is set.
 
-- `hold_timeout`: Defines the duration a tap-hold key must be pressed to determine hold behavior. If tap-hold key is released within this time, the key is recognized as a "tap". Holding it beyond this duration triggers the "hold" action. Defaults to 250ms.
-- `gap_timeout`: Defines the duration a tap-hold key must be released to terminate a morse sequence. Defaults to 250ms. Note that only morse and tap-dance needs this setting, simple tap-hold does not.
+- `hold_timeout`: Defines the duration a tap-hold key must be pressed to determine hold behavior. If tap-hold key is released within this time, the key is recognized as a "tap". Holding it beyond this duration triggers the "hold" action when that hold pattern is final; if a longer configured morse pattern can still continue from the hold, RMK keeps the morse key unresolved until the sequence is completed. Defaults to 250ms.
+- `gap_timeout`: Defines the duration a tap-hold key must be released to terminate a morse sequence. Buffered non-morse keys remain behind unresolved morse keys until the sequence resolves, preserving typing order during rollovers. Defaults to 250ms. Note that only morse and tap-dance needs this setting, simple tap-hold does not.
 
 #### Default profile for Morse/TapDance/TapHold
 

--- a/rmk/src/keyboard/morse.rs
+++ b/rmk/src/keyboard/morse.rs
@@ -47,15 +47,9 @@ impl<'a> Keyboard<'a> {
             _ => unreachable!(),
         };
 
-        // If there's still morse key in the held buffer, don't fire normal keys
-        // FIXME? is |Holding needed here?
-        if self
-            .held_buffer
-            .keys
-            .iter()
-            .any(|k| k.action.is_morse() && matches!(k.state, KeyState::Pressed(_)))
-        {
-            return; //?
+        // If there's still an unresolved morse key in the held buffer, don't fire normal keys.
+        if self.has_unresolved_morse_key() {
+            return;
         }
 
         self.fire_held_non_morse_keys().await;
@@ -172,6 +166,10 @@ impl<'a> Keyboard<'a> {
                                 if let Some(k) = self.held_buffer.find_pos_mut(event.pos) {
                                     k.state = KeyState::EarlyFired(pattern);
                                 }
+
+                                if !self.has_unresolved_morse_key() {
+                                    self.fire_held_non_morse_keys().await;
+                                }
                             }
                         }
                     }
@@ -233,6 +231,16 @@ impl<'a> Keyboard<'a> {
         }
 
         self.held_buffer.keys.sort_unstable_by_key(|k| k.timeout_time);
+    }
+
+    fn has_unresolved_morse_key(&self) -> bool {
+        self.held_buffer.keys.iter().any(|k| {
+            k.action.is_morse()
+                && matches!(
+                    k.state,
+                    KeyState::Pressed(_) | KeyState::Holding(_) | KeyState::Released(_)
+                )
+        })
     }
 
     pub fn action_from_pattern(keymap: &KeyMap, keyAction: &KeyAction, pattern: MorsePattern) -> Action {

--- a/rmk/tests/keyboard_morse_tap_dance_test.rs
+++ b/rmk/tests/keyboard_morse_tap_dance_test.rs
@@ -3,13 +3,13 @@ pub mod common;
 
 use embassy_time::Duration;
 use heapless::Vec;
-use rmk::config::{BehaviorConfig, MorsesConfig, PositionalConfig};
+use rmk::config::{BehaviorConfig, Hand, MorsesConfig, PositionalConfig};
 use rmk::keyboard::Keyboard;
 use rmk::types::action::{Action, KeyAction};
 use rmk::types::keycode::{HidKeyCode, KeyCode};
 use rmk::types::modifier::ModifierCombination;
-use rmk::types::morse::{Morse, MorseMode, MorseProfile};
-use rmk::{k, td};
+use rmk::types::morse::{HOLD, Morse, MorseMode, MorseProfile};
+use rmk::{a, k, td};
 
 use crate::common::wrap_keymap;
 
@@ -139,6 +139,157 @@ fn create_permissive_hold_keyboard() -> Keyboard<'static> {
 
     let behavior_config: &'static mut BehaviorConfig = Box::leak(Box::new(behavior_config));
     let per_key_config: &'static PositionalConfig<1, 4> = Box::leak(Box::new(PositionalConfig::default()));
+    Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
+}
+
+fn key_action(keycode: HidKeyCode) -> Action {
+    Action::Key(KeyCode::Hid(keycode))
+}
+
+fn create_timeout_blocking_morse_keyboard() -> Keyboard<'static> {
+    let keymap = [
+        [[td!(0), k!(E), td!(1), td!(2)]],
+        [[k!(Kp1), k!(Kp2), k!(Kp3), k!(Kp4)]],
+    ];
+
+    let mut hold_continues_morse = Morse::default();
+    let _ = hold_continues_morse.actions.insert(HOLD, key_action(HidKeyCode::B));
+    let _ = hold_continues_morse
+        .actions
+        .insert(HOLD.followed_by_hold(), key_action(HidKeyCode::C));
+
+    let behavior_config = BehaviorConfig {
+        morse: MorsesConfig {
+            enable_flow_tap: false,
+            default_profile: MorseProfile::new(
+                Some(false),
+                Some(MorseMode::PermissiveHold),
+                Some(250u16),
+                Some(250u16),
+            ),
+            morses: Vec::from_slice(&[
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::A),
+                    key_action(HidKeyCode::B),
+                    key_action(HidKeyCode::C),
+                    key_action(HidKeyCode::D),
+                    MorseProfile::const_default(),
+                ),
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::X),
+                    key_action(HidKeyCode::Y),
+                    key_action(HidKeyCode::Z),
+                    key_action(HidKeyCode::Space),
+                    MorseProfile::const_default(),
+                ),
+                hold_continues_morse,
+            ])
+            .unwrap(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let behavior_config: &'static mut BehaviorConfig = Box::leak(Box::new(behavior_config));
+    let per_key_config: &'static PositionalConfig<1, 4> = Box::leak(Box::new(PositionalConfig::default()));
+    Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
+}
+
+fn create_dusk_rollover_keyboard(use_tap_dance_c: bool) -> Keyboard<'static> {
+    let hrm_profile = MorseProfile::new(Some(true), Some(MorseMode::PermissiveHold), Some(400u16), None);
+    let fh_profile = MorseProfile::new(None, Some(MorseMode::HoldOnOtherPress), None, None);
+    let ph_profile = MorseProfile::new(None, Some(MorseMode::PermissiveHold), None, None);
+    let th_profile = MorseProfile::new(None, Some(MorseMode::Normal), None, None);
+
+    let c_action = if use_tap_dance_c {
+        td!(6)
+    } else {
+        KeyAction::TapHold(key_action(HidKeyCode::C), Action::LayerOn(3), hrm_profile)
+    };
+
+    #[rustfmt::skip]
+    let dusk_layer = [
+        [k!(B),     k!(F), k!(L), k!(P), k!(Q),     k!(Quote),     k!(W),     k!(O),     k!(U),   k!(Y)],
+        [td!(2),    td!(3), td!(4), td!(5), k!(K),  k!(J),         c_action,  td!(7),    td!(8),  td!(9)],
+        [k!(X),     k!(V), k!(M), k!(D), k!(Z),     k!(Minus),     k!(G),     k!(Comma), k!(Dot), k!(Slash)],
+        [a!(No),    a!(No), td!(0), KeyAction::TapHold(key_action(HidKeyCode::R), Action::LayerOn(1), ph_profile), k!(Enter), k!(Backspace), td!(1), k!(Grave), a!(No), a!(No)],
+    ];
+    let no_layer = [[a!(No); 10]; 4];
+    let keymap = [dusk_layer, no_layer, no_layer, no_layer, no_layer];
+
+    let behavior_config = BehaviorConfig {
+        morse: MorsesConfig {
+            enable_flow_tap: true,
+            prior_idle_time: Duration::from_millis(120),
+            default_profile: MorseProfile::new(None, Some(MorseMode::Normal), Some(250u16), Some(250u16)),
+            // The test build's MORSE_MAX_NUM is 8; only TD(0)..TD(6) is needed for this rollover.
+            morses: Vec::from_slice(&[
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::Tab),
+                    Action::LayerOn(4),
+                    key_action(HidKeyCode::Tab),
+                    Action::No,
+                    th_profile,
+                ),
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::Space),
+                    Action::LayerOn(2),
+                    key_action(HidKeyCode::Space),
+                    Action::No,
+                    fh_profile,
+                ),
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::N),
+                    Action::Modifier(ModifierCombination::LSHIFT),
+                    key_action(HidKeyCode::N),
+                    Action::No,
+                    hrm_profile,
+                ),
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::S),
+                    Action::Modifier(ModifierCombination::LCTRL),
+                    key_action(HidKeyCode::S),
+                    Action::No,
+                    hrm_profile,
+                ),
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::H),
+                    Action::Modifier(ModifierCombination::LGUI),
+                    key_action(HidKeyCode::H),
+                    Action::No,
+                    hrm_profile,
+                ),
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::T),
+                    Action::LayerOn(3),
+                    key_action(HidKeyCode::T),
+                    Action::No,
+                    hrm_profile,
+                ),
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::C),
+                    Action::LayerOn(3),
+                    key_action(HidKeyCode::C),
+                    Action::No,
+                    hrm_profile,
+                ),
+            ])
+            .unwrap(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    #[rustfmt::skip]
+    let hand = [
+        [Hand::Left,    Hand::Left,    Hand::Left,    Hand::Left,    Hand::Left,       Hand::Right,     Hand::Right, Hand::Right,     Hand::Right,     Hand::Right],
+        [Hand::Left,    Hand::Left,    Hand::Left,    Hand::Left,    Hand::Left,       Hand::Right,     Hand::Right, Hand::Right,     Hand::Right,     Hand::Right],
+        [Hand::Left,    Hand::Left,    Hand::Left,    Hand::Left,    Hand::Left,       Hand::Right,     Hand::Right, Hand::Right,     Hand::Right,     Hand::Right],
+        [Hand::Unknown, Hand::Unknown, Hand::Bilateral, Hand::Left, Hand::Bilateral,   Hand::Bilateral, Hand::Right, Hand::Bilateral, Hand::Unknown,   Hand::Unknown],
+    ];
+
+    let behavior_config: &'static mut BehaviorConfig = Box::leak(Box::new(behavior_config));
+    let per_key_config: &'static PositionalConfig<4, 10> = Box::leak(Box::new(PositionalConfig::new(hand)));
     Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
 }
 
@@ -548,6 +699,59 @@ fn test_permissive_hold_normal_released_first() {
     };
 }
 
+/// Regression for timeout cleanup: when one morse key times out, buffered normal
+/// keys must still wait behind any other unresolved morse key.
+#[test]
+fn test_timeout_does_not_flush_normal_keys_before_released_morse() {
+    key_sequence_test! {
+        keyboard: create_timeout_blocking_morse_keyboard(),
+        sequence: [
+            [0, 0, true, 10],    // Press TD(0)
+            [0, 1, true, 10],    // Press E, buffered by TD(0)
+            [0, 2, true, 10],    // Press TD(1), also buffered
+            [0, 0, false, 10],   // Release TD(0), now released-but-unresolved
+            [0, 2, false, 300],  // After TD(1) hold timeout and TD(0) gap timeout
+            [0, 1, false, 10],   // Release E
+        ],
+        expected_reports: [
+            // TD(1) hold timeout fires first, but E must remain buffered because
+            // TD(0) is still waiting for its gap timeout.
+            [0, [kc_to_u8!(Y), 0, 0, 0, 0, 0]],
+            // TD(0) gap timeout resolves as tap=A.
+            [0, [kc_to_u8!(Y), kc_to_u8!(A), 0, 0, 0, 0]],
+            [0, [kc_to_u8!(Y), 0, 0, 0, 0, 0]],
+            // Only after TD(0) resolves may buffered E fire.
+            [0, [kc_to_u8!(Y), kc_to_u8!(E), 0, 0, 0, 0]],
+            // Release TD(1)'s hold, then release E.
+            [0, [0, kc_to_u8!(E), 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+        ]
+    };
+}
+
+/// Regression for timeout cleanup: a morse key that reached hold timeout can
+/// still be unresolved if a longer hold pattern exists.
+#[test]
+fn test_timeout_does_not_flush_normal_keys_before_holding_morse() {
+    key_sequence_test! {
+        keyboard: create_timeout_blocking_morse_keyboard(),
+        sequence: [
+            [0, 3, true, 10],    // Press TD(2)
+            [0, 1, true, 10],    // Press E, buffered by TD(2)
+            [0, 3, false, 300],  // Release TD(2) after its unresolved hold timeout
+            [0, 1, false, 300],  // Release E after TD(2)'s gap timeout
+        ],
+        expected_reports: [
+            // TD(2)'s hold timeout enters Holding(HOLD), but HOLD can still
+            // continue to hold-hold, so E must stay buffered.
+            [0, [kc_to_u8!(B), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(E), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+        ]
+    };
+}
+
 /// Test that after early fire, re-pressing and release again to produce two taps.
 ///
 /// Scenario: Press td!(1), release quickly (early fire triggers E),
@@ -687,6 +891,94 @@ fn test_flow_tapped_tap_then_hold_after_tap() {
             // RShift would mean the continuation breadcrumb was lost.
             [0, [kc_to_u8!(Backspace), 0, 0, 0, 0, 0]],
             [0, [0, 0, 0, 0, 0, 0]]
+        ]
+    };
+}
+
+/// Regression test for the user's `dusk` layout rollover while typing "could".
+///
+/// C is configured as `TD(6)` with tap=C and hold_after_tap=C. The physical
+/// rollover is C down, O down, C up, U down, O up, U up. C must not allow U
+/// to overtake the already-held O.
+#[test]
+fn test_dusk_tap_dance_cou_rollover_keeps_o_before_u() {
+    key_sequence_test! {
+        keyboard: create_dusk_rollover_keyboard(true),
+        sequence: [
+            [1, 6, true, 150],  // Press C / TD(6), after prior idle time
+            [0, 7, true, 30],   // Press O while C is held
+            [1, 6, false, 30],  // Release C before U is pressed
+            [0, 8, true, 30],   // Press U while O is still held
+            [0, 7, false, 30],  // Release O
+            [0, 8, false, 30],  // Release U
+            [0, 2, true, 30],   // Press L
+            [0, 2, false, 30],  // Release L
+            [2, 3, true, 30],   // Press D
+            [2, 3, false, 30],  // Release D
+        ],
+        expected_reports: [
+            [0, [kc_to_u8!(C), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(O), 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(O), kc_to_u8!(U), 0, 0, 0, 0]],
+            [0, [0, kc_to_u8!(U), 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(L), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(D), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+        ]
+    };
+}
+
+/// Same C/O/U rollover, but U is delayed past the early-fired C gap timeout.
+/// This documents that the buffered O is flushed correctly once the gap timer
+/// expires before the next key arrives.
+#[test]
+fn test_dusk_tap_dance_cou_rollover_after_gap_timeout() {
+    key_sequence_test! {
+        keyboard: create_dusk_rollover_keyboard(true),
+        sequence: [
+            [1, 6, true, 150],  // Press C / TD(6), after prior idle time
+            [0, 7, true, 30],   // Press O while C is held
+            [1, 6, false, 30],  // Release C
+            [0, 8, true, 300],  // Press U after C's 250ms gap timeout
+            [0, 7, false, 30],  // Release O
+            [0, 8, false, 30],  // Release U
+        ],
+        expected_reports: [
+            [0, [kc_to_u8!(C), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(O), 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(O), kc_to_u8!(U), 0, 0, 0, 0]],
+            [0, [0, kc_to_u8!(U), 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+        ]
+    };
+}
+
+/// Control case for the user's observation: replacing `TD(6)` with the
+/// equivalent tap-hold action keeps the text order correct for the same
+/// physical rollover.
+#[test]
+fn test_dusk_tap_hold_cou_rollover_keeps_o_before_u() {
+    key_sequence_test! {
+        keyboard: create_dusk_rollover_keyboard(false),
+        sequence: [
+            [1, 6, true, 150],  // Press C / LT(3,C,HRM), after prior idle time
+            [0, 7, true, 30],   // Press O while C is held
+            [1, 6, false, 30],  // Release C before U is pressed
+            [0, 8, true, 30],   // Press U while O is still held
+            [0, 7, false, 30],  // Release O
+            [0, 8, false, 30],  // Release U
+        ],
+        expected_reports: [
+            [0, [kc_to_u8!(C), 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(C), kc_to_u8!(O), 0, 0, 0, 0]],
+            [0, [0, kc_to_u8!(O), 0, 0, 0, 0]],
+            [0, [kc_to_u8!(U), kc_to_u8!(O), 0, 0, 0, 0]],
+            [0, [kc_to_u8!(U), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
         ]
     };
 }


### PR DESCRIPTION
When a tap-dance/morse key early-fires its tap action, keep the EarlyFired breadcrumb for hold-after-tap continuation but flush buffered non-morse keys if no unresolved morse key still blocks them.

Add a dusk-layout C/O/U rollover regression that reproduces the prior C-U-O ordering, plus gap-timeout and tap-hold controls.

This fixes #855