### PR TITLE
feat: Add support for overriding flow_tap per profile

### DIFF
--- a/docs/docs/main/docs/configuration/appendix.md
+++ b/docs/docs/main/docs/configuration/appendix.md
@@ -187,7 +187,7 @@ morses = [
 [behavior.morse.profiles]
 # matrix_map may refer these to override the defaults given in [behavior.morse] for some key positions - this example is a home row mod
 H1 = { permissive_hold = true, unilateral_tap = true, hold_timeout = "250ms", gap_timeout = "250ms" }
-H2 = { permissive_hold = true, unilateral_tap = true, hold_timeout = "200ms", gap_timeout = "200ms" }
+H2 = { enable_flow_tap = false, permissive_hold = true, unilateral_tap = true, hold_timeout = "200ms", gap_timeout = "200ms" }
 MRZ = { normal_mode = true, unilateral_tap = false, hold_timeout = "200ms", gap_timeout = "200ms" }
 
 # Combo configuration

--- a/docs/docs/main/docs/configuration/behavior.md
+++ b/docs/docs/main/docs/configuration/behavior.md
@@ -238,8 +238,8 @@ The `profile` of a morse key contains all tunable configurations of this morse k
 
 A profile contains the following fields:
 
-- `enable_flow_tap`: Enables HRM (Home Row Mod) mode. When enabled, the `prior_idle_time` setting becomes functional. Defaults to `false`.
-- `prior_idle_time`: If the previous non-modifier key is released within this period before pressing the current tap-hold key, the tap action for the tap-hold behavior will be triggered. This parameter is effective only when enable_flow_tap is set to `true`. Defaults to 120ms.
+- `enable_flow_tap`: Enables HRM (Home Row Mod) mode. When enabled, the `prior_idle_time` setting becomes functional. Defaults to `false`. Profiles may set this to override the global `[behavior.morse]` value; omitting it inherits the global value.
+- `prior_idle_time`: If the previous non-modifier key is released within this period before pressing the current tap-hold key, the tap action for the tap-hold behavior will be triggered. This parameter is configured globally in `[behavior.morse]` and is effective only when `enable_flow_tap` is enabled for the key. Defaults to 120ms.
 
 - `unilateral_tap`: (Experimental) Enables unilateral tap mode. When enabled, tap action will be triggered when a key from "same" hand is pressed. In current experimental version, the "same" hand is calculated using the `<hand>`, which can be given in `matrix_map`. This option is recommended to set to true when `enable_flow_tap` is set to true.
 
@@ -300,7 +300,7 @@ The following examples are the typical default configurations:
 HRM = { unilateral_tap = true, permissive_hold = true, hold_timeout = "250ms", gap_timeout = "250ms" }
 
 # This profile is recommended when the hold action activates a layer or acts as a modifier (without HRM) (for example thumb keys)
-FH = { hold_on_other_press = true, unilateral_tap = false, hold_timeout = "200ms", gap_timeout = "200ms" }
+FH = { enable_flow_tap = false, hold_on_other_press = true, unilateral_tap = false, hold_timeout = "200ms", gap_timeout = "200ms" }
 
 # This profile is recommended for "real" morse keys
 MRZ = { normal_mode = true, unilateral_tap = false, hold_timeout = "200ms", gap_timeout = "200ms" }

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -582,6 +582,8 @@ pub(crate) struct BehaviorConfig {
 /// overrides the defaults given in TapHoldConfig
 #[derive(Clone, Debug, Deserialize, Default)]
 pub(crate) struct MorseProfile {
+    pub enable_flow_tap: Option<bool>,
+
     /// if true, tap-hold key will always send tap action when tapped with the same hand only
     pub unilateral_tap: Option<bool>,
 

--- a/rmk-config/src/resolved/behavior.rs
+++ b/rmk-config/src/resolved/behavior.rs
@@ -70,6 +70,7 @@ pub struct Morse {
 
 #[derive(Clone)]
 pub struct MorseProfile {
+    pub enable_flow_tap: Option<bool>,
     pub unilateral_tap: Option<bool>,
     pub permissive_hold: Option<bool>,
     pub hold_on_other_press: Option<bool>,
@@ -160,6 +161,7 @@ impl crate::KeyboardTomlConfig {
                 .unwrap_or_default();
 
             let default_profile = MorseProfile {
+                enable_flow_tap: None,
                 unilateral_tap: m.unilateral_tap,
                 permissive_hold: m.permissive_hold,
                 hold_on_other_press: m.hold_on_other_press,
@@ -227,11 +229,62 @@ fn resolve_macro_operation(op: crate::MacroOperation) -> MacroOperation {
 
 fn resolve_morse_profile(p: &crate::MorseProfile) -> MorseProfile {
     MorseProfile {
+        enable_flow_tap: p.enable_flow_tap,
         unilateral_tap: p.unilateral_tap,
         permissive_hold: p.permissive_hold,
         hold_on_other_press: p.hold_on_other_press,
         normal_mode: p.normal_mode,
         hold_timeout_ms: p.hold_timeout.as_ref().map(|t| t.0),
         gap_timeout_ms: p.gap_timeout.as_ref().map(|t| t.0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::KeyboardTomlConfig;
+
+    #[test]
+    fn morse_profile_enable_flow_tap_resolves_as_override() {
+        let toml = r#"
+[layout]
+rows = 1
+cols = 1
+layers = 1
+keymap = [
+  [
+    ["A"],
+  ],
+]
+
+[behavior.morse]
+enable_flow_tap = true
+
+[behavior.morse.profiles.flow_on]
+enable_flow_tap = true
+
+[behavior.morse.profiles.flow_off]
+enable_flow_tap = false
+
+[behavior.morse.profiles.inherit]
+hold_timeout = "200ms"
+"#;
+
+        let unique = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let path = std::env::temp_dir().join(format!("rmk-config-flow-tap-{}-{}.toml", std::process::id(), unique));
+
+        fs::write(&path, toml).unwrap();
+        let config = KeyboardTomlConfig::new_from_toml_path_with_event_defaults(&path);
+        let _ = fs::remove_file(&path);
+
+        let behavior = config.behavior().unwrap();
+        let morse = behavior.morse.unwrap();
+        assert!(morse.enable_flow_tap);
+        assert_eq!(morse.default_profile.enable_flow_tap, None);
+        assert_eq!(morse.profiles["flow_on"].enable_flow_tap, Some(true));
+        assert_eq!(morse.profiles["flow_off"].enable_flow_tap, Some(false));
+        assert_eq!(morse.profiles["inherit"].enable_flow_tap, None);
     }
 }

--- a/rmk-macro/src/codegen/action_parser.rs
+++ b/rmk-macro/src/codegen/action_parser.rs
@@ -107,6 +107,12 @@ pub(crate) fn expand_profile(profile: &MorseProfile) -> proc_macro2::TokenStream
         quote! { ::core::option::Option::None }
     };
 
+    let enable_flow_tap = if let Some(enable) = profile.enable_flow_tap {
+        quote! { ::core::option::Option::Some(#enable) }
+    } else {
+        quote! { ::core::option::Option::None }
+    };
+
     let hold_timeout_ms = match &profile.hold_timeout_ms {
         Some(t) => {
             let timeout = *t as u16;
@@ -123,7 +129,10 @@ pub(crate) fn expand_profile(profile: &MorseProfile) -> proc_macro2::TokenStream
         None => quote! { ::core::option::Option::None },
     };
 
-    quote! { rmk::types::morse::MorseProfile::new(#unilateral_tap, #mode, #hold_timeout_ms, #gap_timeout_ms) }
+    quote! {
+        rmk::types::morse::MorseProfile::new(#unilateral_tap, #mode, #hold_timeout_ms, #gap_timeout_ms)
+            .with_enable_flow_tap(#enable_flow_tap)
+    }
 }
 
 pub(crate) fn expand_profile_name(
@@ -453,15 +462,43 @@ pub(crate) fn get_key_with_alias(key: String) -> Ident {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rmk_config::resolved::behavior::MorseProfile;
 
     fn expand(key: &str) -> String {
         parse_key(key.to_string(), &None).to_string()
+    }
+
+    fn profile(enable_flow_tap: Option<bool>) -> MorseProfile {
+        MorseProfile {
+            enable_flow_tap,
+            unilateral_tap: Some(true),
+            permissive_hold: None,
+            hold_on_other_press: None,
+            normal_mode: Some(true),
+            hold_timeout_ms: Some(250),
+            gap_timeout_ms: Some(250),
+        }
     }
 
     // Normalize away the whitespace that `TokenStream::to_string` inserts so
     // assertions can match the structure without being brittle about spacing.
     fn squash(s: &str) -> String {
         s.chars().filter(|c| !c.is_whitespace()).collect()
+    }
+
+    #[test]
+    fn expand_profile_emits_flow_tap_override() {
+        let disabled = expand_profile(&profile(Some(false))).to_string();
+        assert!(disabled.contains("with_enable_flow_tap"));
+        assert!(disabled.contains("Option :: Some (false)"));
+
+        let enabled = expand_profile(&profile(Some(true))).to_string();
+        assert!(enabled.contains("with_enable_flow_tap"));
+        assert!(enabled.contains("Option :: Some (true)"));
+
+        let inherit = expand_profile(&profile(None)).to_string();
+        assert!(inherit.contains("with_enable_flow_tap"));
+        assert!(inherit.contains("Option :: None"));
     }
 
     #[test]

--- a/rmk-types/src/morse.rs
+++ b/rmk-types/src/morse.rs
@@ -41,19 +41,41 @@ pub enum MorseMode {
 ///
 /// Bit layout of the inner `u32`:
 /// ```text
-/// 31  30 | 29      16 | 15  14 | 13       0
-/// mode   | gap_timeout | uni_tap| hold_timeout
-///  (2b)  |   (14b ms)  |  (2b)  |  (14b ms)
+/// 31  30 | 29       17 | 16  15 | 14  13   | 12       0
+/// mode   | gap_timeout | uni_tap| flow_tap | hold_timeout
+///  (2b)  |   (13b ms)  |  (2b)  |   (2b)   |  (13b ms)
 /// ```
 ///
 /// - `mode` (bits 31-30): `00` = None, `01` = PermissiveHold, `10` = HoldOnOtherPress, `11` = Normal
-/// - `gap_timeout` (bits 29-16): gap timeout in ms (0 = None, max 16383)
-/// - `uni_tap` (bits 15-14): `00`/`01` = None, `10` = Some(false), `11` = Some(true)
-/// - `hold_timeout` (bits 13-0): hold timeout in ms (0 = None, max 16383)
+/// - `flow_tap` (bits 14, 13): `00`/`01` = None, `10` = Some(false), `11` = Some(true)
+/// - `gap_timeout` (bits 29-17): gap timeout in ms (0 = None, max 8191)
+/// - `uni_tap` (bits 16-15): `00`/`01` = None, `10` = Some(false), `11` = Some(true)
+/// - `hold_timeout` (bits 12-0): hold timeout in ms (0 = None, max 8191)
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize, MaxSize)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "rmk_protocol", derive(Schema))]
 pub struct MorseProfile(u32);
+
+const TIMEOUT_MASK: u32 = 0x1FFF;
+const TIMEOUT_MAX_MS: u16 = TIMEOUT_MASK as u16;
+const GAP_TIMEOUT_SHIFT: u32 = 17;
+const HOLD_TIMEOUT_MASK: u32 = TIMEOUT_MASK;
+const GAP_TIMEOUT_MASK: u32 = TIMEOUT_MASK << GAP_TIMEOUT_SHIFT;
+const UNI_TAP_LOW_BIT: u32 = 0x0000_8000;
+const UNI_TAP_HIGH_BIT: u32 = 0x0001_0000;
+const UNI_TAP_MASK: u32 = UNI_TAP_LOW_BIT | UNI_TAP_HIGH_BIT;
+const FLOW_TAP_LOW_BIT: u32 = 0x0000_2000;
+const FLOW_TAP_HIGH_BIT: u32 = 0x0000_4000;
+const FLOW_TAP_MASK: u32 = FLOW_TAP_LOW_BIT | FLOW_TAP_HIGH_BIT;
+const MODE_MASK: u32 = 0xC000_0000;
+
+const fn encode_timeout_ms(t: u16) -> u32 {
+    if t > TIMEOUT_MAX_MS {
+        TIMEOUT_MAX_MS as u32
+    } else {
+        t as u32
+    }
+}
 
 impl MorseProfile {
     pub const fn const_default() -> Self {
@@ -62,19 +84,39 @@ impl MorseProfile {
 
     /// If the previous key is on the same "hand", the current key will be determined as a tap
     pub fn unilateral_tap(self) -> Option<bool> {
-        match self.0 & 0x0000_C000 {
-            0x0000_C000 => Some(true),
-            0x0000_8000 => Some(false),
+        match (self.0 & UNI_TAP_MASK) >> 15 {
+            3 => Some(true),
+            2 => Some(false),
             _ => None,
         }
     }
 
     pub const fn with_unilateral_tap(self, b: Option<bool>) -> Self {
         Self(
-            (self.0 & 0xFFFF_3FFF)
+            (self.0 & !UNI_TAP_MASK)
                 | match b {
-                    Some(true) => 0x0000_C000,
-                    Some(false) => 0x0000_8000,
+                    Some(true) => UNI_TAP_MASK,
+                    Some(false) => UNI_TAP_HIGH_BIT,
+                    None => 0,
+                },
+        )
+    }
+
+    /// Per-profile override for flow tap. `None` inherits the global morse setting.
+    pub fn enable_flow_tap(self) -> Option<bool> {
+        match (self.0 & FLOW_TAP_MASK) >> 13 {
+            3 => Some(true),
+            2 => Some(false),
+            _ => None,
+        }
+    }
+
+    pub const fn with_enable_flow_tap(self, b: Option<bool>) -> Self {
+        Self(
+            (self.0 & !FLOW_TAP_MASK)
+                | match b {
+                    Some(true) => FLOW_TAP_MASK,
+                    Some(false) => FLOW_TAP_HIGH_BIT,
                     None => 0,
                 },
         )
@@ -82,8 +124,8 @@ impl MorseProfile {
 
     /// The decision mode of the morse/tap-hold key
     pub fn mode(self) -> Option<MorseMode> {
-        match self.0 & 0xC000_0000 {
-            0xC000_0000 => Some(MorseMode::Normal),
+        match self.0 & MODE_MASK {
+            MODE_MASK => Some(MorseMode::Normal),
             0x8000_0000 => Some(MorseMode::HoldOnOtherPress),
             0x4000_0000 => Some(MorseMode::PermissiveHold),
             _ => None,
@@ -92,9 +134,9 @@ impl MorseProfile {
 
     pub const fn with_mode(self, m: Option<MorseMode>) -> Self {
         Self(
-            (self.0 & 0x3FFF_FFFF)
+            (self.0 & !MODE_MASK)
                 | match m {
-                    Some(MorseMode::Normal) => 0xC000_0000,
+                    Some(MorseMode::Normal) => MODE_MASK,
                     Some(MorseMode::HoldOnOtherPress) => 0x8000_0000,
                     Some(MorseMode::PermissiveHold) => 0x4000_0000,
                     None => 0,
@@ -104,37 +146,37 @@ impl MorseProfile {
 
     /// If the key is pressed longer than this, it is accepted as `hold` (in milliseconds)
     pub fn hold_timeout_ms(self) -> Option<u16> {
-        let t = (self.0 & 0x3FFF) as u16;
+        let t = (self.0 & HOLD_TIMEOUT_MASK) as u16;
         if t == 0 { None } else { Some(t) }
     }
 
     pub const fn with_hold_timeout_ms(self, t: Option<u16>) -> Self {
         if let Some(t) = t {
-            Self((self.0 & 0xFFFF_C000) | (t as u32 & 0x3FFF))
+            Self((self.0 & !HOLD_TIMEOUT_MASK) | encode_timeout_ms(t))
         } else {
-            Self(self.0 & 0xFFFF_C000)
+            Self(self.0 & !HOLD_TIMEOUT_MASK)
         }
     }
 
     pub const fn set_hold_timeout_ms(&mut self, t: u16) {
-        self.0 = (self.0 & 0xFFFF_C000) | (t as u32 & 0x3FFF)
+        self.0 = (self.0 & !HOLD_TIMEOUT_MASK) | encode_timeout_ms(t)
     }
 
     pub const fn set_gap_timeout_ms(&mut self, t: u16) {
-        self.0 = (self.0 & 0xC000_FFFF) | ((t as u32 & 0x3FFF) << 16)
+        self.0 = (self.0 & !GAP_TIMEOUT_MASK) | (encode_timeout_ms(t) << GAP_TIMEOUT_SHIFT)
     }
 
     /// The time elapsed from the last release of a key is longer than this, it will break the morse pattern (in milliseconds)
     pub fn gap_timeout_ms(self) -> Option<u16> {
-        let t = ((self.0 >> 16) & 0x3FFF) as u16;
+        let t = ((self.0 & GAP_TIMEOUT_MASK) >> GAP_TIMEOUT_SHIFT) as u16;
         if t == 0 { None } else { Some(t) }
     }
 
     pub const fn with_gap_timeout_ms(self, t: Option<u16>) -> Self {
         if let Some(t) = t {
-            Self((self.0 & 0xC000_FFFF) | ((t as u32 & 0x3FFF) << 16))
+            Self((self.0 & !GAP_TIMEOUT_MASK) | (encode_timeout_ms(t) << GAP_TIMEOUT_SHIFT))
         } else {
-            Self(self.0 & 0xC000_FFFF)
+            Self(self.0 & !GAP_TIMEOUT_MASK)
         }
     }
 
@@ -146,17 +188,17 @@ impl MorseProfile {
     ) -> Self {
         let mut v = 0u32;
         if let Some(t) = hold_timeout_ms {
-            v = (t & 0x3FFF) as u32;
+            v = encode_timeout_ms(t);
         }
         if let Some(t) = gap_timeout_ms {
-            v |= ((t & 0x3FFF) as u32) << 16;
+            v |= encode_timeout_ms(t) << GAP_TIMEOUT_SHIFT;
         }
         if let Some(b) = unilateral_tap {
-            v |= if b { 0x0000_C000 } else { 0x0000_8000 };
+            v |= if b { UNI_TAP_MASK } else { UNI_TAP_HIGH_BIT };
         }
         if let Some(m) = mode {
             v |= match m {
-                MorseMode::Normal => 0xC000_0000,
+                MorseMode::Normal => MODE_MASK,
                 MorseMode::HoldOnOtherPress => 0x8000_0000,
                 MorseMode::PermissiveHold => 0x4000_0000,
             };
@@ -634,15 +676,70 @@ mod tests {
         assert_eq!(profile.unilateral_tap(), Some(true));
         assert_eq!(profile.mode(), Some(MorseMode::PermissiveHold));
 
-        profile.set_hold_timeout_ms(0x3FFF);
-        profile.set_gap_timeout_ms(0x3FFF);
-        assert_eq!(profile.hold_timeout_ms(), Some(0x3FFF));
-        assert_eq!(profile.gap_timeout_ms(), Some(0x3FFF));
+        profile.set_hold_timeout_ms(0xFFFF);
+        profile.set_gap_timeout_ms(0xFFFF);
+        assert_eq!(profile.hold_timeout_ms(), Some(TIMEOUT_MAX_MS));
+        assert_eq!(profile.gap_timeout_ms(), Some(TIMEOUT_MAX_MS));
 
         profile.set_hold_timeout_ms(0);
         profile.set_gap_timeout_ms(0);
         assert_eq!(profile.hold_timeout_ms(), None);
         assert_eq!(profile.gap_timeout_ms(), None);
+    }
+
+    #[test]
+    fn test_morse_profile_packed_layout_matches_docs() {
+        let profile = MorseProfile::new(
+            Some(false),
+            Some(MorseMode::HoldOnOtherPress),
+            Some(0x0123),
+            Some(0x0456),
+        )
+        .with_enable_flow_tap(Some(false));
+        assert_eq!(
+            u32::from(profile),
+            0x8000_0000 | (0x0456u32 << 17) | 0x0001_0000 | 0x0000_4000 | 0x0123
+        );
+        assert_eq!(profile.unilateral_tap(), Some(false));
+        assert_eq!(profile.enable_flow_tap(), Some(false));
+
+        let profile = MorseProfile::new(Some(true), Some(MorseMode::Normal), Some(0x0123), Some(0x0456))
+            .with_enable_flow_tap(Some(true));
+        assert_eq!(
+            u32::from(profile),
+            0xC000_0000 | (0x0456u32 << 17) | 0x0001_8000 | 0x0000_6000 | 0x0123
+        );
+        assert_eq!(profile.unilateral_tap(), Some(true));
+        assert_eq!(profile.enable_flow_tap(), Some(true));
+    }
+
+    #[test]
+    fn test_morse_profile_enable_flow_tap_accessors_preserve_packed_fields() {
+        assert_eq!(core::mem::size_of::<MorseProfile>(), 4);
+        assert_eq!(MorseProfile::POSTCARD_MAX_SIZE, u32::POSTCARD_MAX_SIZE);
+        assert_eq!(MorseProfile::const_default().enable_flow_tap(), None);
+
+        let profile = MorseProfile::new(Some(true), Some(MorseMode::PermissiveHold), Some(1000), Some(2000));
+        let profile = profile.with_enable_flow_tap(Some(true));
+        assert_eq!(profile.enable_flow_tap(), Some(true));
+        assert_eq!(profile.hold_timeout_ms(), Some(1000));
+        assert_eq!(profile.gap_timeout_ms(), Some(2000));
+        assert_eq!(profile.unilateral_tap(), Some(true));
+        assert_eq!(profile.mode(), Some(MorseMode::PermissiveHold));
+
+        let profile = profile.with_enable_flow_tap(Some(false));
+        assert_eq!(profile.enable_flow_tap(), Some(false));
+        assert_eq!(profile.hold_timeout_ms(), Some(1000));
+        assert_eq!(profile.gap_timeout_ms(), Some(2000));
+        assert_eq!(profile.unilateral_tap(), Some(true));
+        assert_eq!(profile.mode(), Some(MorseMode::PermissiveHold));
+
+        let profile = profile.with_enable_flow_tap(None);
+        assert_eq!(profile.enable_flow_tap(), None);
+        assert_eq!(profile.hold_timeout_ms(), Some(1000));
+        assert_eq!(profile.gap_timeout_ms(), Some(2000));
+        assert_eq!(profile.unilateral_tap(), Some(true));
+        assert_eq!(profile.mode(), Some(MorseMode::PermissiveHold));
     }
 
     /// Validates that the manual Schema impl matches the actual serde wire format.

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -438,6 +438,16 @@ impl<'a> Keyboard<'a> {
                 self.process_key_action_inner(key_action, event, event_time).await
             }
             KeyBehaviorDecision::FlowTap => {
+                let key_action = if keyboard_state_updated && !is_combo {
+                    &self.keymap.get_action_with_layer_cache(event)
+                } else {
+                    key_action
+                };
+                if !key_action.is_morse() || !Self::is_flow_tap_enabled(self.keymap, key_action) {
+                    self.process_key_action_inner(key_action, event, event_time).await;
+                    return;
+                }
+
                 let action = Self::action_from_pattern(self.keymap, key_action, TAP); //tap action
                 self.process_key_action_normal(action, event).await;
                 // Drop any existing held entry at this position (e.g. an EarlyFired entry left by
@@ -655,8 +665,8 @@ impl<'a> Keyboard<'a> {
 
         // When pressing a morse key, check flow tap first.
         if event.pressed
-            && self.keymap.morse_enable_flow_tap()
             && key_action.is_morse()
+            && Self::is_flow_tap_enabled(self.keymap, key_action)
             && self.last_press_time.elapsed() < self.keymap.morse_prior_idle_time()
         {
             // It's in key streak, trigger the first tap action
@@ -707,6 +717,7 @@ impl<'a> Keyboard<'a> {
 
                         if decision_for_current_key == KeyBehaviorDecision::FlowTap
                             && matches!(held_key.state, KeyState::Pressed(_))
+                            && Self::is_flow_tap_enabled(self.keymap, &held_key.action)
                         {
                             debug!("Flow tap triggered, resolve buffered morse key as tapping");
                             // If flow tap of current key is triggered, tapping all held keys

--- a/rmk/src/keyboard/morse.rs
+++ b/rmk/src/keyboard/morse.rs
@@ -348,6 +348,19 @@ impl<'a> Keyboard<'a> {
         keymap.morse_default_profile().unilateral_tap().unwrap_or(false)
     }
 
+    pub fn is_flow_tap_enabled(keymap: &KeyMap, key_action: &KeyAction) -> bool {
+        match key_action {
+            KeyAction::TapHold(_, _, profile) => profile
+                .enable_flow_tap()
+                .unwrap_or_else(|| keymap.morse_enable_flow_tap()),
+            KeyAction::Morse(index) => keymap
+                .get_morse(*index as usize)
+                .and_then(|morse| morse.profile.enable_flow_tap())
+                .unwrap_or_else(|| keymap.morse_enable_flow_tap()),
+            _ => keymap.morse_enable_flow_tap(),
+        }
+    }
+
     /// Checks if the given pattern can fire its action early even though longer
     /// continuations exist. Returns Some(action) when the hold continuation has
     /// the same action and the tap continuation is not configured.

--- a/rmk/tests/keyboard_morse_hold_on_other_press_test.rs
+++ b/rmk/tests/keyboard_morse_hold_on_other_press_test.rs
@@ -1,17 +1,18 @@
 pub mod common;
 
 use embassy_time::Duration;
-use rmk::config::{BehaviorConfig, CombosConfig, MorsesConfig};
-use rmk::k;
+use heapless::Vec;
+use rmk::config::{BehaviorConfig, CombosConfig, MorsesConfig, PositionalConfig};
 use rmk::keyboard::Keyboard;
 use rmk::keyboard::combo::{Combo, ComboConfig};
 use rmk::types::action::{Action, KeyAction};
 use rmk::types::keycode::{HidKeyCode, KeyCode};
 use rmk::types::modifier::ModifierCombination;
-use rmk_types::morse::{MorseMode, MorseProfile};
+use rmk::{a, k};
+use rmk_types::morse::{Morse, MorseMode, MorseProfile};
 
 use crate::common::morse::create_simple_morse_keyboard;
-use crate::common::{KC_LGUI, KC_LSHIFT};
+use crate::common::{KC_LGUI, KC_LSHIFT, wrap_keymap};
 
 fn create_hold_on_other_key_press_keyboard() -> Keyboard<'static> {
     create_simple_morse_keyboard(BehaviorConfig {
@@ -82,6 +83,136 @@ fn create_hold_on_other_key_press_keyboard_with_combo() -> Keyboard<'static> {
         },
         ..BehaviorConfig::default()
     })
+}
+
+fn create_profile_flow_tap_keyboard(
+    global_enable_flow_tap: bool,
+    profile_enable_flow_tap: Option<bool>,
+) -> Keyboard<'static> {
+    let profile = MorseProfile::new(
+        Some(false),
+        Some(MorseMode::HoldOnOtherPress),
+        Some(250u16),
+        Some(250u16),
+    )
+    .with_enable_flow_tap(profile_enable_flow_tap);
+    let keymap = [[[
+        k!(A),
+        KeyAction::TapHold(
+            Action::Key(KeyCode::Hid(HidKeyCode::B)),
+            Action::Modifier(ModifierCombination::LSHIFT),
+            profile,
+        ),
+    ]]];
+    let behavior_config = BehaviorConfig {
+        morse: MorsesConfig {
+            enable_flow_tap: global_enable_flow_tap,
+            prior_idle_time: Duration::from_millis(120),
+            default_profile: MorseProfile::new(
+                Some(false),
+                Some(MorseMode::HoldOnOtherPress),
+                Some(250u16),
+                Some(250u16),
+            ),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let behavior_config: &'static mut BehaviorConfig = Box::leak(Box::new(behavior_config));
+    let per_key_config: &'static PositionalConfig<1, 2> = Box::leak(Box::new(PositionalConfig::default()));
+    Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
+}
+
+fn create_profile_flow_tap_morse_keyboard(
+    global_enable_flow_tap: bool,
+    profile_enable_flow_tap: Option<bool>,
+) -> Keyboard<'static> {
+    let profile = MorseProfile::new(
+        Some(false),
+        Some(MorseMode::HoldOnOtherPress),
+        Some(250u16),
+        Some(250u16),
+    )
+    .with_enable_flow_tap(profile_enable_flow_tap);
+    let keymap = [[[k!(A), KeyAction::Morse(0)]]];
+    let behavior_config = BehaviorConfig {
+        morse: MorsesConfig {
+            enable_flow_tap: global_enable_flow_tap,
+            prior_idle_time: Duration::from_millis(120),
+            default_profile: MorseProfile::new(
+                Some(false),
+                Some(MorseMode::HoldOnOtherPress),
+                Some(250u16),
+                Some(250u16),
+            ),
+            morses: Vec::from_slice(&[Morse::new_from_vial(
+                Action::Key(KeyCode::Hid(HidKeyCode::B)),
+                Action::Modifier(ModifierCombination::LSHIFT),
+                Action::No,
+                Action::No,
+                profile,
+            )])
+            .unwrap(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let behavior_config: &'static mut BehaviorConfig = Box::leak(Box::new(behavior_config));
+    let per_key_config: &'static PositionalConfig<1, 2> = Box::leak(Box::new(PositionalConfig::default()));
+    Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
+}
+
+fn create_flow_tap_layer_cache_keyboard() -> Keyboard<'static> {
+    let disabled_flow_profile = MorseProfile::new(
+        Some(false),
+        Some(MorseMode::HoldOnOtherPress),
+        Some(250u16),
+        Some(250u16),
+    )
+    .with_enable_flow_tap(Some(false));
+    let enabled_flow_profile = MorseProfile::new(
+        Some(false),
+        Some(MorseMode::HoldOnOtherPress),
+        Some(250u16),
+        Some(250u16),
+    )
+    .with_enable_flow_tap(Some(true));
+    let keymap = [
+        [[
+            k!(A),
+            KeyAction::TapHold(
+                Action::Key(KeyCode::Hid(HidKeyCode::D)),
+                Action::LayerOn(1),
+                disabled_flow_profile,
+            ),
+            KeyAction::TapHold(
+                Action::Key(KeyCode::Hid(HidKeyCode::B)),
+                Action::Modifier(ModifierCombination::LSHIFT),
+                enabled_flow_profile,
+            ),
+        ]],
+        [[a!(Transparent), a!(Transparent), k!(Kp1)]],
+    ];
+    let behavior_config = BehaviorConfig {
+        morse: MorsesConfig {
+            enable_flow_tap: false,
+            prior_idle_time: Duration::from_millis(120),
+            default_profile: MorseProfile::new(
+                Some(false),
+                Some(MorseMode::HoldOnOtherPress),
+                Some(250u16),
+                Some(250u16),
+            ),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let behavior_config: &'static mut BehaviorConfig = Box::leak(Box::new(behavior_config));
+    let per_key_config: &'static PositionalConfig<1, 3> = Box::leak(Box::new(PositionalConfig::default()));
+    Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
 }
 
 #[test]
@@ -1197,6 +1328,119 @@ fn test_flow_tap() {
             [0, [0, 0, 0, 0, 0, 0]], // Release B
             [0, [kc_to_u8!(C), 0, 0, 0, 0, 0]], // Press C
             [0, [0, 0, 0, 0, 0, 0]], // Release C
+        ]
+    };
+}
+
+#[test]
+fn profile_flow_tap_true_overrides_global_false() {
+    key_sequence_test! {
+        keyboard: create_profile_flow_tap_keyboard(false, Some(true)),
+        sequence: [
+            [0, 0, true, 30],  // Press A
+            [0, 0, false, 30], // Release A
+            [0, 1, true, 20],  // Press mt!(B, LShift) -> profile Flow Tap
+            [0, 0, true, 10],  // Press A while B is flow-tapped
+            [0, 0, false, 10], // Release A
+            [0, 1, false, 10], // Release B
+        ],
+        expected_reports: [
+            [0, [kc_to_u8!(A), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(B), 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(B), kc_to_u8!(A), 0, 0, 0, 0]],
+            [0, [kc_to_u8!(B), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+        ]
+    };
+}
+
+#[test]
+fn profile_flow_tap_false_overrides_global_true() {
+    key_sequence_test! {
+        keyboard: create_profile_flow_tap_keyboard(true, Some(false)),
+        sequence: [
+            [0, 0, true, 30],  // Press A
+            [0, 0, false, 30], // Release A
+            [0, 1, true, 20],  // Press mt!(B, LShift), profile disables Flow Tap
+            [0, 0, true, 10],  // Press A, causing hold-on-other-press
+            [0, 0, false, 10], // Release A
+            [0, 1, false, 10], // Release B
+        ],
+        expected_reports: [
+            [0, [kc_to_u8!(A), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
+            [KC_LSHIFT, [kc_to_u8!(A), 0, 0, 0, 0, 0]],
+            [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+        ]
+    };
+}
+
+#[test]
+fn morse_profile_flow_tap_true_overrides_global_false() {
+    key_sequence_test! {
+        keyboard: create_profile_flow_tap_morse_keyboard(false, Some(true)),
+        sequence: [
+            [0, 0, true, 30],  // Press A
+            [0, 0, false, 30], // Release A
+            [0, 1, true, 20],  // Press TD(0) -> profile Flow Tap
+            [0, 0, true, 10],  // Press A while B is flow-tapped
+            [0, 0, false, 10], // Release A
+            [0, 1, false, 10], // Release TD(0)
+        ],
+        expected_reports: [
+            [0, [kc_to_u8!(A), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(B), 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(B), kc_to_u8!(A), 0, 0, 0, 0]],
+            [0, [kc_to_u8!(B), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+        ]
+    };
+}
+
+#[test]
+fn morse_profile_flow_tap_false_overrides_global_true() {
+    key_sequence_test! {
+        keyboard: create_profile_flow_tap_morse_keyboard(true, Some(false)),
+        sequence: [
+            [0, 0, true, 30],  // Press A
+            [0, 0, false, 30], // Release A
+            [0, 1, true, 20],  // Press TD(0), profile disables Flow Tap
+            [0, 0, true, 10],  // Press A, causing hold-on-other-press
+            [0, 0, false, 10], // Release A
+            [0, 1, false, 10], // Release TD(0)
+        ],
+        expected_reports: [
+            [0, [kc_to_u8!(A), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
+            [KC_LSHIFT, [kc_to_u8!(A), 0, 0, 0, 0, 0]],
+            [KC_LSHIFT, [0, 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+        ]
+    };
+}
+
+#[test]
+fn flow_tap_rechecks_current_key_after_held_key_changes_layer() {
+    key_sequence_test! {
+        keyboard: create_flow_tap_layer_cache_keyboard(),
+        sequence: [
+            [0, 0, true, 30],  // Press A
+            [0, 0, false, 30], // Release A
+            [0, 1, true, 20],  // Press LT(1, D), profile disables Flow Tap
+            [0, 2, true, 10],  // Press flow-tap key, but held LT activates layer 1 first
+            [0, 2, false, 10], // Release Kp1 from layer 1
+            [0, 1, false, 10], // Release LT
+        ],
+        expected_reports: [
+            [0, [kc_to_u8!(A), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(Kp1), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
         ]
     };
 }

--- a/rmk/tests/keyboard_morse_tap_dance_test.rs
+++ b/rmk/tests/keyboard_morse_tap_dance_test.rs
@@ -293,6 +293,84 @@ fn create_dusk_rollover_keyboard(use_tap_dance_c: bool) -> Keyboard<'static> {
     Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
 }
 
+fn create_saurus_client_roll_keyboard() -> Keyboard<'static> {
+    let hrm_profile = MorseProfile::new(Some(true), Some(MorseMode::PermissiveHold), Some(400u16), Some(250u16));
+    let hrmsgt_profile = MorseProfile::new(Some(true), Some(MorseMode::PermissiveHold), Some(400u16), Some(100u16));
+    // Isolate the profile override path: the held key opts out of flow-tap,
+    // while the later key still inherits the global flow-tap setting.
+    let hrmsgt_no_flow_profile = hrmsgt_profile.with_enable_flow_tap(Some(false));
+
+    #[rustfmt::skip]
+    let dusk_layer = [
+        [k!(B),     k!(F), k!(L), k!(D), k!(Q),     k!(Quote), k!(W),     k!(O),  k!(U),     k!(Y)],
+        [td!(0),    k!(S), k!(H), td!(1), k!(K),    k!(J),     td!(2),    k!(A), td!(3),    td!(4)],
+        [k!(X),     k!(V), k!(M), k!(G), k!(Z),     k!(Minus), k!(P),     k!(Comma), k!(Dot), k!(Slash)],
+        [a!(No),    a!(No), k!(Tab), k!(R), k!(Enter), k!(Backspace), k!(Space), k!(Grave), a!(No), a!(No)],
+    ];
+    let no_layer = [[a!(No); 10]; 4];
+    let keymap = [dusk_layer, no_layer, no_layer, no_layer, no_layer];
+
+    let behavior_config = BehaviorConfig {
+        morse: MorsesConfig {
+            enable_flow_tap: true,
+            prior_idle_time: Duration::from_millis(120),
+            default_profile: MorseProfile::new(None, Some(MorseMode::Normal), Some(250u16), Some(250u16)),
+            morses: Vec::from_slice(&[
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::N),
+                    Action::Modifier(ModifierCombination::LSHIFT),
+                    key_action(HidKeyCode::N),
+                    Action::No,
+                    hrmsgt_no_flow_profile,
+                ),
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::T),
+                    Action::LayerOn(3),
+                    key_action(HidKeyCode::T),
+                    Action::No,
+                    hrm_profile,
+                ),
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::C),
+                    Action::LayerOn(3),
+                    key_action(HidKeyCode::C),
+                    Action::No,
+                    hrm_profile,
+                ),
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::E),
+                    Action::Modifier(ModifierCombination::RCTRL),
+                    key_action(HidKeyCode::E),
+                    Action::No,
+                    hrm_profile,
+                ),
+                Morse::new_from_vial(
+                    key_action(HidKeyCode::I),
+                    Action::Modifier(ModifierCombination::RSHIFT),
+                    key_action(HidKeyCode::I),
+                    Action::No,
+                    hrmsgt_profile,
+                ),
+            ])
+            .unwrap(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    #[rustfmt::skip]
+    let hand = [
+        [Hand::Left,    Hand::Left,    Hand::Left,    Hand::Left,    Hand::Left,       Hand::Right,     Hand::Right, Hand::Right,     Hand::Right,     Hand::Right],
+        [Hand::Left,    Hand::Left,    Hand::Left,    Hand::Left,    Hand::Left,       Hand::Right,     Hand::Right, Hand::Right,     Hand::Right,     Hand::Right],
+        [Hand::Left,    Hand::Left,    Hand::Left,    Hand::Left,    Hand::Left,       Hand::Right,     Hand::Right, Hand::Right,     Hand::Right,     Hand::Right],
+        [Hand::Unknown, Hand::Unknown, Hand::Bilateral, Hand::Left, Hand::Bilateral,   Hand::Bilateral, Hand::Right, Hand::Bilateral, Hand::Unknown,   Hand::Unknown],
+    ];
+
+    let behavior_config: &'static mut BehaviorConfig = Box::leak(Box::new(behavior_config));
+    let per_key_config: &'static PositionalConfig<4, 10> = Box::leak(Box::new(PositionalConfig::new(hand)));
+    Keyboard::new(wrap_keymap(keymap, per_key_config, behavior_config))
+}
+
 #[test]
 fn test_tap() {
     key_sequence_test! {
@@ -891,6 +969,52 @@ fn test_flow_tapped_tap_then_hold_after_tap() {
             // RShift would mean the continuation breadcrumb was lost.
             [0, [kc_to_u8!(Backspace), 0, 0, 0, 0, 0]],
             [0, [0, 0, 0, 0, 0, 0]]
+        ]
+    };
+}
+
+/// Regression test for a Saurus-shaped `dusk` layout while typing "client".
+///
+/// The final `e`/`n`/`t` roll leaves `N` pressed before `T`, while `E` only
+/// resolves after `N` is already held. `T` then flow-taps because `E` just
+/// produced a simple keypress. Even when `N` disables flow-tap through a
+/// profile override, the later flow-tapped `T` must not overtake it, or the
+/// host sees "clietn".
+#[test]
+fn test_saurus_client_roll_with_flow_tap_override_keeps_n_before_t() {
+    key_sequence_test! {
+        keyboard: create_saurus_client_roll_keyboard(),
+        sequence: [
+            [1, 6, true, 150],  // Press C, after prior idle time
+            [1, 6, false, 30],  // Release C
+            [0, 2, true, 30],   // Press L
+            [0, 2, false, 30],  // Release L
+            [1, 9, true, 30],   // Press I, flow-tapped after L
+            [1, 9, false, 30],  // Release I
+            [1, 8, true, 150],  // Press E, after prior idle time
+            [1, 0, true, 40],   // Press N while E is unresolved
+            [1, 8, false, 30],  // Release E, resolving it before T
+            [1, 3, true, 30],   // Press T, flow-tapped after E
+            [1, 0, false, 30],  // Release N
+            [1, 3, false, 30],  // Release T
+            [0, 9, true, 300],  // Let T's hold-after-tap breadcrumb expire, then press Y
+            [0, 9, false, 30],  // Release Y
+        ],
+        expected_reports: [
+            [0, [kc_to_u8!(C), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(L), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(I), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(E), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(N), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(T), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
+            [0, [kc_to_u8!(Y), 0, 0, 0, 0, 0]],
+            [0, [0, 0, 0, 0, 0, 0]],
         ]
     };
 }


### PR DESCRIPTION
This adds a feature that allows to override the tap_flow configuration option per Morse profile. This effectively addresses https://github.com/HaoboGu/rmk/issues/883. The trade of is that it shrinks the max possible timeout overrides from 16s to 8s per-profile. Given this change doesn't regress the profile storage size it seems like an acceptable tradeoff. In most cases users don't really need to set these timeout to something higher than 1 or 2 seconds.