### PR TITLE
Add GetDeviceInfo endpoint

### DIFF
--- a/rmk-types/src/protocol/rynk/command.rs
+++ b/rmk-types/src/protocol/rynk/command.rs
@@ -10,9 +10,9 @@
 use super::endpoint::{Endpoint, Topic, max_const};
 use super::message::RynkMessage;
 use super::{
-    BehaviorConfig, DeviceCapabilities, GetEncoderRequest, GetMacroRequest, KeyPosition, MacroData, MatrixState,
-    ProtocolVersion, RynkError, SetComboRequest, SetEncoderRequest, SetForkRequest, SetKeyRequest, SetMacroRequest,
-    SetMorseRequest, StorageResetMode,
+    BehaviorConfig, DeviceCapabilities, DeviceInfo, GetEncoderRequest, GetMacroRequest, KeyPosition, MacroData,
+    MatrixState, ProtocolVersion, RynkError, SetComboRequest, SetEncoderRequest, SetForkRequest, SetKeyRequest,
+    SetMacroRequest, SetMorseRequest, StorageResetMode,
 };
 #[cfg(feature = "bulk")]
 use super::{
@@ -196,12 +196,14 @@ macro_rules! topics {
 
 // Define endpoints: `Name = value: Request => Response;`
 endpoints! {
-    // ── System (0x00xx); 0x0006..=0x0008 reserved for the lock gate ──
+    // ── System (0x00xx); 0x0006..=0x0008 reserved for the lock gate, 0x0009 for layout ──
     GetVersion = 0x0001: () => ProtocolVersion;
     GetCapabilities = 0x0002: () => DeviceCapabilities;
     Reboot = 0x0003: () => ();
     BootloaderJump = 0x0004: () => ();
     StorageReset = 0x0005: StorageResetMode => ();
+    /// Identity strings and USB ids; feature gating stays in `GetCapabilities`.
+    GetDeviceInfo = 0x000A: () => DeviceInfo;
 
     // ── Keymap (0x01xx) — includes encoder ──
     GetKeyAction = 0x0101: KeyPosition => KeyAction;

--- a/rmk-types/src/protocol/rynk/message.rs
+++ b/rmk-types/src/protocol/rynk/message.rs
@@ -141,15 +141,15 @@ impl<'a> TryFrom<&'a mut [u8]> for RynkMessage<'a> {
 mod tests {
     use postcard::experimental::max_size::MaxSize;
 
-    use super::super::DeviceCapabilities;
+    use super::super::DeviceInfo;
     use super::*;
 
     #[test]
     fn rynk_min_buffer_size_covers_largest_known_response() {
-        // `DeviceCapabilities` is one of the largest single-message responses
-        // when bulk is disabled; the min buffer must hold its wrapped form
-        // plus header.
-        let wrapped = <Result<DeviceCapabilities, RynkError> as MaxSize>::POSTCARD_MAX_SIZE;
+        // `DeviceInfo` (three 32-byte strings) is the largest single-message
+        // response when bulk is disabled; the min buffer must hold its wrapped
+        // form plus header.
+        let wrapped = <Result<DeviceInfo, RynkError> as MaxSize>::POSTCARD_MAX_SIZE;
         assert!(RYNK_MAX_PAYLOAD >= wrapped);
         assert!(RYNK_MIN_BUFFER_SIZE >= wrapped + RYNK_HEADER_SIZE);
     }

--- a/rmk-types/src/protocol/rynk/payload/system.rs
+++ b/rmk-types/src/protocol/rynk/payload/system.rs
@@ -2,12 +2,15 @@
 //!
 //! Types for protocol handshake, device discovery, security, and global configuration.
 
-use heapless::Vec;
+use heapless::{String, Vec};
 use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
 
 /// Maximum number of key positions in an unlock challenge.
 pub const UNLOCK_KEYS_SIZE: usize = 2;
+
+/// Maximum byte length of each `DeviceInfo` string field.
+pub const DEVICE_INFO_STRING_SIZE: usize = 32;
 
 /// Protocol version advertised during the connection handshake.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, MaxSize)]
@@ -65,6 +68,44 @@ pub struct DeviceCapabilities {
     pub max_bulk_keys: u8,
     pub macro_chunk_size: u16,
     pub bulk_transfer_supported: bool,
+}
+
+/// Version of the `rmk` crate baked into the firmware, so hosts can key
+/// version-specific behavior off the library release, not the user's app.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, MaxSize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+pub struct FirmwareVersion {
+    pub major: u8,
+    pub minor: u8,
+    pub patch: u8,
+}
+
+/// Device identity for display and per-device host profiles.
+///
+/// Complements [`DeviceCapabilities`]: capabilities answer "what can you do"
+/// for feature gating, identity answers "which device is this".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+pub struct DeviceInfo {
+    pub rmk_version: FirmwareVersion,
+    pub vendor_id: u16,
+    pub product_id: u16,
+    #[cfg_attr(feature = "wasm", tsify(type = "string"))]
+    pub manufacturer: String<DEVICE_INFO_STRING_SIZE>,
+    #[cfg_attr(feature = "wasm", tsify(type = "string"))]
+    pub product_name: String<DEVICE_INFO_STRING_SIZE>,
+    #[cfg_attr(feature = "wasm", tsify(type = "string"))]
+    pub serial_number: String<DEVICE_INFO_STRING_SIZE>,
+}
+
+impl MaxSize for DeviceInfo {
+    // A str encodes as varint length + UTF-8 bytes — the same wire shape as
+    // `Vec<u8, N>`, so the Vec bound covers each string field.
+    const POSTCARD_MAX_SIZE: usize = FirmwareVersion::POSTCARD_MAX_SIZE
+        + 2 * u16::POSTCARD_MAX_SIZE
+        + 3 * crate::heapless_vec_max_size::<u8, DEVICE_INFO_STRING_SIZE>();
 }
 
 /// Current lock/unlock state of the device.
@@ -173,6 +214,29 @@ mod tests {
             macro_chunk_size: 0,
             bulk_transfer_supported: false,
         });
+    }
+
+    #[test]
+    fn round_trip_device_info() {
+        // Max-capacity case: each string filled to 32 bytes with 4-byte chars
+        // and both ids at u16::MAX, so every varint takes its full width and
+        // the bound is genuinely exercised.
+        let full: String<DEVICE_INFO_STRING_SIZE> = String::try_from("🦀🦀🦀🦀🦀🦀🦀🦀").unwrap();
+        assert_eq!(full.len(), DEVICE_INFO_STRING_SIZE);
+        let info = DeviceInfo {
+            rmk_version: FirmwareVersion {
+                major: 255,
+                minor: 255,
+                patch: 255,
+            },
+            vendor_id: u16::MAX,
+            product_id: u16::MAX,
+            manufacturer: full.clone(),
+            product_name: full.clone(),
+            serial_number: full,
+        };
+        round_trip(&info);
+        assert_max_size_bound(&info);
     }
 
     #[test]

