### PR TITLE
feat(rmk): add RynkHidService 

### DIFF
--- a/rmk-types/src/protocol/rynk/mod.rs
+++ b/rmk-types/src/protocol/rynk/mod.rs
@@ -62,6 +62,9 @@ pub use self::payload::*;
 /// Largest single GATT write/notification on the Rynk BLE characteristics.
 pub const RYNK_BLE_CHUNK_SIZE: usize = 244;
 
+/// Fixed size of one Rynk-over-WebHID report (`RynkHidService`)
+pub const RYNK_HID_REPORT_SIZE: usize = 32;
+
 /// Rynk GATT service UUID
 pub const RYNK_SERVICE_UUID: u128 = 0x10900067_537f_4f0a_9b55_929e271f61ab;
 /// Rynk `input_data` characteristic UUID.

--- a/rmk/src/ble/ble_server.rs
+++ b/rmk/src/ble/ble_server.rs
@@ -3,6 +3,8 @@ use usbd_hid::descriptor::{AsInputReport, SerializedDescriptor};
 
 use super::battery_service::BatteryService;
 use super::device_info::DeviceConfigurationService;
+#[cfg(feature = "rynk")]
+use crate::hid::RynkHidReport;
 #[cfg(feature = "vial")]
 use crate::hid::ViaReport;
 use crate::hid::{CompositeReport, CompositeReportType, HidError, HidWriterTrait, KeyboardReport, Report};
@@ -12,7 +14,9 @@ use crate::hid::{CompositeReport, CompositeReportType, HidError, HidWriterTrait,
 pub(crate) const CCCD_TABLE_SIZE: usize = trouble_host::config::CLIENT_ATT_TABLE_SIZE;
 
 #[cfg(feature = "rynk")]
-use rmk_types::protocol::rynk::{RYNK_BLE_CHUNK_SIZE, RYNK_INPUT_CHAR_UUID, RYNK_OUTPUT_CHAR_UUID, RYNK_SERVICE_UUID};
+use rmk_types::protocol::rynk::{
+    RYNK_BLE_CHUNK_SIZE, RYNK_HID_REPORT_SIZE, RYNK_INPUT_CHAR_UUID, RYNK_OUTPUT_CHAR_UUID, RYNK_SERVICE_UUID,
+};
 
 #[cfg(feature = "vial")]
 #[gatt_server]
@@ -30,6 +34,7 @@ pub(crate) struct Server {
     pub(crate) battery_service: BatteryService,
     pub(crate) hid_service: HidService,
     pub(crate) rynk_service: RynkService,
+    pub(crate) rynk_hid_service: RynkHidService,
     pub(crate) composite_service: CompositeService,
     pub(crate) device_config_service: DeviceConfigurationService,
 }
@@ -58,6 +63,28 @@ pub(crate) struct RynkService {
     pub(crate) input_data: heapless::Vec<u8, RYNK_BLE_CHUNK_SIZE>,
     #[characteristic(uuid = RYNK_OUTPUT_CHAR_UUID, read, write, write_without_response)]
     pub(crate) output_data: heapless::Vec<u8, RYNK_BLE_CHUNK_SIZE>,
+}
+
+/// Rynk HID-over-GATT service.
+/// `gatt_events_task` feeds the payload into [`crate::channel::RYNK_BLE_RX_PIPE`],
+/// [`crate::ble::rynk::run_host_ble`] session drains the pipe to get data.
+#[cfg(feature = "rynk")]
+#[gatt_service(uuid = service::HUMAN_INTERFACE_DEVICE)]
+pub(crate) struct RynkHidService {
+    #[characteristic(uuid = "2a4a", read, value = [0x01, 0x01, 0x00, 0x03])]
+    pub(crate) hid_info: [u8; 4],
+    #[characteristic(uuid = "2a4b", read, value = RynkHidReport::desc().try_into().expect("Failed to convert RynkHidReport to [u8; 27]"))]
+    pub(crate) report_map: [u8; 27],
+    #[characteristic(uuid = "2a4c", write_without_response)]
+    pub(crate) hid_control_point: u8,
+    #[characteristic(uuid = "2a4e", read, write_without_response, value = 1)]
+    pub(crate) protocol_mode: u8,
+    #[descriptor(uuid = "2908", read, value = [0u8, 1u8])]
+    #[characteristic(uuid = "2a4d", read, notify)]
+    pub(crate) input_data: [u8; RYNK_HID_REPORT_SIZE],
+    #[descriptor(uuid = "2908", read, value = [0u8, 2u8])]
+    #[characteristic(uuid = "2a4d", read, write, write_without_response)]
+    pub(crate) output_data: [u8; RYNK_HID_REPORT_SIZE],
 }
 
 /// GATT service exposing the Vial-over-HID protocol. The keyboard writes replies via

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -9,6 +9,8 @@ use rand_core::{CryptoRng, RngCore};
 use rmk_types::ble::BleState;
 use rmk_types::connection::ConnectionType;
 use rmk_types::led_indicator::LedIndicator;
+#[cfg(feature = "rynk")]
+use rmk_types::protocol::rynk::RYNK_HID_REPORT_SIZE;
 use trouble_host::prelude::appearance::human_interface_device::KEYBOARD;
 use trouble_host::prelude::service::{BATTERY, HUMAN_INTERFACE_DEVICE};
 use trouble_host::prelude::*;
@@ -20,6 +22,8 @@ use crate::ble::led::BleLedReader;
 #[cfg(feature = "passkey_entry")]
 use crate::ble::passkey::{PasskeyInputState, next_gatt_event};
 use crate::ble::profile::{ProfileInfo, ProfileManager, UPDATED_CCCD_TABLE, UPDATED_PROFILE};
+#[cfg(feature = "rynk")]
+use crate::ble::rynk::{RynkBleSource, RynkHidFrameTracker};
 use crate::channel::{BLE_REPORT_CHANNEL, LED_SIGNAL};
 use crate::config::RmkConfig;
 use crate::core_traits::Runnable;
@@ -300,6 +304,9 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
         server.rynk_service.output_data.clone(),
         server.rynk_service.input_data.clone(),
     );
