### PR TITLE
feat: embed version and git hash in USB serial number

### DIFF
--- a/docs/docs/main/docs/configuration/keyboard_device.mdx
+++ b/docs/docs/main/docs/configuration/keyboard_device.mdx
@@ -20,7 +20,7 @@ vendor_id = 0x4c4b                # USB vendor ID (16-bit hex)
 product_id = 0x4643               # USB product ID (16-bit hex)
 manufacturer = "YourName"         # (Optional) Manufacturer string
 product_name = "KeyboardName"     # (Optional) Keyboard name, if not set, it will be same as `name` field
-serial_number = "vial:f64c2b3c"   # (Optional) Serial number of the keyboard
+serial_number = "my-firmware-v1"  # (Optional) Serial number; defaults to rmk:<version> (with a vial: prefix for Vial builds)
 chip = "nrf52840"                 # Target microcontroller
 usb_enable = true                 # (Optional) Enable USB functionality. If omitted, RMK uses the board/chip default.
 ```
@@ -29,20 +29,22 @@ usb_enable = true                 # (Optional) Enable USB functionality. If omit
 <Tab label={<Rust />}>
 
 ```rust title="main.rs"
+use rmk::config::{DeviceConfig, RmkConfig};
 
 let keyboard_device_config = DeviceConfig {
     vid: 0x4c4b,
     pid: 0x4643,
     manufacturer: "Haobo",
     product_name: "RMK Keyboard",
-    serial_number: "vial:f64c2b3c:000001",
+    // Omit serial_number to use RMK's default version stamp (Vial builds get the
+    // vial: marker automatically).
+    ..Default::default()
 };
 
 let rmk_config = RmkConfig {
     device_config: keyboard_device_config,
     // .. Other configurations
 };
-
 ```
 
 </Tab>
@@ -50,8 +52,27 @@ let rmk_config = RmkConfig {
 
 ::: info
 
-To make your keyboard to be recognized by Vial, the `serial_number` shall start with
-`vial:f64c2b3c:`
+If `serial_number` is omitted, RMK embeds a version stamp automatically. For Vial builds (the
+default), this is `vial:f64c2b3c;rmk:<version>`, which lets Vial discover the keyboard without a
+hardcoded serial override. Non-Vial builds use `rmk:<version>` without the Vial marker. The Vial
+marker comes first because BLE's serial number characteristic is length limited, so a trailing
+marker can be truncated away.
+
+:::
+
+::: tip Overriding the serial number
+
+Set `serial_number` explicitly in `DeviceConfig` to use your own value instead of the RMK default.
+For Vial to discover the keyboard, the value must start with `vial:f64c2b3c`:
+
+```rust title="main.rs"
+use rmk::config::DeviceConfig;
+
+let keyboard_device_config = DeviceConfig {
+    serial_number: "vial:f64c2b3c;my-firmware:1.0.0",
+    ..DeviceConfig::default()
+};
+```
 
 :::
 
@@ -106,3 +127,4 @@ support must be explicitly disabled:
 chip = "nrf52832"
 usb_enable = false  # Required for chips without USB
 ```
+

--- a/examples/use_rust/nrf52832_ble/src/main.rs
+++ b/examples/use_rust/nrf52832_ble/src/main.rs
@@ -126,7 +126,7 @@ async fn main(spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "Haobo",
         product_name: "RMK Keyboard",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (1, 1)]);
     let storage_config = StorageConfig {

--- a/examples/use_rust/nrf52840_ble/src/main.rs
+++ b/examples/use_rust/nrf52840_ble/src/main.rs
@@ -164,7 +164,7 @@ async fn main(spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "Haobo",
         product_name: "RMK Keyboard",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, UNLOCK_KEYS);
     let ble_battery_config = BleBatteryConfig::new(Some(is_charging_pin), true, None, false);

--- a/examples/use_rust/nrf52840_ble_split/src/central.rs
+++ b/examples/use_rust/nrf52840_ble_split/src/central.rs
@@ -171,7 +171,7 @@ async fn main(spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "Haobo",
         product_name: "RMK Keyboard",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (1, 1)]);
     let ble_battery_config = BleBatteryConfig::new(Some(is_charging_pin), true, None, false);

--- a/examples/use_rust/nrf52840_ble_split_dongle/src/central.rs
+++ b/examples/use_rust/nrf52840_ble_split_dongle/src/central.rs
@@ -172,7 +172,7 @@ async fn main(spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "Haobo",
         product_name: "RMK Keyboard",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (1, 1)]);
     let ble_battery_config = BleBatteryConfig::new(Some(is_charging_pin), true, None, false);