--- a/rmk-types/src/protocol/rynk/snapshots/wire_frames.snap
+++ b/rmk-types/src/protocol/rynk/snapshots/wire_frames.snap
@@ -24,6 +24,8 @@ GetCurrentLayer reply Ok(1)                                             01 08 01
 GetCurrentLayer request ()                                              01 08 01 00 00
 GetDefaultLayer reply Ok(2)                                             03 01 01 02 00 00 02
 GetDefaultLayer request ()                                              03 01 01 00 00
+GetDeviceInfo reply Ok(DeviceInfo{1.2.3,4,5,RMK,..})                    0a 00 01 21 00 00 01 02 03 04 05 03 52 4d 4b 0c 52 4d 4b 20 4b 65 79 62 6f 61 72 64 09 72 79 6e 6b 3a 30 30 30 31
+GetDeviceInfo request ()                                                0a 00 01 00 00
 GetEncoderAction reply Ok(EncoderAction{Morse(3),No})                   05 01 01 04 00 00 05 03 00
 GetEncoderAction request GetEncoderRequest{1,2}                         05 01 01 02 00 01 02
 GetFork reply Ok(Fork{Single(A),No,Morse(2)})                           01 05 01 10 00 00 02 01 00 04 00 05 02 01 02 01 00 00 00 02 01