+    // WebHID transport handles — fixed-size [u8; N] chars are Copy (no clone).
+    #[cfg(feature = "rynk")]
+    let (output_hid, input_hid) = (server.rynk_hid_service.output_data, server.rynk_hid_service.input_data);
     let mouse = server.composite_service.mouse_report;
     let media = server.composite_service.media_report;
     let media_control_point = server.composite_service.hid_control_point;
@@ -307,6 +314,10 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
 
     #[cfg(feature = "passkey_entry")]
     let mut passkey_state = PasskeyInputState::new();
+
+    // WebHID de-frame state: tracks the in-flight rynk frame to drop report padding.
+    #[cfg(feature = "rynk")]
+    let mut hid_frame_tracker = RynkHidFrameTracker::new();
 
     loop {
         #[cfg(feature = "passkey_entry")]
@@ -438,6 +449,7 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
                                         // Awaits the pipe's backpressure when the rynk
                                         // consumer falls behind.
                                         crate::channel::RYNK_BLE_RX_PIPE.write_all(data).await;
+                                        RynkBleSource::Custom.activate();
                                     } else {
                                         warn!("Rynk: dropping {}-byte write on unencrypted link", data.len());
                                     }
@@ -445,9 +457,36 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
 
                                 handled = true;
                             } else if event.handle() == input_host.cccd_handle.expect("No CCCD for host input") {
+                                // Bind the transport only on a real write, not on a CCCD subscribe.
                                 cccd_updated = true;
                                 handled = true;
                             }
+
+                            // WebHID transport (RynkHidService): each write is a fixed
+                            // 32-byte report — a fragment of the rynk frame stream.
+                            // De-frame (drop padding via the header LEN) into the pipe.
+                            #[cfg(feature = "rynk")]
+                            if !handled && event.handle() == output_hid.handle {
+                                let data = event.data();
+                                if encrypted {
+                                    if data.len() == RYNK_HID_REPORT_SIZE {
+                                        let bytes = hid_frame_tracker.take(data);
+                                        crate::channel::RYNK_BLE_RX_PIPE.write_all(bytes).await;
+                                        RynkBleSource::Hid.activate();
+                                    } else {
+                                        warn!("Wrong Rynk HID report size: {}", data.len());
+                                    }
+                                } else {
+                                    warn!("Rynk HID: dropping {}-byte write on unencrypted link", data.len());
+                                }
+                                handled = true;
+                            } else if !handled
+                                && event.handle() == input_hid.cccd_handle.expect("No CCCD for host hid input")
+                            {
+                                cccd_updated = true;
+                                handled = true;
+                            }
+
                             if !handled {
                                 debug!("Write GATT Event to Unknown: {:?}", event.handle());
                             }

--- a/rmk/src/ble/rynk.rs
+++ b/rmk/src/ble/rynk.rs
@@ -1,11 +1,20 @@
-//! Rynk over BLE GATT.
+//! Rynk config over BLE GATT — a single per-connection session shared by both
+//! transports: the custom 128-bit GATT [`RynkService`] (native bluest hosts) and
+//! the vendor HID-over-GATT `RynkHidService` (browsers via WebHID).
 //!
-//! [`run_host_ble`] runs one per-connection session: the inbound pipe as Rx,
-//! a notify-based Tx adapter as the write half. Returns on disconnect.
+//! A connection is one host on one transport, so [`run_host_ble`] runs ONE
+//! [`RynkService::run_session`]: the inbound [`RYNK_BLE_RX_PIPE`] (both transports
+//! de-frame into it in `gatt_events_task`) is the Rx, and [`RynkBleTx`] routes each
+//! reply/topic to whichever characteristic the host is using ([`RynkBleSource`]).
+//! Both carry the same rynk frames, just fragmented to the transport packet —
+//! MTU-chunked on the custom char, fixed 32-byte reports on the HID char. Returns
+//! on disconnect.
+
+use core::sync::atomic::{AtomicU8, Ordering};
 
 use embedded_io_async::{ErrorType, Write};
 use heapless::Vec;
-use rmk_types::protocol::rynk::RYNK_BLE_CHUNK_SIZE;
+use rmk_types::protocol::rynk::{RYNK_BLE_CHUNK_SIZE, RYNK_HEADER_SIZE, RYNK_HID_REPORT_SIZE};
 use trouble_host::prelude::*;
 
 use crate::ble::ble_server::Server;
@@ -13,25 +22,88 @@ use crate::channel::RYNK_BLE_RX_PIPE;
 use crate::host::rynk::RynkService;
 use crate::host::transport::HostTransportError;
 
