### PR TITLE
improve format_all.sh

### DIFF
--- a/scripts/format_all.sh
+++ b/scripts/format_all.sh
@@ -1,7 +1,42 @@
 #!/bin/bash
 
-# Exit on any error
 set -e
+
+format_changed() {
+    if [ -z "$1" ]; then
+        exit 0
+    fi
+    rustfmt +nightly "$@"
+}
+
+# If --touched is passed, only format .rs files changed in the working tree
+if [ "$1" = "--touched" ]; then
+    CHANGED=$(git status --porcelain | awk '/^[? MARC][? MARC] .*\.rs$/ { print $2 }')
+    format_changed $CHANGED
+    exit 0
+fi
+
+# If --touched-branch is passed, only format .rs files changed since branching off main
+if [ "$1" = "--touched-branch" ]; then
+    BASE=$(git merge-base HEAD main 2>/dev/null || true)
+    if [ -z "$BASE" ]; then
+        exit 0
+    fi
+    CHANGED=$(git diff --diff-filter=d --name-only "$BASE" HEAD | grep '\.rs$' || true)
+    format_changed $CHANGED
+    exit 0
+fi
+
+# If --touched-since <ref> is passed, only format .rs files changed since the given ref
+if [ "$1" = "--touched-since" ]; then
+    if [ -z "$2" ]; then
+        echo "Usage: $0 --touched-since <ref>"
+        exit 1
+    fi
+    CHANGED=$(git diff --diff-filter=d --name-only "$2" HEAD | grep '\.rs$' || true)
+    format_changed $CHANGED
+    exit 0
+fi
 
 # Format rmk and rmk-macro
 cd rmk && cargo +nightly fmt && cd ..


### PR DESCRIPTION
adds `--touched` argument, only formats the files that are changed in the working tree. (what you see when `git status`) and `--touched-since`, where you can pass a git commit hash or `HEAD~n` and it formats every commit since then.  
`--touched-branch` is useful for PRs. It formats all changed files in commits since branching off from main.  