--- a/examples/use_rust/nrf54l15_ble/src/main.rs
+++ b/examples/use_rust/nrf54l15_ble/src/main.rs
@@ -171,7 +171,7 @@ async fn main(spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "Haobo",
         product_name: "RMK nRF54L15",
-        serial_number: "vial:f64c2b3c:000055",
+        ..DeviceConfig::default()
     };
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, UNLOCK_KEYS);
     let storage_config = StorageConfig {

--- a/examples/use_rust/nrf54lm20_ble/src/main.rs
+++ b/examples/use_rust/nrf54lm20_ble/src/main.rs
@@ -187,7 +187,7 @@ async fn main(spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "Haobo",
         product_name: "RMK nRF54LM20A",
-        serial_number: "vial:f64c2b3c:000054",
+        ..DeviceConfig::default()
     };
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, UNLOCK_KEYS);
     let storage_config = StorageConfig {

--- a/examples/use_rust/pi_pico_w_ble/src/main.rs
+++ b/examples/use_rust/pi_pico_w_ble/src/main.rs
@@ -114,7 +114,7 @@ async fn main(spawner: Spawner) {
         pid: 0x464c,
         manufacturer: "Haobo",
         product_name: "RMK PicoW",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
 
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (1, 1)]);

--- a/examples/use_rust/pi_pico_w_ble_split/src/central.rs
+++ b/examples/use_rust/pi_pico_w_ble_split/src/central.rs
@@ -117,7 +117,7 @@ async fn main(spawner: Spawner) {
         pid: 0x464c,
         manufacturer: "Haobo",
         product_name: "RMK PicoW Split",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
 
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (1, 1)]);

--- a/examples/use_rust/py32f07x/src/main.rs
+++ b/examples/use_rust/py32f07x/src/main.rs
@@ -57,7 +57,7 @@ async fn main(_spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "RMK & py32-rs",
         product_name: "RMK Keyboard",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
 
     let _vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (1, 1)]);

--- a/examples/use_rust/rp2040/src/main.rs
+++ b/examples/use_rust/rp2040/src/main.rs
@@ -58,7 +58,7 @@ async fn main(_spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "Haobo",
         product_name: "RMK Keyboard",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
 
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (1, 1)]);

--- a/examples/use_rust/rp2040_direct_pin/src/main.rs
+++ b/examples/use_rust/rp2040_direct_pin/src/main.rs
@@ -65,7 +65,7 @@ async fn main(_spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "Haobo",
         product_name: "RMK Keyboard",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
 
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (1, 1)]);

--- a/examples/use_rust/rp2040_oled/src/main.rs
+++ b/examples/use_rust/rp2040_oled/src/main.rs
@@ -64,7 +64,7 @@ async fn main(_spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "Haobo",
         product_name: "RMK Keyboard",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
 
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (1, 1)]);

--- a/examples/use_rust/rp2040_split/src/central.rs
+++ b/examples/use_rust/rp2040_split/src/central.rs
@@ -62,7 +62,7 @@ async fn main(_spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "Haobo",
         product_name: "RMK Keyboard",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
 
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (1, 1)]);

--- a/examples/use_rust/rp2040_split_pio/src/central.rs
+++ b/examples/use_rust/rp2040_split_pio/src/central.rs
@@ -59,7 +59,7 @@ async fn main(_spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "Haobo",
         product_name: "RMK Keyboard",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
 
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (1, 1)]);

--- a/examples/use_rust/rp2350/src/main.rs
+++ b/examples/use_rust/rp2350/src/main.rs
@@ -71,7 +71,7 @@ async fn main(_spawner: Spawner) {
         pid: 0x4643,
         manufacturer: "Haobo",
         product_name: "RMK Keyboard",
-        serial_number: "vial:f64c2b3c:000001",
+        ..DeviceConfig::default()
     };
 
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (1, 1)]);

--- a/examples/use_rust/sf32lb52x_ble/src/main.rs
+++ b/examples/use_rust/sf32lb52x_ble/src/main.rs
@@ -164,7 +164,7 @@ async fn main(_spawner: Spawner) {
         pid: 0x4644,
         manufacturer: "RMK & SiFli-rs",
         product_name: "RMK SF32LB52",
-        serial_number: "vial:f64c2b3c:000002",
+        ..DeviceConfig::default()
     };
 
     let vial_config = VialConfig::new(VIAL_KEYBOARD_ID, VIAL_KEYBOARD_DEF, &[(0, 0), (0, 3)]);