-/// Run one rynk session over `conn`, clearing stale RX bytes from a prior
-/// connection first. Returns when the session ends.
+/// Which BLE transport the host is using, so the session routes replies/topics to
+/// the right characteristic. Set only on a config WRITE, never on a CCCD subscribe
+/// — the OS HOGP driver auto-subscribes the HID input CCCD on bond, which would
+/// mis-bind a native session's replies. Reset per connection.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum RynkBleSource {
+    /// No transport yet — drop topic pushes (no subscriber).
+    None,
+    /// Custom 128-bit GATT `RynkService` (native hosts).
+    Custom,
+    /// Vendor HID-over-GATT `RynkHidService` (browsers over WebHID).
+    Hid,
+}
+
+static ACTIVE_SOURCE: AtomicU8 = AtomicU8::new(RynkBleSource::None as u8);
+
+impl RynkBleSource {
+    pub(crate) fn activate(self) {
+        ACTIVE_SOURCE.store(self as u8, Ordering::Relaxed);
+    }
+
+    fn active() -> Self {
+        match ACTIVE_SOURCE.load(Ordering::Relaxed) {
+            v if v == Self::Custom as u8 => Self::Custom,
+            v if v == Self::Hid as u8 => Self::Hid,
+            _ => Self::None,
+        }
+    }
+}
+
+/// Drops fixed 32-byte WebHID reports' zero-padding to recover the contiguous
+/// rynk byte stream. `remaining` tracks the in-flight frame (0 at a boundary) so
+/// only its final, padded report gets trimmed.
+pub(crate) struct RynkHidFrameTracker {
+    remaining: usize,
+}
+
+impl RynkHidFrameTracker {
+    pub(crate) const fn new() -> Self {
+        Self { remaining: 0 }
+    }
+
+    /// One report's real frame bytes, padding dropped. At a frame boundary the
+    /// LEN comes from the report header; mid-frame reports pass through whole.
+    pub(crate) fn take<'r>(&mut self, report: &'r [u8]) -> &'r [u8] {
+        if self.remaining == 0 {
+            let (Some(&lo), Some(&hi)) = (report.get(3), report.get(4)) else {
+                return &[];
+            };
+            self.remaining = RYNK_HEADER_SIZE + u16::from_le_bytes([lo, hi]) as usize;
+        }
+        let n = self.remaining.min(report.len());
+        self.remaining -= n;
+        &report[..n]
+    }
+}
+
+/// Run one rynk session over `conn`, clearing stale RX bytes and the transport
+/// selector from a prior connection first. Returns when the session ends.
 pub async fn run_host_ble<'stack, 'server, P: PacketPool>(
     server: &'server Server<'_>,
     conn: &GattConnection<'stack, 'server, P>,
     service: &RynkService<'_>,
 ) {
     RYNK_BLE_RX_PIPE.clear();
+    RynkBleSource::None.activate();
     let mut rx = &RYNK_BLE_RX_PIPE;
     let mut tx = RynkBleTx {
-        input_data: server.rynk_service.input_data.clone(),
+        custom_input: server.rynk_service.input_data.clone(),
+        hid_input: server.rynk_hid_service.input_data,
         conn,
     };
     service.run_session(&mut rx, &mut tx).await;
 }
 
-/// Write half: notifies `input_data` in MTU-bounded chunks.
+/// Write half: routes each reply/topic frame to the active transport's
+/// characteristic — MTU-chunked on the custom char, or fixed 32-byte report
+/// fragments on the HID char.
 struct RynkBleTx<'a, 'b, 'c, P: PacketPool> {
-    input_data: Characteristic<Vec<u8, RYNK_BLE_CHUNK_SIZE>>,
+    custom_input: Characteristic<Vec<u8, RYNK_BLE_CHUNK_SIZE>>,
+    hid_input: Characteristic<[u8; RYNK_HID_REPORT_SIZE]>,
     conn: &'a GattConnection<'b, 'c, P>,
 }
 
@@ -44,22 +116,99 @@ impl<P: PacketPool> Write for RynkBleTx<'_, '_, '_, P> {
         if buf.is_empty() {
             return Ok(0);
         }
-        // A notification past ATT_MTU − 3 is silently truncated, not split, so
-        // chunk to fit — a dropped tail would desync the host's stream.
-        let max_notify = (self.conn.raw().att_mtu() as usize).saturating_sub(3);
-        let chunk_size = RYNK_BLE_CHUNK_SIZE.min(max_notify).max(1);
-        for chunk in buf.chunks(chunk_size) {
-            // chunk_size <= RYNK_BLE_CHUNK_SIZE, so from_slice can't fail.
-            let payload = Vec::<u8, RYNK_BLE_CHUNK_SIZE>::from_slice(chunk).expect("chunk size <= RYNK_BLE_CHUNK_SIZE");
-            if let Err(e) = self.input_data.notify(self.conn, &payload).await {
-                error!("Failed to notify Rynk reply: {:?}", e);
-                return Err(HostTransportError);
+        match RynkBleSource::active() {
+            RynkBleSource::Hid => {
+                // Fragment into fixed 32-byte reports (final one zero-padded); the
+                // host reassembles via the frame header's LEN. N = 32 fits one
+                // notification at MTU ≥ 35.
+                for chunk in buf.chunks(RYNK_HID_REPORT_SIZE) {
+                    let mut report = [0u8; RYNK_HID_REPORT_SIZE];
+                    report[..chunk.len()].copy_from_slice(chunk);
+                    if let Err(e) = self.hid_input.notify(self.conn, &report).await {
+                        error!("Failed to notify Rynk HID reply: {:?}", e);
+                        return Err(HostTransportError);
+                    }
+                }
             }
+            RynkBleSource::Custom => {
+                // Raw, MTU-chunked — a notify past ATT_MTU − 3 is silently
+                // truncated, not split, so a dropped tail would desync the host.
+                let max_notify = (self.conn.raw().att_mtu() as usize).saturating_sub(3);
+                let chunk_size = RYNK_BLE_CHUNK_SIZE.min(max_notify).max(1);
+                for chunk in buf.chunks(chunk_size) {
+                    let payload =
+                        Vec::<u8, RYNK_BLE_CHUNK_SIZE>::from_slice(chunk).expect("chunk size <= RYNK_BLE_CHUNK_SIZE");
+                    if let Err(e) = self.custom_input.notify(self.conn, &payload).await {
+                        error!("Failed to notify Rynk reply: {:?}", e);
+                        return Err(HostTransportError);
+                    }
+                }
+            }
+            // No transport established yet — drop (e.g. a topic emitted before
+            // the host has written a request or subscribed for notifications).
+            RynkBleSource::None => {}
         }
         Ok(buf.len())
     }
 
     async fn flush(&mut self) -> Result<(), Self::Error> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 70-byte frame (header LEN = 65) fragmented into 32-byte reports and
+    /// de-fragmented via the header LEN reassembles exactly, padding dropped.
+    fn frame_70() -> [u8; 70] {
+        let mut frame = [0u8; 70];
+        frame[3..5].copy_from_slice(&65u16.to_le_bytes());
+        for (i, b) in frame.iter_mut().enumerate().skip(RYNK_HEADER_SIZE) {
+            *b = i as u8;
+        }
+        frame
+    }
+
+    /// Seam → pipe: fragment a frame, de-frame each report through the PRODUCTION
+    /// `RynkHidFrameTracker` (exactly as the WebHID arm of `gatt_events_task`), feed the real bytes
+    /// to [`RYNK_BLE_RX_PIPE`], and read it back through `&RYNK_BLE_RX_PIPE` — the
+    /// `Read` the session consumes — as the original contiguous frame.
+    #[test]
+    fn fragments_reassemble_through_pipe_for_session() {
+        use crate::test_support::test_block_on as block_on;
+
+        RYNK_BLE_RX_PIPE.clear();
+        let frame = frame_70();
+
+        let mut tracker = RynkHidFrameTracker::new();
+        for chunk in frame.chunks(RYNK_HID_REPORT_SIZE) {
+            let mut report = [0u8; RYNK_HID_REPORT_SIZE];
+            report[..chunk.len()].copy_from_slice(chunk);
+            let bytes = tracker.take(&report);
+            assert_eq!(RYNK_BLE_RX_PIPE.try_write(bytes).unwrap(), bytes.len());
+        }
+        assert_eq!(tracker.remaining, 0);
+
+        let rx = &RYNK_BLE_RX_PIPE;
+        let mut got = [0u8; 70];
+        let mut n = 0;
+        while n < got.len() {
+            n += block_on(rx.read(&mut got[n..]));
+        }
+        assert_eq!(got, frame);
+    }
+
+    /// A frame smaller than one report: only header + payload are taken, the rest
+    /// of the report is padding.
+    #[test]
+    fn small_frame_drops_padding() {
+        let mut report = [0u8; RYNK_HID_REPORT_SIZE];
+        report[3..5].copy_from_slice(&2u16.to_le_bytes()); // LEN = 2 → 7-byte frame
+        report[5..7].copy_from_slice(&[0xAA, 0xBB]);
+        let mut tracker = RynkHidFrameTracker::new();
+        assert_eq!(tracker.take(&report), &report[..7]);
+        assert_eq!(tracker.remaining, 0);
     }
 }

