### PR TITLE
bug: RawMutex not publicly available for users

### DIFF
--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -36,7 +36,7 @@ pub use embassy_futures;
 #[cfg(not(any(cortex_m)))]
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex as RawMutex;
 #[cfg(cortex_m)]
-use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex as RawMutex;
+pub use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex as RawMutex;
 pub use embassy_time;
 pub use futures;
 pub use heapless;


### PR DESCRIPTION
fixes: #875

When using #[event(channel_size = 2)] in user code, RawMutex is used in the expanded macro, but isn’t available to user code.

According to the docs (https://rmk.rs/main/docs/features/event#defining-custom-events) users should be able to use that macro in their code to define custom events.