--- a/rmk-config/src/resolved/identity.rs
+++ b/rmk-config/src/resolved/identity.rs
@@ -5,7 +5,9 @@ pub struct Identity {
     pub product_id: u16,
     pub manufacturer: String,
     pub product_name: String,
-    pub serial_number: String,
+    /// `None` when `serial_number` is absent from `keyboard.toml`; the codegen will
+    /// substitute `::rmk::config::RMK_BUILD_INFO` so the default is version-stamped.
+    pub serial_number: Option<String>,
 }
 
 impl crate::KeyboardTomlConfig {
@@ -24,10 +26,7 @@ impl crate::KeyboardTomlConfig {
                 .product_name
                 .clone()
                 .unwrap_or_else(|| "RMK Keyboard".to_string()),
-            serial_number: keyboard
-                .serial_number
-                .clone()
-                .unwrap_or_else(|| "vial:f64c2b3c:000001".to_string()),
+            serial_number: keyboard.serial_number.clone(),
         })
     }
 }

--- a/rmk-macro/src/codegen/keyboard_config.rs
+++ b/rmk-macro/src/codegen/keyboard_config.rs
@@ -18,7 +18,10 @@ pub(crate) fn expand_keyboard_info(
     let vid = identity.vendor_id;
     let product_name = identity.product_name.clone();
     let manufacturer = identity.manufacturer.clone();
-    let serial_number = identity.serial_number.clone();
+    let serial_number_tokens = match &identity.serial_number {
+        Some(s) => quote! { #s },
+        None => quote! { ::rmk::config::RMK_BUILD_INFO },
+    };
 
     let num_col = layout.cols as usize;
     let num_row = layout.rows as usize;
@@ -35,7 +38,7 @@ pub(crate) fn expand_keyboard_info(
             pid: #pid,
             manufacturer: #manufacturer,
             product_name: #product_name,
-            serial_number: #serial_number,
+            serial_number: #serial_number_tokens,
         };
     }
 }

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -114,11 +114,16 @@ where
                 },
             )
             .unwrap();
+        // The serial number characteristic is length limited, so truncate at a char
+        // boundary instead of panicking when the configured serial is too long.
+        let mut serial_number_trimmed = heapless::String::new();
+        for c in serial_number.chars() {
+            if serial_number_trimmed.push(c).is_err() {
+                break;
+            }
+        }
         server
-            .set(
-                &server.device_config_service.serial_number,
-                &heapless::String::try_from(serial_number).unwrap(),
-            )
+            .set(&server.device_config_service.serial_number, &serial_number_trimmed)
             .unwrap();
         server
             .set(

--- a/rmk/src/config/device.rs
+++ b/rmk/src/config/device.rs
@@ -13,6 +13,18 @@ pub struct DeviceConfig<'a> {
     pub serial_number: &'a str,
 }
 
+/// Version string embedded in the USB serial number: `rmk:<version>`.
+///
+/// With the `vial` feature it becomes `vial:f64c2b3c;rmk:<version>`. The `vial:` marker comes
+/// first because BLE's serial characteristic is length limited.
+///
+/// Set `DeviceConfig::serial_number` explicitly to override with your own value.
+#[cfg(feature = "vial")]
+pub const RMK_BUILD_INFO: &str = concat!("vial:f64c2b3c;rmk:", env!("CARGO_PKG_VERSION"));
+
+#[cfg(not(feature = "vial"))]
+pub const RMK_BUILD_INFO: &str = concat!("rmk:", env!("CARGO_PKG_VERSION"));
+
 impl Default for DeviceConfig<'_> {
     fn default() -> Self {
         Self {
@@ -20,7 +32,7 @@ impl Default for DeviceConfig<'_> {
             pid: 0x4643,
             manufacturer: "RMK",
             product_name: "RMK Keyboard",
-            serial_number: "vial:f64c2b3c:000001",
+            serial_number: RMK_BUILD_INFO,
         }
     }
 }

--- a/rmk/src/config/mod.rs
+++ b/rmk/src/config/mod.rs
@@ -12,7 +12,7 @@ pub use behavior::{
 };
 #[cfg(feature = "_ble")]
 pub use ble_battery::BleBatteryConfig;
-pub use device::DeviceConfig;
+pub use device::{DeviceConfig, RMK_BUILD_INFO};
 pub use positional::{Hand, PositionalConfig};
 pub use storage::StorageConfig;
 pub use vial::VialConfig;


### PR DESCRIPTION
This PR changes the serial number from the static string (`vial:f64c2b3c:000001`) and replaces it with a build-time stamp of the form `rmk:<version>-<git-hash>` (with or without `vial:...` based on feature flags). Allowing users to know what they have flashed on their devices.

Vial's `util.py` looks for the string, anywhere in the serial. 

Downstream firmware wanting to append their own build info can use `const_format::concatcp!(rmk::config::RMK_BUILD_INFO, ";my-fw:", ...)`