--- a/rmk/src/channel.rs
+++ b/rmk/src/channel.rs
@@ -111,6 +111,6 @@ pub(crate) static BLE_PROFILE_CHANNEL: Channel<RawMutex, BleProfileAction, 1> = 
 #[cfg(all(feature = "vial", feature = "_ble"))]
 pub(crate) static VIAL_BLE_RX_CHANNEL: Channel<RawMutex, [u8; 32], VIAL_CHANNEL_SIZE> = Channel::new();
 
-/// Rynk RX from the BLE GATT `output_data` writes. The 512 B ring is ~2× one MTU's worth of payload.
+/// Rynk RX from the BLE `output_data` writes. The 512 B ring is ~2× one MTU's maximal payload.
 #[cfg(all(feature = "rynk", feature = "_ble"))]
 pub(crate) static RYNK_BLE_RX_PIPE: embassy_sync::pipe::Pipe<RawMutex, 512> = embassy_sync::pipe::Pipe::new();

--- a/rmk/src/hid.rs
+++ b/rmk/src/hid.rs
@@ -6,6 +6,8 @@ use embassy_usb::class::hid::ReadError;
 use embassy_usb::driver::EndpointError;
 use rmk_types::connection::ConnectionType;
 use rmk_types::led_indicator::LedIndicator;
+#[cfg(feature = "rynk")]
+use rmk_types::protocol::rynk::RYNK_HID_REPORT_SIZE;
 use serde::Serialize;
 use usbd_hid::descriptor::generator_prelude::*;
 use usbd_hid::descriptor::{AsInputReport, MediaKeyboardReport, MouseReport, SystemControlReport};
@@ -57,6 +59,33 @@ pub struct ViaReport {
     pub(crate) input_data: [u8; 32],
     pub(crate) output_data: [u8; 32],
 }
+
+/// Vendor HID report carrying the Rynk config protocol over HID.
+#[cfg(feature = "rynk")]
+#[gen_hid_descriptor(
+    (collection = APPLICATION, usage_page = 0xFF60, usage = 0x61) = {
+        (usage = 0x62, logical_min = 0x0) = {
+            #[item_settings(data,variable,absolute)] input_data=input;
+        };
+        (usage = 0x63, logical_min = 0x0) = {
+            #[item_settings(data,variable,absolute)] output_data=output;
+        };
+    }
+)]
+#[derive(Default)]
+pub struct RynkHidReport {
+    // `gen_hid_descriptor` needs a literal length; keep it in lockstep with
+    // RYNK_HID_REPORT_SIZE (asserted below), which sizes the GATT chars/channel.
+    pub(crate) input_data: [u8; 32],
+    pub(crate) output_data: [u8; 32],
+}
+
+// `core::assert!`: a `defmt` build's crate-level `assert!` isn't const-callable.
+#[cfg(feature = "rynk")]
+const _: () = core::assert!(
+    RYNK_HID_REPORT_SIZE == 32,
+    "RynkHidReport literal length must equal RYNK_HID_REPORT_SIZE"
+);
 
 /// Predefined report ids for composite hid report.
 /// Should be same with `#[gen_hid_descriptor]`

--- a/rmk/src/host/context.rs
+++ b/rmk/src/host/context.rs
@@ -136,6 +136,20 @@ impl<'a> KeyboardContext<'a> {
         let _ = updated;
     }
 
