### PR TITLE
improve run_all! macro to allow for optional trailing comma

### DIFF
--- a/rmk/src/input_device/mod.rs
+++ b/rmk/src/input_device/mod.rs
@@ -78,7 +78,7 @@ pub trait InputDevice: Runnable {
 /// ```
 #[macro_export]
 macro_rules! run_all {
-    ($( $dev:ident ),*) => {{
+    ($( $dev:ident ),* $(,)*) => {{
         use $crate::core_traits::Runnable;
         $crate::join_all!(
             $(


### PR DESCRIPTION
This has been bothering me for way too long now. 
When I am debugging keyboard firmware and delete the last processor in the arguments, I always forget to remove the comma in the line above as well. 

Easy fix, I don't think that has any negative sides. 