### PR TITLE
feat(vial): add host.vial_insecure option to start Vial unlocked

### DIFF
--- a/docs/docs/main/docs/configuration/host_config.md
+++ b/docs/docs/main/docs/configuration/host_config.md
@@ -12,4 +12,8 @@ vial_enabled = true
 # Unlock keys for Vial security (optional)
 # Keys must be pressed simultaneously to unlock Vial configuration
 unlock_keys = [[0, 0], [0, 1]]  # Keys at (row=0,col=0) and (row=0,col=1)
+
+# Start Vial unlocked, bypassing the unlock-key combo (default: false)
+# When true, secured operations such as the Matrix Tester are available immediately without pressing `unlock_keys`.
+vial_insecure = false
 ```

--- a/docs/docs/main/docs/features/vial_support.mdx
+++ b/docs/docs/main/docs/features/vial_support.mdx
@@ -60,3 +60,24 @@ unlock_keys = [[0, 0], [0, 1]]  # Keys at (row=0,col=0) and (row=0,col=1)
 ::: tip The unlock keys use the physical matrix position (row, column), not the keycode. Make sure
 to use keys that are easy to press simultaneously but not commonly pressed together accidentally.
 :::
+
+## Start Vial Unlocked (insecure)
+
+By default Vial starts **locked**: security-sensitive operations are unavailable until the keyboard
+is unlocked by holding the configured `unlock_keys`. This includes the Matrix Tester and saving Tap
+Dance entries (called *morse* in RMK) — Vial requires the keyboard to be unlocked before these can be
+used. The lock is part of [Vial's security model](https://get.vial.today/docs/security.html), which
+prevents a host from silently reading what you type before you explicitly authorize it.
+
+For development and testing it can be convenient to skip this step. Setting `vial_insecure = true`
+under the `[host]` section starts Vial in the unlocked state, so the Matrix Tester, Tap Dance
+saving, and other secured operations are available immediately without pressing the unlock combo.
+
+```toml title="keyboard.toml"
+[host]
+vial_insecure = true
+```
+
+::: Note `vial_insecure` only takes effect with the `vial_lock` feature (enabled by default). It does
+not replace `unlock_keys`: the host can still lock and re-unlock a session that started unlocked, so
+you may keep `unlock_keys` configured alongside it. :::

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -837,6 +837,10 @@ pub(crate) struct HostConfig {
     pub vial_enabled: bool,
     /// Unlock keys for Vial (optional)
     pub unlock_keys: Option<Vec<[u8; 2]>>,
+    /// Start Vial unlocked, bypassing the unlock-key combo (default: false).
+    /// Only has effect with the `vial_lock` feature.
+    #[serde_inline_default(false)]
+    pub vial_insecure: bool,
 }
 
 impl Default for HostConfig {
@@ -844,6 +848,7 @@ impl Default for HostConfig {
         Self {
             vial_enabled: true,
             unlock_keys: None,
+            vial_insecure: false,
         }
     }
 }

--- a/rmk-config/src/resolved/host.rs
+++ b/rmk-config/src/resolved/host.rs
@@ -2,6 +2,7 @@
 pub struct Host {
     pub vial_enabled: bool,
     pub unlock_keys: Vec<[u8; 2]>,
+    pub vial_insecure: bool,
 }
 
 impl crate::KeyboardTomlConfig {
@@ -11,6 +12,7 @@ impl crate::KeyboardTomlConfig {
         Host {
             vial_enabled: host_toml.vial_enabled,
             unlock_keys: host_toml.unlock_keys.unwrap_or_default(),
+            vial_insecure: host_toml.vial_insecure,
         }
     }
 }

--- a/rmk-macro/src/codegen/keyboard_config.rs
+++ b/rmk-macro/src/codegen/keyboard_config.rs
@@ -58,12 +58,14 @@ pub(crate) fn expand_vial_config(host: &Host) -> proc_macro2::TokenStream {
     } else {
         quote! { &[] }
     };
+    let vial_insecure = host.vial_insecure;
     quote! {
         include!(concat!(env!("OUT_DIR"), "/config_generated.rs"));
         const VIAL_CONFIG: ::rmk::config::VialConfig = ::rmk::config::VialConfig {
             vial_keyboard_id: &VIAL_KEYBOARD_ID,
             vial_keyboard_def: &VIAL_KEYBOARD_DEF,
-            unlock_keys: #unlock_keys
+            unlock_keys: #unlock_keys,
+            vial_insecure: #vial_insecure,
         };
     }
 }

--- a/rmk/src/config/vial.rs
+++ b/rmk/src/config/vial.rs
@@ -6,6 +6,7 @@ pub struct VialConfig<'a> {
     pub vial_keyboard_id: &'a [u8],
     pub vial_keyboard_def: &'a [u8],
     pub unlock_keys: &'a [(u8, u8)],
+    pub vial_insecure: bool,
 }
 
 impl<'a> VialConfig<'a> {
@@ -14,6 +15,7 @@ impl<'a> VialConfig<'a> {
             vial_keyboard_id,
             vial_keyboard_def,
             unlock_keys,
+            vial_insecure: false,
         }
     }
 }

--- a/rmk/src/host/via/mod.rs
+++ b/rmk/src/host/via/mod.rs
@@ -29,7 +29,11 @@ impl<'a> VialService<'a> {
             ctx,
             vial_config: config.vial_config,
             #[cfg(feature = "vial_lock")]
-            locker: vial_lock::VialLock::new(config.vial_config.unlock_keys, ctx.keymap),
+            locker: vial_lock::VialLock::new(
+                config.vial_config.unlock_keys,
+                ctx.keymap,
+                config.vial_config.vial_insecure,
+            ),
         }
     }
 

--- a/rmk/src/host/via/vial_lock.rs
+++ b/rmk/src/host/via/vial_lock.rs
@@ -9,9 +9,9 @@ pub(crate) struct VialLock<'a> {
 }
 
 impl<'a> VialLock<'a> {
-    pub fn new(unlock_keys: &'a [(u8, u8)], keymap: &'a KeyMap<'a>) -> Self {
+    pub fn new(unlock_keys: &'a [(u8, u8)], keymap: &'a KeyMap<'a>, insecure: bool) -> Self {
         Self {
-            unlocked: false,
+            unlocked: insecure,
             unlocking: false,
             last_poll: embassy_time::Instant::MIN,
             unlock_keys,


### PR DESCRIPTION
Add a `[host] vial_insecure` boolean (default false) that initializes the Vial lock in the unlocked state, so secured operations such as the Matrix Tester are available immediately without pressing the `unlock_keys` combo. Intended for development; production builds should leave it disabled.

The flag flows from `keyboard.toml [host]` through `HostConfig` and the resolved `Host` into the generated `VialConfig`, then into `VialLock::new`, which now initializes `unlocked` from it. Re-locking and unlock-key polling are unchanged, so a host can still lock/unlock a session that started unlocked. The flag only has effect with the `vial_lock` feature.

`VialConfig::new` keeps its three-argument signature (defaulting the new field to false) so existing pure-Rust configs continue to compile.