+    /// Write both encoder directions in one synchronous RAM update, then persist
+    /// once.
+    pub async fn set_encoder(&self, layer: u8, idx: u8, action: EncoderAction) {
+        let written = self.keymap.set_encoder(layer as usize, idx as usize, action);
+        #[cfg(feature = "storage")]
+        if written {
+            FLASH_CHANNEL
+                .send(FlashOperationMessage::Encoder { idx, layer, action })
+                .await;
+        }
+        #[cfg(not(feature = "storage"))]
+        let _ = written;
+    }
+
     // ── Macros ───────────────────────────────────────────────────────────
 
     pub fn read_macro_buffer(&self, offset: usize, target: &mut [u8]) {

--- a/rmk/src/host/rynk/handlers/keymap.rs
+++ b/rmk/src/host/rynk/handlers/keymap.rs
@@ -57,13 +57,7 @@ impl Handle<GetEncoderAction> for RynkService<'_> {
 impl Handle<SetEncoderAction> for RynkService<'_> {
     async fn handle(&self, r: SetEncoderRequest) -> Result<(), RynkError> {
         self.check_encoder_bounds(r.layer, r.encoder_id)?;
-        // No clean "set whole encoder" accessor exists yet — split into two writes.
-        self.ctx
-            .set_encoder_clockwise(r.layer, r.encoder_id, r.action.clockwise)
-            .await;
-        self.ctx
-            .set_encoder_counter_clockwise(r.layer, r.encoder_id, r.action.counter_clockwise)
-            .await;
+        self.ctx.set_encoder(r.layer, r.encoder_id, r.action).await;
         Ok(())
     }
 }

--- a/rmk/src/host/rynk/mod.rs
+++ b/rmk/src/host/rynk/mod.rs
@@ -228,6 +228,7 @@ impl RynkService<'_> {
             let Ok(mut msg) = RynkMessage::try_from(&mut buf[..]) else {
                 return;
             };
