### PR TITLE
ci: upload bin artifacts for RISC-V esp32 chips in user build

### DIFF
--- a/.github/workflows/user_build.yml
+++ b/.github/workflows/user_build.yml
@@ -81,6 +81,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: get_chip_name
+    # Only esp32s3 (Xtensa) needs the espup toolchain in build_esp;
+    # RISC-V esp32 chips build here with the standard toolchain.
     if: needs.get_chip_name.outputs.chip_name != 'esp32s3'
     steps:
       - uses: cargo-bins/cargo-binstall@main
@@ -111,15 +113,24 @@ jobs:
         working-directory: ./rmk
         run: cargo make uf2 --release
       - name: Upload uf2 artifacts
+        if: ${{ !startsWith(needs.get_chip_name.outputs.chip_name, 'esp32') }}
         uses: actions/upload-artifact@v7
         with:
           name: ${{ needs.get_chip_name.outputs.artifact_prefix }}${{ needs.get_chip_name.outputs.project_name }}-firmware_uf2
           path: rmk/*.uf2
       - name: Upload hex artifacts
+        if: ${{ !startsWith(needs.get_chip_name.outputs.chip_name, 'esp32') }}
         uses: actions/upload-artifact@v7
         with:
           name: ${{ needs.get_chip_name.outputs.artifact_prefix }}${{ needs.get_chip_name.outputs.project_name }}-firmware_hex
           path: rmk/*.hex
+      - name: Upload bin artifacts
+        # espflash produces .bin images for esp32 chips instead of uf2/hex
+        if: ${{ startsWith(needs.get_chip_name.outputs.chip_name, 'esp32') }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ needs.get_chip_name.outputs.artifact_prefix }}${{ needs.get_chip_name.outputs.project_name }}-firmware_bin
+          path: rmk/*.bin
   build_esp:
     runs-on: ubuntu-latest
     needs: get_chip_name


### PR DESCRIPTION
## Problem

RISC-V esp32 chips (esp32c3/c6/h2) don't match the `build_esp` gate (`chip_name == 'esp32s3'`), so they run in the generic `build` job. The build succeeds — cargo-make auto-installs `cargo-espflash`, and the template's `uf2` task produces `.bin` images — but the job only uploads `rmk/*.uf2` and `rmk/*.hex`, so no artifacts appear.

Reported by @peterjc for an esp32h2 split build: https://github.com/peterjc/rmk-pico-keyboards/actions/runs/28672157097/job/85037673964

## Fix

- Add an `Upload bin artifacts` step (`rmk/*.bin`) to the generic `build` job, gated to esp32 chips.
- Gate the uf2/hex upload steps to non-esp32 chips, removing the misleading "No files were found" warnings.

`build_esp` stays gated on exactly `esp32s3` — it exists for the Xtensa/espup toolchain, which RISC-V esp32 chips don't need.

Companion fix in rmk-template names the split esp32 images `<project>-central.bin`/`<project>-peripheral.bin` instead of hardcoded `central.bin`/`peripheral.bin`: HaoboGu/rmk-template#24

## Verification

- `actionlint`: no new findings vs. `main` (11 pre-existing info-level shellcheck notes on both).
- Generated an esp32h2 split project from the updated template locally and ran `cargo make uf2 --release`: produced `Fly_Half_ESP32H2-central.bin` and `Fly_Half_ESP32H2-peripheral.bin`, which the new `rmk/*.bin` glob matches.