--- a/rmk-types/src/protocol/rynk/snapshots/wire_values.snap
+++ b/rmk-types/src/protocol/rynk/snapshots/wire_values.snap
@@ -41,6 +41,7 @@ ConnectionStatus{Configured,{1,Adv},Ble}  02 01 00 01
 ConnectionType::Ble                       01
 ConnectionType::Usb                       00
 DeviceCapabilities{1..16}                 01 02 03 04 05 06 07 08 09 0a 0b 01 00 01 0c 00 0d 0e 0f 10 01
+DeviceInfo{1.2.3,4,5,RMK,..}              01 02 03 04 05 03 52 4d 4b 0c 52 4d 4b 20 4b 65 79 62 6f 61 72 64 09 72 79 6e 6b 3a 30 30 30 31
 EncoderAction{Morse(3),No}                05 03 00
 Fork{Single(A),No,Morse(2)}               02 01 00 04 00 05 02 01 02 01 00 00 00 02 01
 GetEncoderRequest{1,2}                    01 02

--- a/rmk-types/src/protocol/rynk/tests.rs
+++ b/rmk-types/src/protocol/rynk/tests.rs
@@ -195,6 +195,7 @@ fn encode_frame<T: serde::Serialize>(cmd: Cmd, seq: u8, val: &T) -> alloc::vec::
 struct Exemplars {
     matrix: MatrixState,
     capabilities: DeviceCapabilities,
+    device_info: DeviceInfo,
     behavior: BehaviorConfig,
     connection: ConnectionStatus,
     state_bits: StateBits,
@@ -233,6 +234,19 @@ fn exemplars() -> Exemplars {
         max_bulk_keys: 15,
         macro_chunk_size: 16,
         bulk_transfer_supported: true,
+    };
+    // Ascending version/id values; distinct strings so a field swap shows.
+    let device_info = DeviceInfo {
+        rmk_version: FirmwareVersion {
+            major: 1,
+            minor: 2,
+            patch: 3,
+        },
+        vendor_id: 4,
+        product_id: 5,
+        manufacturer: heapless::String::try_from("RMK").unwrap(),
+        product_name: heapless::String::try_from("RMK Keyboard").unwrap(),
+        serial_number: heapless::String::try_from("rynk:0001").unwrap(),
     };
     let behavior = BehaviorConfig {
         combo_timeout_ms: 50,
@@ -285,6 +299,7 @@ fn exemplars() -> Exemplars {
     Exemplars {
         matrix,
         capabilities,
+        device_info,
         behavior,
         connection,
         state_bits,
@@ -442,6 +457,7 @@ fn wire_values_locked() {
         // --- Status / system responses ---
         ("MatrixState{[0x05,0x00,0x20]}", encode(&ex.matrix)),
         ("DeviceCapabilities{1..16}", encode(&ex.capabilities)),
+        ("DeviceInfo{1.2.3,4,5,RMK,..}", encode(&ex.device_info)),
         ("BehaviorConfig{50,500,200,20}", encode(&ex.behavior)),
         ("ConnectionStatus{Configured,{1,Adv},Ble}", encode(&ex.connection)),
         ("ProtocolVersion{1,0}", encode(&ProtocolVersion { major: 1, minor: 0 })),
@@ -627,6 +643,15 @@ fn wire_frames_locked() {
         (
             "StorageReset reply Ok(())",
             encode_frame(Cmd::StorageReset, SEQ, &Ok::<(), RynkError>(()))
+        ),
+        ("GetDeviceInfo request ()", encode_frame(Cmd::GetDeviceInfo, SEQ, &())),
+        (
+            "GetDeviceInfo reply Ok(DeviceInfo{1.2.3,4,5,RMK,..})",
+            encode_frame(
+                Cmd::GetDeviceInfo,
+                SEQ,
+                &Ok::<DeviceInfo, RynkError>(ex.device_info.clone())
+            ),
         ),
         // ── Keymap / encoder (0x01xx) ──
         (

--- a/rmk/src/host/rynk/handlers/system.rs
+++ b/rmk/src/host/rynk/handlers/system.rs
@@ -1,10 +1,15 @@
-//! System handlers — handshake, reboot, bootloader jump, storage reset.
+//! System handlers — handshake, device identity, reboot, bootloader jump, storage reset.
 
 use rmk_types::constants;
-use rmk_types::protocol::rynk::command::{BootloaderJump, GetCapabilities, GetVersion, Reboot, StorageReset};
-use rmk_types::protocol::rynk::{DeviceCapabilities, ProtocolVersion, RYNK_HEADER_SIZE, RynkError, StorageResetMode};
+use rmk_types::protocol::rynk::command::{
+    BootloaderJump, GetCapabilities, GetDeviceInfo, GetVersion, Reboot, StorageReset,
+};
+use rmk_types::protocol::rynk::{
+    DEVICE_INFO_STRING_SIZE, DeviceCapabilities, DeviceInfo, ProtocolVersion, RYNK_HEADER_SIZE, RynkError,
+    StorageResetMode,
+};
 
-use super::super::RynkService;
+use super::super::{RMK_VERSION, RynkService};
 use super::Handle;
 
 impl Handle<GetVersion> for RynkService<'_> {
@@ -78,4 +83,29 @@ impl Handle<StorageReset> for RynkService<'_> {
         self.ctx.reset_storage().await;
         Ok(())
     }
+}
+
+impl Handle<GetDeviceInfo> for RynkService<'_> {
+    async fn handle(&self, _: ()) -> Result<DeviceInfo, RynkError> {
+        Ok(DeviceInfo {
+            rmk_version: RMK_VERSION,
+            vendor_id: self.device.vid,
+            product_id: self.device.pid,
+            manufacturer: truncated(self.device.manufacturer),
+            product_name: truncated(self.device.product_name),
+            serial_number: truncated(self.device.serial_number),
+        })
+    }
+}
+
+/// Copy `s` into the bounded wire string; over-long input is cut at the last
+/// whole char that fits, so multi-byte content can never panic or split.
+fn truncated(s: &str) -> heapless::String<DEVICE_INFO_STRING_SIZE> {
+    let mut out = heapless::String::new();
+    for c in s.chars() {
+        if out.push(c).is_err() {
+            break;
+        }
+    }
+    out
 }

--- a/rmk/src/host/rynk/mod.rs
+++ b/rmk/src/host/rynk/mod.rs
@@ -19,14 +19,14 @@ use embassy_futures::select::{Either, select};
 use embedded_io_async::{Read, Write};
 use rmk_types::constants::RYNK_BUFFER_SIZE;
 use rmk_types::protocol::rynk::{
-    Cmd, RYNK_HEADER_SIZE, RYNK_MIN_BUFFER_SIZE, RynkError, RynkHeader, RynkMessage, command,
+    Cmd, FirmwareVersion, RYNK_HEADER_SIZE, RYNK_MIN_BUFFER_SIZE, RynkError, RynkHeader, RynkMessage, command,
 };
 #[allow(unused_imports)] // re-exported at `crate::host` for downstream users
 pub use uart::run_rynk_uart;
 
 use self::handlers::Handle;
 use super::context::KeyboardContext;
-use crate::config::RmkConfig;
+use crate::config::{DeviceConfig, RmkConfig};
 use crate::keymap::KeyMap;
 
 // Use `core::assert!` explicitly: in a `defmt` build the crate-level `assert!`
@@ -38,15 +38,37 @@ const _: () = core::assert!(
      floor",
 );
 
+const RMK_VERSION: FirmwareVersion = {
+    const fn component(s: &str) -> u8 {
+        let bytes = s.as_bytes();
+        let mut i = 0;
+        let mut value = 0u8;
+        while i < bytes.len() {
+            value = value * 10 + (bytes[i] - b'0');
+            i += 1;
+        }
+        value
+    }
+
+    FirmwareVersion {
+        major: component(env!("CARGO_PKG_VERSION_MAJOR")),
+        minor: component(env!("CARGO_PKG_VERSION_MINOR")),
+        patch: component(env!("CARGO_PKG_VERSION_PATCH")),
+    }
+};
+
 /// Transport-agnostic Rynk service.
 pub struct RynkService<'a> {
     pub(super) ctx: KeyboardContext<'a>,
+    /// Device identity served by `GetDeviceInfo`.
+    device: DeviceConfig<'static>,
 }
 
 impl<'a> RynkService<'a> {
-    pub fn new(keymap: &'a KeyMap<'a>, _config: &RmkConfig<'static>) -> Self {
+    pub fn new(keymap: &'a KeyMap<'a>, config: &RmkConfig<'static>) -> Self {
         Self {
             ctx: KeyboardContext::new(keymap),
+            device: config.device_config,
         }
     }
 
@@ -61,6 +83,7 @@ impl<'a> RynkService<'a> {
             Cmd::Reboot => Handle::<command::Reboot>::handle_message(self, msg).await,
             Cmd::BootloaderJump => Handle::<command::BootloaderJump>::handle_message(self, msg).await,
             Cmd::StorageReset => Handle::<command::StorageReset>::handle_message(self, msg).await,
+            Cmd::GetDeviceInfo => Handle::<command::GetDeviceInfo>::handle_message(self, msg).await,
 
             // Keymap (incl. encoder)
             Cmd::GetKeyAction => Handle::<command::GetKeyAction>::handle_message(self, msg).await,

--- a/rmk/tests/rynk_loopback.rs
+++ b/rmk/tests/rynk_loopback.rs
@@ -36,18 +36,17 @@ use rmk_types::fork::Fork;
 use rmk_types::led_indicator::LedIndicator;
 use rmk_types::morse::{Morse, MorseMode, MorseProfile};
 use rmk_types::protocol::rynk::{
-    BehaviorConfig as WireBehaviorConfig, Cmd, DeviceCapabilities, GetEncoderRequest, GetMacroRequest, KeyPosition,
-    MacroData, MatrixState, ProtocolVersion, RYNK_HEADER_SIZE, RynkError, SetComboRequest, SetEncoderRequest,
-    SetForkRequest, SetKeyRequest, SetMacroRequest, SetMorseRequest, StorageResetMode,
+    BehaviorConfig as WireBehaviorConfig, Cmd, DeviceCapabilities, DeviceInfo, GetEncoderRequest, GetMacroRequest,
+    KeyPosition, MacroData, MatrixState, ProtocolVersion, RYNK_HEADER_SIZE, RynkError, SetComboRequest,
+    SetEncoderRequest, SetForkRequest, SetKeyRequest, SetMacroRequest, SetMorseRequest, StorageResetMode,
 };
 
 use crate::common::rynk_link::{link_session, link_two_sessions};
 use crate::common::{wrap_keymap, wrap_keymap_with_encoders};
 
 /// Build a `RynkService` over a tiny 1-layer 2-row 2-col keymap, so the tests
-/// don't depend on the size of the helper module's default keyboard. The
-/// config is unused by the dispatch core but required by `RynkService::new`;
-/// leak a default so the returned service can be `'static`.
+/// don't depend on the size of the helper module's default keyboard. Leak a
+/// default config so the returned service can be `'static`.
 fn service() -> RynkService<'static> {
     let behavior: &'static mut BehaviorConfig = Box::leak(Box::new(BehaviorConfig::default()));
     let per_key: &'static PositionalConfig<2, 2> = Box::leak(Box::new(PositionalConfig::default()));
@@ -126,6 +125,27 @@ fn get_capabilities() {
         // with the handlers.
         assert!(!caps.bulk_transfer_supported);
         assert_eq!(caps.max_bulk_keys, 0);
+    });
+}
+
+#[test]
+fn get_device_info() {
+    let service = service();
+    link_session(&service, async |client| {
+        let info = client
+            .request::<(), DeviceInfo>(Cmd::GetDeviceInfo, 0x08, &())
+            .await
+            .expect("Ok envelope");
+        // service() passes RmkConfig::default(), so the identity is the default
+        // DeviceConfig, and rmk_version tracks this crate's own version.
+        assert_eq!(info.vendor_id, 0x4c4b);
+        assert_eq!(info.product_id, 0x4643);
+        assert_eq!(info.manufacturer.as_str(), "RMK");
+        assert_eq!(info.product_name.as_str(), "RMK Keyboard");
+        assert_eq!(info.serial_number.as_str(), "vial:f64c2b3c:000001");
+        assert_eq!(info.rmk_version.major, env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap());
+        assert_eq!(info.rmk_version.minor, env!("CARGO_PKG_VERSION_MINOR").parse().unwrap());
+        assert_eq!(info.rmk_version.patch, env!("CARGO_PKG_VERSION_PATCH").parse().unwrap());
     });
 }
 


### PR DESCRIPTION
DeviceInfo carries the rmk crate version, USB vid/pid, and manufacturer/product/serial strings for host display and per-device profiles, kept separate from DeviceCapabilities.