+
             self.dispatch(&mut msg).await;
             let resp_len = msg.frame_len();
             if tx.write_all(&buf[..resp_len]).await.is_err() {

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -700,6 +700,20 @@ impl<'a> KeyMap<'a> {
         None
     }
 
+    /// Write both directions of an encoder under one borrow. Returns `false`
+    /// if the slot is out of range.
+    pub(crate) fn set_encoder(&self, layer: usize, id: usize, action: EncoderAction) -> bool {
+        let mut inner = self.inner.borrow_mut();
+        let idx = inner.encoder_index(layer, id);
+        if let Some(encoders) = &mut inner.encoders
+            && let Some(slot) = encoders.get_mut(idx)
+        {
+            *slot = action;
+            return true;
+        }
+        false
+    }
+
     // ── Macro buffer (for Vial DynamicKeymapMacroGetBuffer/SetBuffer) ──
 
     pub(crate) fn read_macro_buffer(&self, offset: usize, target: &mut [u8]) {

--- a/rmk/tests/common/mod.rs
+++ b/rmk/tests/common/mod.rs
@@ -1,5 +1,7 @@
 pub mod morse;
 #[cfg(feature = "rynk")]
+pub mod rynk_hid_link;
+#[cfg(feature = "rynk")]
 pub mod rynk_link;
 pub mod test_block_on;
 pub mod test_macro;

--- a/rmk/tests/common/rynk_hid_link.rs
+++ b/rmk/tests/common/rynk_hid_link.rs
@@ -1,0 +1,237 @@
+//! HID-framed variant of [`super::rynk_link`]: interposes the fixed 32-byte HID
+//! report framing (firmware `RynkHidService`, de-framed at the `ble::rynk` seam
+//! via `drop_report_padding` and reply-framed by `RynkBleTx`) between the host
+//! client and `run_session`, so the framing round-trips through the *real*
+//! dispatcher.
+//!
+//! The two pipes carry whole 32-byte reports, each a fragment of the rynk frame
+//! stream (final report zero-padded); the frame header's LEN delimits the frame.
+//! The device-side `HidRx`/`HidTx` and the client mirror the firmware framing;
+//! `run_session` itself sees a clean contiguous byte stream and is unchanged.
+
+use embassy_futures::select::{Either, select};
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::pipe::Pipe;
+use embedded_io_async::{ErrorType, Read, Write};
+use rmk::host::HostService as RynkService;
+use rmk_types::constants::RYNK_BUFFER_SIZE;
+use rmk_types::protocol::rynk::{Cmd, RYNK_HEADER_SIZE, RYNK_HID_REPORT_SIZE, RynkError, RynkHeader, RynkMessage};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use super::test_block_on::test_block_on;
+
+/// One direction of the link, carrying whole HID reports.
+pub type Link = Pipe<NoopRawMutex, RYNK_BUFFER_SIZE>;
+
+/// Fragment `data` (one frame) into fixed 32-byte reports, the final one
+/// zero-padded, and write each to `link`. Mirrors the firmware HID framing.
+async fn write_framed(link: &Link, data: &[u8]) {
+    for chunk in data.chunks(RYNK_HID_REPORT_SIZE) {
+        let mut report = [0u8; RYNK_HID_REPORT_SIZE];
+        report[..chunk.len()].copy_from_slice(chunk);
+        link.write_all(&report).await;
+    }
+}
+
+/// A frame read off the wire, decoded only as far as its header.
+pub struct Frame {
+    pub header: RynkHeader,
+    pub payload: Vec<u8>,
+}
+
+impl Frame {
+    /// Decode the payload as a `Result<T, RynkError>` envelope, strictly.
+    pub fn envelope<T: DeserializeOwned>(&self) -> Result<T, RynkError> {
+        let (env, rest) = postcard::take_from_bytes::<Result<T, RynkError>>(&self.payload)
+            .expect("response payload must decode as an envelope");
+        assert!(rest.is_empty(), "response payload has {} trailing byte(s)", rest.len());
+        env
+    }
+
+    /// Decode the payload as a bare `T` — topic frames are not enveloped.
+    pub fn raw<T: DeserializeOwned>(&self) -> T {
+        let (value, rest) = postcard::take_from_bytes::<T>(&self.payload).expect("topic payload must decode");
+        assert!(rest.is_empty(), "topic payload has {} trailing byte(s)", rest.len());
+        value
+    }
+}
+
+/// Device-side Rx: reads whole reports off the pipe and de-frames them into the
+/// byte stream `run_session` reads. Mirrors the firmware de-frame (`ble::rynk`'s
+/// `drop_report_padding` feeding `RYNK_BLE_RX_PIPE`), with `pending`/`pos` standing
+/// in for the pipe's buffering and `remaining` tracking the in-flight frame.
+struct HidRx<'p> {
+    link: &'p Link,
+    pending: Vec<u8>,
+    pos: usize,
+    remaining: usize,
+}
+
+impl ErrorType for HidRx<'_> {
+    type Error = core::convert::Infallible;
+}
+
+impl Read for HidRx<'_> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        loop {
+            if self.pos < self.pending.len() {
+                let n = (self.pending.len() - self.pos).min(buf.len());
+                buf[..n].copy_from_slice(&self.pending[self.pos..self.pos + n]);
+                self.pos += n;
+                return Ok(n);
+            }
+            let mut link: &Link = self.link;
+            let mut report = [0u8; RYNK_HID_REPORT_SIZE];
+            link.read_exact(&mut report).await.expect("read report");
+            if self.remaining == 0 {
+                self.remaining = RYNK_HEADER_SIZE + u16::from_le_bytes([report[3], report[4]]) as usize;
+            }
+            let take = self.remaining.min(RYNK_HID_REPORT_SIZE);
+            self.remaining -= take;
+            self.pending.clear();
+            self.pending.extend_from_slice(&report[..take]);
+            self.pos = 0;
+        }
+    }
+}
+
+/// Device-side Tx: frames `run_session`'s whole-frame writes into reports onto
+/// the pipe. Mirrors the firmware reply framing (`ble::rynk::RynkBleTx`, HID arm).
+struct HidTx<'p> {
+    link: &'p Link,
+}
+
+impl ErrorType for HidTx<'_> {
+    type Error = core::convert::Infallible;
+}
+
+impl Write for HidTx<'_> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        write_framed(self.link, buf).await;
+        Ok(buf.len())
+    }
+
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+/// Host end of the link. Frames requests into reports and reassembles responses
+/// from reports, sharing the `rmk-types` codec with the device.
+pub struct RynkHidClient<'p> {
+    rx: &'p Link,
+    tx: &'p Link,
+    buf: [u8; RYNK_BUFFER_SIZE],
+}
+
+impl RynkHidClient<'_> {
+    /// Encode a request frame and write it as fixed 32-byte report fragments.
+    pub async fn send<T: Serialize>(&mut self, cmd: Cmd, seq: u8, payload: &T) {
+        let n = RynkMessage::build(&mut self.buf, cmd, seq, payload)
+            .expect("build request frame")
+            .frame_len();
+        write_framed(self.tx, &self.buf[..n]).await;
+    }
+
+    /// Read whole reports and reassemble exactly one rynk frame — reports carry a
+    /// fragment of the frame, so this may consume several; the header LEN delimits
+    /// it and the final report's padding is dropped.
+    pub async fn recv_frame(&mut self) -> Frame {
+        let mut link: &Link = self.rx;
+        let mut stream: Vec<u8> = Vec::new();
+        let mut remaining = 0usize;
+        loop {
+            let mut report = [0u8; RYNK_HID_REPORT_SIZE];
+            link.read_exact(&mut report).await.expect("read report");
+            if remaining == 0 {
+                remaining = RYNK_HEADER_SIZE + u16::from_le_bytes([report[3], report[4]]) as usize;
+            }
+            let take = remaining.min(RYNK_HID_REPORT_SIZE);
+            remaining -= take;
+            stream.extend_from_slice(&report[..take]);
+            if remaining == 0 {
+                let mut head = [0u8; RYNK_HEADER_SIZE];
+                head.copy_from_slice(&stream[..RYNK_HEADER_SIZE]);
+                let header = RynkHeader::parse(&head);
+                let payload = stream[RYNK_HEADER_SIZE..].to_vec();
+                return Frame { header, payload };
+            }
+        }
+    }
+
+    /// Read frames until one echoes `seq`, skipping any topic pushes (seq 0).
+    pub async fn recv_response(&mut self, seq: u8) -> Frame {
+        debug_assert_ne!(
+            seq, 0,
+            "use a non-zero request seq so topic frames (seq 0) don't alias it"
+        );
+        loop {
+            let frame = self.recv_frame().await;
+            if frame.header.seq == seq {
+                return frame;
+            }
+            assert_eq!(
+                frame.header.seq, 0,
+                "unexpected frame (cmd={:?}, seq={}) while awaiting response seq {}",
+                frame.header.cmd, frame.header.seq, seq,
+            );
+        }
+    }
+
+    /// One full request/response round-trip across the HID framing.
+    pub async fn request<Req: Serialize, Resp: DeserializeOwned>(
+        &mut self,
+        cmd: Cmd,
+        seq: u8,
+        req: &Req,
+    ) -> Result<Resp, RynkError> {
+        self.send(cmd, seq, req).await;
+        let frame = self.recv_response(seq).await;
+        assert_eq!(frame.header.cmd, cmd, "response must echo the request cmd");
+        frame.envelope()
+    }
+
+    /// Await the next unsolicited topic push.
+    pub async fn recv_topic(&mut self) -> Frame {
+        let frame = self.recv_frame().await;
+        assert!(
+            frame.header.cmd.is_topic(),
+            "expected a topic frame, got cmd={:?}",
+            frame.header.cmd
+        );
+        assert_eq!(frame.header.seq, 0, "topic frames use seq 0");
+        frame
+    }
+}
+
+/// Run `script` (playing the host) against `service` with HID report framing
+/// interposed on both ends; returns the script's value. Same lifecycle contract
+/// as [`super::rynk_link::link_session`]: the session resolving first is a
+/// framing bug, so we panic.
+pub fn link_session_hid<T>(service: &RynkService<'_>, script: impl AsyncFnOnce(&mut RynkHidClient<'_>) -> T) -> T {
+    let h2d = Link::new();
+    let d2h = Link::new();
+    let mut dev_rx = HidRx {
+        link: &h2d,
+        pending: Vec::new(),
+        pos: 0,
+        remaining: 0,
+    };
+    let mut dev_tx = HidTx { link: &d2h };
+    let mut client = RynkHidClient {
+        rx: &d2h,
+        tx: &h2d,
+        buf: [0u8; RYNK_BUFFER_SIZE],
+    };
+    test_block_on(async {
+        let device = select(
+            service.run_session(&mut dev_rx, &mut dev_tx),
+            rmk::channel::drain_flash_channel_for_test(),
+        );
+        match select(device, script(&mut client)).await {
+            Either::First(_) => panic!("run_session ended before the client script finished"),
+            Either::Second(value) => value,
+        }
+    })
+}

