### PR TITLE
Add tsify wasm/TS type generation

### DIFF
--- a/rmk-types/Cargo.toml
+++ b/rmk-types/Cargo.toml
@@ -19,6 +19,11 @@ strum = { version = "0.28", default-features = false, features = ["derive"] }
 
 bitfield-struct = "0.13"
 
+# TypeScript type + wasm-bindgen ABI generation for the web client
+tsify = { version = "0.5", optional = true, default-features = false, features = ["js"] }
+wasm-bindgen = { version = "0.2", optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
+
 [build-dependencies]
 rmk-config = { path = "../rmk-config", version = "=0.6.1" }
 toml = "1.0"
@@ -39,6 +44,9 @@ rynk = []
 bulk = ["rynk"]
 # Host tool: uses protocol ceiling values for Vec capacities.
 host = ["rynk", "bulk", "_ble", "split", "steno"]
+# TypeScript type + wasm ABI export for the web client. Enabled by a codegen/wasm
+# build, never by firmware.
+wasm = ["dep:tsify", "dep:wasm-bindgen", "dep:serde-wasm-bindgen", "host"]
 # Build-time only features: forwarded from rmk to control constant generation in build.rs.
 _ble = []
 split = []

--- a/rmk-types/src/fmt.rs
+++ b/rmk-types/src/fmt.rs
@@ -33,3 +33,49 @@ macro_rules! impl_debug_list {
         }
     };
 }
