### PR TITLE
Add an option in chip_config.frequenecy to configure CPU clock of ESP32.

### DIFF
--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -513,6 +513,9 @@ pub struct ChipConfig {
     /// DCDC regulator 0 voltage (for nrf52840)
     /// Values: "3V3" or "1V8"
     pub dcdc_reg0_voltage: Option<String>,
+    /// Frequency of the CPU. Currently supported only on
+    /// ESP32 and supports only 160 and 80(which are in MHz)
+    pub frequency: Option<String>
 }
 
 /// Config for lights

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -513,9 +513,9 @@ pub struct ChipConfig {
     /// DCDC regulator 0 voltage (for nrf52840)
     /// Values: "3V3" or "1V8"
     pub dcdc_reg0_voltage: Option<String>,
-    /// Frequency of the CPU. Currently supported only on
-    /// ESP32 and supports only 160 and 80(which are in MHz)
-    pub frequency: Option<String>,
+    /// Frequency of the CPU in MHz Currently supported only on
+    /// ESP32 and supports only 160 and 80
+    pub frequency: Option<f64>,
 }
 
 /// Config for lights

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -515,7 +515,7 @@ pub struct ChipConfig {
     pub dcdc_reg0_voltage: Option<String>,
     /// Frequency of the CPU. Currently supported only on
     /// ESP32 and supports only 160 and 80(which are in MHz)
-    pub frequency: Option<String>
+    pub frequency: Option<String>,
 }
 
 /// Config for lights

--- a/rmk-macro/src/codegen/chip/chip_init.rs
+++ b/rmk-macro/src/codegen/chip/chip_init.rs
@@ -230,7 +230,9 @@ pub(crate) fn chip_init_default(hardware: &Hardware, peripheral_id: Option<usize
                 match &hardware.chip_config.frequency.as_deref() {
                     Some("160") | None => quote! { ::esp_hal::clock::CpuClock::_160MHz },
                     Some("80") => quote! { ::esp_hal::clock::CpuClock::_80MHz },
-                    _ => panic!("Currently only CPU clocks of 160MHz and 80Mhz are supported for ESP32")
+                    _ => panic!(
+                        "Currently only CPU clocks of 160MHz and 80Mhz are supported for ESP32"
+                    ),
                 }
             } else {
                 quote! { ::esp_hal::clock::CpuClock::_160MHz }

--- a/rmk-macro/src/codegen/chip/chip_init.rs
+++ b/rmk-macro/src/codegen/chip/chip_init.rs
@@ -226,16 +226,30 @@ pub(crate) fn chip_init_default(hardware: &Hardware, peripheral_id: Option<usize
         }
         ChipSeries::Esp32 => {
             let ble_addr = get_ble_addr(hardware, peripheral_id);
+            let cpu_clock = if hardware.chip.series == ChipSeries::Esp32 {
+                match &hardware.chip_config.frequency.as_deref() {
+                    Some("160") | None => quote! { ::esp_hal::clock::CpuClock::_160MHz },
+                    Some("80") => quote! { ::esp_hal::clock::CpuClock::_80MHz },
+                    _ => panic!("Currently only CPU clocks of 160MHz and 80Mhz are supported for ESP32")
+                }
+            } else {
+                quote! { ::esp_hal::clock::CpuClock::_160MHz }
+            };
             quote! {
                 ::esp_println::logger::init_logger_from_env();
-                let p = ::esp_hal::init(::esp_hal::Config::default().with_cpu_clock(::esp_hal::clock::CpuClock::max()));
+                let p = ::esp_hal::init(
+                    ::esp_hal::Config::default().with_cpu_clock(
+                        #cpu_clock
+                    )
+                );
                 ::esp_alloc::heap_allocator!(size: 72 * 1024);
                 let timg0 = ::esp_hal::timer::timg::TimerGroup::new(p.TIMG0);
                 let software_interrupt = ::esp_hal::interrupt::software::SoftwareInterruptControl::new(p.SW_INTERRUPT);
                 ::esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
                 let _trng_source = ::esp_hal::rng::TrngSource::new(p.RNG, p.ADC1);
                 let mut rng = ::esp_hal::rng::Trng::try_new().unwrap();
-                let connector = ::esp_radio::ble::controller::BleConnector::new(p.BT, Default::default()).unwrap();
+                let ble_config = ::esp_radio::ble::Config::default();
+                let connector = ::esp_radio::ble::controller::BleConnector::new(p.BT, ble_config).unwrap();
                 let controller: ::bt_hci::controller::ExternalController<_, 64> = ::bt_hci::controller::ExternalController::new(connector);
                 let ble_addr = #ble_addr;
                 let mut host_resources = ::rmk::HostResources::new();
@@ -268,7 +282,7 @@ fn override_chip_config(chip: &ChipModel, item_fn: &ItemFn) -> TokenStream2 {
             let mut p = ::embassy_rp::init(config);
         }),
         ChipSeries::Esp32 => initialization_tokens.extend(quote! {
-            let p = ::esp_hal::init(::esp_hal::Config::default().with_cpu_clock(::esp_hal::clock::CpuClock::max()));
+            let p = ::esp_hal::init(::esp_hal::Config::default());
         }),
     }
 

--- a/rmk-macro/src/codegen/chip/chip_init.rs
+++ b/rmk-macro/src/codegen/chip/chip_init.rs
@@ -227,9 +227,9 @@ pub(crate) fn chip_init_default(hardware: &Hardware, peripheral_id: Option<usize
         ChipSeries::Esp32 => {
             let ble_addr = get_ble_addr(hardware, peripheral_id);
             let cpu_clock = if hardware.chip.series == ChipSeries::Esp32 {
-                match &hardware.chip_config.frequency.as_deref() {
-                    Some("160") | None => quote! { ::esp_hal::clock::CpuClock::_160MHz },
-                    Some("80") => quote! { ::esp_hal::clock::CpuClock::_80MHz },
+                match hardware.chip_config.frequency.as_ref() {
+                    Some(&160.0) | None => quote! { ::esp_hal::clock::CpuClock::_160MHz },
+                    Some(&80.0) => quote! { ::esp_hal::clock::CpuClock::_80MHz },
                     _ => panic!(
                         "Currently only CPU clocks of 160MHz and 80Mhz are supported for ESP32"
                     ),


### PR DESCRIPTION
>Currently it can be only 160 and 80 (values in MHz) as in par with esp-hal. As a note, when configuration of XTAL clock in
> esp-hal has been stabilized, we could also have that to further lower CPU clock to save battery.

The patch is ready for review. However, I think it could be a good idea if `rmk` prints a warning to the console if the chip is not ESP32 yet `frequency` is present.

Cheers!