--- a/rmk/tests/common/rynk_link.rs
+++ b/rmk/tests/common/rynk_link.rs
@@ -27,6 +27,7 @@
 //! (`take_from_bytes` rejecting trailing bytes), which is what keeps the two
 //! ends from drifting.
 
+use embassy_futures::join::join;
 use embassy_futures::select::{Either, select};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::pipe::Pipe;
@@ -186,6 +187,48 @@ pub fn link_session<T>(service: &RynkService<'_>, script: impl AsyncFnOnce(&mut 
         );
         match select(device, script(&mut client)).await {
             Either::First(_) => panic!("run_session ended before the client script finished"),
+            Either::Second(value) => value,
+        }
+    })
+}
+
+/// Like [`link_session`] but runs TWO concurrent `run_session`s over the SAME
+/// `service` — the production shape on a board that exposes both BLE-GATT and
+/// BLE-HID (or BLE + USB), where each transport drives its own session against
+/// one shared `RynkService`/`KeyMap` and its own `TopicSubscribers`. Exercises
+/// the dispatch guard and the concurrent-subscriber path. `script` drives both
+/// host ends.
+pub fn link_two_sessions<T>(
+    service: &RynkService<'_>,
+    script: impl AsyncFnOnce(&mut RynkClient<'_>, &mut RynkClient<'_>) -> T,
+) -> T {
+    let (h2d_a, d2h_a, h2d_b, d2h_b) = (Link::new(), Link::new(), Link::new(), Link::new());
+    let mut dev_rx_a: &Link = &h2d_a;
+    let mut dev_tx_a: &Link = &d2h_a;
+    let mut dev_rx_b: &Link = &h2d_b;
+    let mut dev_tx_b: &Link = &d2h_b;
+    let mut client_a = RynkClient {
+        rx: &d2h_a,
+        tx: &h2d_a,
+        buf: [0u8; RYNK_BUFFER_SIZE],
+    };
+    let mut client_b = RynkClient {
+        rx: &d2h_b,
+        tx: &h2d_b,
+        buf: [0u8; RYNK_BUFFER_SIZE],
+    };
+    test_block_on(async {
+        // Both sessions run concurrently and never EOF; the pair is dropped once
+        // the script returns. Either resolving first is a framing/guard bug.
+        let devices = select(
+            join(
+                service.run_session(&mut dev_rx_a, &mut dev_tx_a),
+                service.run_session(&mut dev_rx_b, &mut dev_tx_b),
+            ),
+            rmk::channel::drain_flash_channel_for_test(),
+        );
+        match select(devices, script(&mut client_a, &mut client_b)).await {
+            Either::First(_) => panic!("a run_session ended before the client script finished"),
             Either::Second(value) => value,
         }
     })

--- a/rmk/tests/rynk_hid_loopback.rs
+++ b/rmk/tests/rynk_hid_loopback.rs
@@ -1,0 +1,96 @@
+//! HID-framed loopback: the same production [`RynkService::run_session`] as
+//! `rynk_loopback.rs`, but every exchange crosses the fixed 32-byte HID report
+//! framing (firmware `RynkHidService`; de-framed at the `ble::rynk` seam via
+//! `drop_report_padding`, reply-framed by `ble::rynk::RynkBleTx`). Proves the
+//! framing round-trips through the real dispatcher: single-report frames,
+//! multi-report reassembly (`GetCapabilities` > 32 B), a pipelined two-request
+//! session, and a server→host topic push.
+
+#![cfg(feature = "rynk")]
+
+pub mod common;
+
+use rmk::config::{BehaviorConfig, PositionalConfig, RmkConfig};
+use rmk::event::{WpmUpdateEvent, publish_event};
+use rmk::host::HostService as RynkService;
+use rmk::types::action::{Action, KeyAction};
+use rmk::types::keycode::{HidKeyCode, KeyCode};
+use rmk_types::protocol::rynk::{Cmd, DeviceCapabilities, KeyPosition, ProtocolVersion, SetKeyRequest};
+
+use crate::common::rynk_hid_link::link_session_hid;
+use crate::common::wrap_keymap;
+
+/// A 2-layer 2×2 `RynkService`, leaked to `'static` (see `rynk_loopback.rs`).
+fn service() -> RynkService<'static> {
+    let behavior: &'static mut BehaviorConfig = Box::leak(Box::new(BehaviorConfig::default()));
+    let per_key: &'static PositionalConfig<2, 2> = Box::leak(Box::new(PositionalConfig::default()));
+    let keymap = [[[KeyAction::No; 2]; 2]; 1];
+    let km = wrap_keymap(keymap, per_key, behavior);
+    let config: &'static RmkConfig<'static> = Box::leak(Box::new(RmkConfig::default()));
+    RynkService::new(km, config)
+}
+
+/// Smallest exchange: an empty request and an 8-byte response each fit one report.
+#[test]
+fn get_version_over_hid_framing() {
+    let service = service();
+    link_session_hid(&service, async |client| {
+        let version = client.request::<(), ProtocolVersion>(Cmd::GetVersion, 0x42, &()).await;
+        assert_eq!(version, Ok(ProtocolVersion::CURRENT));
+    });
+}
+
+/// `DeviceCapabilities` exceeds one 32-byte report, so its reply spans several —
+/// this is the case that actually exercises multi-report Tx framing + the
+/// client's reassembly.
+#[test]
+fn get_capabilities_spans_multiple_reports() {
+    let service = service();
+    link_session_hid(&service, async |client| {
+        let caps = client
+            .request::<(), DeviceCapabilities>(Cmd::GetCapabilities, 0x07, &())
+            .await
+            .expect("Ok envelope");
+        assert_eq!(caps.num_layers, 1);
+        assert_eq!(caps.num_rows, 2);
+        assert_eq!(caps.num_cols, 2);
+        assert_eq!(caps.storage_enabled, cfg!(feature = "storage"));
+        assert_eq!(caps.ble_enabled, cfg!(feature = "_ble"));
+    });
+}
+
+/// Two requests pipelined over one session: the stream stays alive across the
+/// Set response (no spurious EOF), and the Get reads back the mutated state.
+#[test]
+fn set_then_get_key_action_round_trip() {
+    let service = service();
+    link_session_hid(&service, async |client| {
+        let position = KeyPosition {
+            layer: 0,
+            row: 1,
+            col: 0,
+        };
+        let action = KeyAction::Single(Action::Key(KeyCode::Hid(HidKeyCode::A)));
+
+        let set = SetKeyRequest { position, action };
+        let r = client.request::<_, ()>(Cmd::SetKeyAction, 0x01, &set).await;
+        assert_eq!(r, Ok(()), "SetKeyAction should accept an in-range write");
+
+        let got = client.request::<_, KeyAction>(Cmd::GetKeyAction, 0x02, &position).await;
+        assert_eq!(got, Ok(action), "GetKeyAction should read back what Set wrote");
+    });
+}
+
+/// Server→host push: a topic frame emitted between turns must also survive the
+/// HID framing (here a single small report).
+#[test]
+fn topic_push_over_hid_framing() {
+    let service = service();
+    let v = link_session_hid(&service, async |client| {
+        publish_event(WpmUpdateEvent::new(42));
+        let frame = client.recv_topic().await;
+        assert_eq!(frame.header.cmd, Cmd::WpmUpdate);
+        frame.raw::<u16>()
+    });
+    assert_eq!(v, 42);
+}