+
+/// Bridges Rust `#[bitfield(u8)]` types with non-bitfield TypeScript objects.
+/// With `feature = "wasm"`, emits the TypeScript object type.
+///
+/// Also implements Serialize/Deserialize so Rust values can be converted to
+/// TypeScript objects seamlessly.
+#[macro_export]
+macro_rules! bitfield_named_serde {
+    ($bitfield:ident, { $( $field:ident = $setter:ident ),+ $(,)? }) => {
+        impl serde::Serialize for $bitfield {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> ::core::result::Result<S::Ok, S::Error> {
+                if serializer.is_human_readable() {
+                    #[derive(serde::Serialize)]
+                    struct Repr { $($field: bool,)+ }
+                    serde::Serialize::serialize(&Repr { $($field: self.$field(),)+ }, serializer)
+                } else {
+                    serializer.serialize_u8(self.into_bits())
+                }
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for $bitfield {
+            fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> ::core::result::Result<Self, D::Error> {
+                if deserializer.is_human_readable() {
+                    #[derive(serde::Deserialize)]
+                    struct Repr { $($field: bool,)+ }
+                    let r = <Repr as serde::Deserialize>::deserialize(deserializer)?;
+                    ::core::result::Result::Ok(Self::new() $(.$setter(r.$field))+)
+                } else {
+                    ::core::result::Result::Ok(Self::from_bits(<u8 as serde::Deserialize>::deserialize(deserializer)?))
+                }
+            }
+        }
+
+        // Static `.d.ts` shape, built from the same field table.
+        #[cfg(feature = "wasm")]
+        const _: () = {
+            #[::wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
+            const TS_APPEND_CONTENT: &'static str = concat!(
+                "export type ", stringify!($bitfield), " = {",
+                $( " ", stringify!($field), ": boolean;", )+
+                " };"
+            );
+        };
+    };
+}

--- a/rmk-types/src/led_indicator.rs
+++ b/rmk-types/src/led_indicator.rs
@@ -6,7 +6,6 @@ use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
 
 use bitfield_struct::bitfield;
 use postcard::experimental::max_size::MaxSize;
-use serde::{Deserialize, Serialize};
 
 /// Indicators defined in the HID spec 11.1
 #[derive(Debug)]
@@ -20,7 +19,7 @@ pub enum LedIndicatorType {
 }
 
 #[bitfield(u8, defmt = cfg(feature = "defmt"))]
-#[derive(Eq, PartialEq, Serialize, Deserialize, MaxSize)]
+#[derive(Eq, PartialEq, MaxSize)]
 pub struct LedIndicator {
     #[bits(1)]
     pub num_lock: bool,
@@ -35,6 +34,15 @@ pub struct LedIndicator {
     #[bits(3)]
     _reserved: u8,
 }
+
+// u8 on the wire (postcard); named bools on serde-wasm-bindgen / serde_json (TS).
+crate::bitfield_named_serde!(LedIndicator, {
+    num_lock = with_num_lock,
+    caps_lock = with_caps_lock,
+    scroll_lock = with_scroll_lock,
+    compose = with_compose,
+    kana = with_kana,
+});
 
 impl BitOr for LedIndicator {
     type Output = Self;

--- a/rmk-types/src/lib.rs
+++ b/rmk-types/src/lib.rs
@@ -28,7 +28,7 @@
 //! ### Build-time
 //! - [`constants`] — Generated from `keyboard.toml` by `build.rs`
 
-#![no_std]
+#![cfg_attr(not(feature = "wasm"), no_std)]
 
 pub mod action;
 pub mod battery;

--- a/rmk-types/src/modifier.rs
+++ b/rmk-types/src/modifier.rs
@@ -7,13 +7,12 @@ use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
 
 use bitfield_struct::bitfield;
 use postcard::experimental::max_size::MaxSize;
-use serde::{Deserialize, Serialize};
 
 use crate::keycode::HidKeyCode;
 
 /// The bit representation of the modifier combination.
 #[bitfield(u8, order = Lsb, debug = false)]
-#[derive(Serialize, Deserialize, MaxSize, Eq, PartialEq)]
+#[derive(MaxSize, Eq, PartialEq)]
 pub struct ModifierCombination {
     #[bits(1)]
     pub left_ctrl: bool,
@@ -45,6 +44,18 @@ crate::impl_debug_list!(ModifierCombination, |self| [
 ]
 .into_iter()
 .filter_map(|(state, label)| state.then_some(label)));
+
+// u8 on the wire (postcard); named bools on serde-wasm-bindgen / serde_json (TS).
+crate::bitfield_named_serde!(ModifierCombination, {
+    left_ctrl = with_left_ctrl,
+    left_shift = with_left_shift,
+    left_alt = with_left_alt,
+    left_gui = with_left_gui,
+    right_ctrl = with_right_ctrl,
+    right_shift = with_right_shift,
+    right_alt = with_right_alt,
+    right_gui = with_right_gui,
+});
 
 impl BitOr for ModifierCombination {
     type Output = Self;

--- a/rmk-types/src/mouse_button.rs
+++ b/rmk-types/src/mouse_button.rs
@@ -6,11 +6,10 @@ use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
 
 use bitfield_struct::bitfield;
 use postcard::experimental::max_size::MaxSize;
-use serde::{Deserialize, Serialize};
 
 /// Mouse buttons
 #[bitfield(u8, order = Lsb, defmt = cfg(feature = "defmt"))]
-#[derive(Eq, PartialEq, Serialize, Deserialize, MaxSize)]
+#[derive(Eq, PartialEq, MaxSize)]
 pub struct MouseButtons {
     #[bits(1)]
     pub button1: bool, //left
@@ -29,6 +28,18 @@ pub struct MouseButtons {
     #[bits(1)]
     pub button8: bool,
 }
+
+// u8 on the wire (postcard); named bools on serde-wasm-bindgen / serde_json (TS).
+crate::bitfield_named_serde!(MouseButtons, {
+    button1 = with_button1,
+    button2 = with_button2,
+    button3 = with_button3,
+    button4 = with_button4,
+    button5 = with_button5,
+    button6 = with_button6,
+    button7 = with_button7,
+    button8 = with_button8,
+});
 
 impl BitOr for MouseButtons {
     type Output = Self;

--- a/rmk-types/src/protocol/rynk/payload/system.rs
+++ b/rmk-types/src/protocol/rynk/payload/system.rs
@@ -11,6 +11,8 @@ pub const UNLOCK_KEYS_SIZE: usize = 2;
 
 /// Protocol version advertised during the connection handshake.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, MaxSize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ProtocolVersion {
     pub major: u8,
     pub minor: u8,
@@ -27,6 +29,8 @@ impl ProtocolVersion {
 /// The host reads this once after connecting to learn the firmware's layout,
 /// feature set, and protocol limits.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, MaxSize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct DeviceCapabilities {
     // -- Layout --
     pub num_layers: u8,


### PR DESCRIPTION
Add tsify 0.5 (gated behind the new `wasm` feature) so the web client's typed signatures carry real types instead of `any`; the crate drops `no_std` only under `feature = "wasm"` (host/codegen build), firmware is unaffected. tsify derives on ProtocolVersion / DeviceCapabilities.