--- a/rmk/tests/rynk_loopback.rs
+++ b/rmk/tests/rynk_loopback.rs
@@ -41,7 +41,7 @@ use rmk_types::protocol::rynk::{
     SetForkRequest, SetKeyRequest, SetMacroRequest, SetMorseRequest, StorageResetMode,
 };
 
-use crate::common::rynk_link::link_session;
+use crate::common::rynk_link::{link_session, link_two_sessions};
 use crate::common::{wrap_keymap, wrap_keymap_with_encoders};
 
 /// Build a `RynkService` over a tiny 1-layer 2-row 2-col keymap, so the tests
@@ -203,6 +203,48 @@ fn get_set_key_action_round_trip() {
     });
 }
 
+/// Two `run_session`s over one shared `RynkService` — the production shape when
+/// a board runs the BLE-GATT and BLE-HID (`RynkHidService`) sessions
+/// concurrently. Both build their own `TopicSubscribers` against the global
+/// event channels and share one `KeyMap`; this must not panic (subscriber
+/// overflow or RefCell double-borrow) and writes from one session must be
+/// visible to the other.
+#[test]
+fn concurrent_sessions_share_one_service() {
+    let service = service_2_layers();
+    link_two_sessions(&service, async |a, b| {
+        let position = KeyPosition {
+            layer: 1,
+            row: 0,
+            col: 0,
+        };
+        let key_a = KeyAction::Single(Action::Key(KeyCode::Hid(HidKeyCode::A)));
+        let key_b = KeyAction::Single(Action::Key(KeyCode::Hid(HidKeyCode::B)));
+
+        // Write from session A, then session B, over the shared KeyMap.
+        let set_a = SetKeyRequest {
+            position,
+            action: key_a,
+        };
+        assert_eq!(a.request::<_, ()>(Cmd::SetKeyAction, 0x11, &set_a).await, Ok(()));
+        let set_b = SetKeyRequest {
+            position,
+            action: key_b,
+        };
+        assert_eq!(b.request::<_, ()>(Cmd::SetKeyAction, 0x21, &set_b).await, Ok(()));
+
+        // Both sessions read the same shared state — B's write (the last) wins.
+        let from_a = a.request::<_, KeyAction>(Cmd::GetKeyAction, 0x12, &position).await;
+        let from_b = b.request::<_, KeyAction>(Cmd::GetKeyAction, 0x22, &position).await;
+        assert_eq!(
+            from_a,
+            Ok(key_b),
+            "session A observes session B's write (shared KeyMap)"
+        );
+        assert_eq!(from_b, Ok(key_b), "session B reads back its own write");
+    });
+}
+
 #[test]
 fn get_key_action_rejects_out_of_range() {
     let service = service();
@@ -336,6 +378,35 @@ fn capabilities_report_configured_encoder_count() {
             .request::<_, EncoderAction>(Cmd::GetEncoderAction, 0x09, &oor)
             .await;
         assert_eq!(r, Err(RynkError::Invalid));
+    });
+}
+
+#[test]
+fn get_set_encoder_round_trip() {
+    // SetEncoderAction writes both directions in one shot; the readback must
+    // reflect the whole `EncoderAction`, not a half-applied pair.
+    let service = service_with_encoders();
+    link_session(&service, async |client| {
+        let action = EncoderAction::new(
+            KeyAction::Single(Action::Key(KeyCode::Hid(HidKeyCode::A))),
+            KeyAction::Single(Action::Key(KeyCode::Hid(HidKeyCode::B))),
+        );
+        let set = SetEncoderRequest {
+            encoder_id: 1,
+            layer: 0,
+            action,
+        };
+        let r = client.request::<_, ()>(Cmd::SetEncoderAction, 0x0A, &set).await;
+        assert_eq!(r, Ok(()));
+
+        let get = GetEncoderRequest {
+            encoder_id: 1,
+            layer: 0,
+        };
+        let read = client
+            .request::<_, EncoderAction>(Cmd::GetEncoderAction, 0x0B, &get)
+            .await;
+        assert_eq!(read, Ok(action));
     });
 }
 


### PR DESCRIPTION
For remapping over BLE in web, HID over BLE is necessary.