### PR TITLE
fix(usb): don't publish Suspended for a never-enumerated USB device

### DIFF
--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix BLE output stopping while the keyboard is on charge-only USB power (charge-only cable, wall charger, power bank). A never-enumerated device's bus-idle suspend was published as `Suspended`, which `usb_ready()` treats as routable, so reports were routed to USB endpoints that were never configured and silently dropped ([#910](https://github.com/HaoboGu/rmk/issues/910))
 - Fix stuck key when a combo key is re-pressed while the combo is still held. Previously the re-press overwrote the combo output's HID slot, and on combo release the output couldn't be unregistered, leaving the re-pressed key stuck on the host.
 - Fix stuck combo output when overlapping triggered combos share a key (e.g. `M+,` and `,+.` both containing Comma). Releasing the shared key now dispatches the release of every fully-unwound combo output, not just the first.
 - Fix `unregister_keycode` choosing the wrong HID slot when a combo output and another pressed key share a position. Slot lookup now prefers a `(pos, keycode)` match and falls back to keycode-only.

--- a/rmk/src/usb/mod.rs
+++ b/rmk/src/usb/mod.rs
@@ -432,8 +432,10 @@ impl RequestHandler for UsbRequestHandler {
 }
 
 pub(crate) struct UsbDeviceHandler {
-    /// State to restore on resume. Captured at suspend so an Enabled-but-not-yet-Configured
-    /// device that suspends/resumes doesn't get incorrectly upgraded to Configured.
+    /// State to restore on resume. Only a Configured device is ever published as
+    /// Suspended (see `suspended()`), so this always holds Configured while the
+    /// device is suspended; kept as a snapshot rather than a hardcoded value so
+    /// resume stays correct if another pre-suspend state becomes publishable.
     pre_suspend: UsbState,
 }
 
@@ -475,21 +477,26 @@ impl Handler for UsbDeviceHandler {
     }
 
     fn suspended(&mut self, suspended: bool) {
-        // When no logging feature is enabled, `info!` expands to a no-op and
-        // both arms collapse to identical empty blocks — suppress the lint.
-        #[allow(clippy::if_same_then_else)]
         if suspended {
-            // Snapshot the live state so resume can restore it. Skip the snapshot
-            // if a stray duplicate `suspended(true)` ever fires while we're already
-            // Suspended — otherwise we'd lose the original pre-suspend state.
+            // Only publish Suspended when the device was configured before the
+            // suspend. `usb_ready()` deliberately treats Suspended as routable
+            // (a suspended host must stay reachable for remote wakeup), but that
+            // only holds for a device the host has actually enumerated. A
+            // never-configured device also sees bus-idle suspends — a charge-only
+            // cable or wall charger leaves D+/D- idle, which e.g. on nRF52840
+            // raises SUSPEND ~3 ms after enable — and publishing Suspended there
+            // would route reports to endpoints that were never configured,
+            // silently dropping keystrokes that BLE could have delivered.
             let live = current_usb_state();
-            if live != UsbState::Suspended {
+            if live == UsbState::Configured {
                 self.pre_suspend = live;
+                set_usb_state(UsbState::Suspended);
+                info!(
+                    "Device suspended, the Vbus current limit is 500µA (or 2.5mA for high-power devices with remote wakeup enabled)."
+                );
+            } else if live != UsbState::Suspended {
+                info!("Bus suspended before enumeration (charger or charge-only cable?), USB stays inactive");
             }
-            set_usb_state(UsbState::Suspended);
-            info!(
-                "Device suspended, the Vbus current limit is 500µA (or 2.5mA for high-power devices with remote wakeup enabled)."
-            );
         } else {
             // Only restore from Suspended; if we're somehow not in Suspended (out-of-order
             // callbacks), don't overwrite — `configured()`/`enabled()` will resync.
@@ -504,5 +511,82 @@ impl Handler for UsbDeviceHandler {
 
     fn remote_wakeup_enabled(&mut self, enabled: bool) {
         info!("Remote wakeup enabled state: {}", enabled);
+    }
+}
+
+// These tests mutate the process-global CONNECTION_STATUS; cargo-nextest's
+// per-test process isolation keeps them from racing each other (plain
+// `cargo test` is rejected at startup by `test_support::require_nextest`).
+#[cfg(test)]
+mod tests {
+    use embassy_usb::Handler;
+    use rmk_types::connection::UsbState;
+
+    use super::UsbDeviceHandler;
+    use crate::state::{current_usb_state, set_usb_state};
+
+    /// A charge-only cable / wall charger enables the device (VBUS present) but
+    /// never enumerates it; the bus-idle suspend that follows must not publish
+    /// Suspended, otherwise `usb_ready()` would route reports to endpoints that
+    /// were never configured while a BLE host could have received them.
+    #[test]
+    fn suspend_without_enumeration_stays_enabled() {
+        let mut handler = UsbDeviceHandler::new();
+        handler.enabled(true);
+        assert_eq!(current_usb_state(), UsbState::Enabled);
+
+        handler.suspended(true);
+        assert_eq!(current_usb_state(), UsbState::Enabled);
+
+        // Spurious resume (bus activity without enumeration) changes nothing.
+        handler.suspended(false);
+        assert_eq!(current_usb_state(), UsbState::Enabled);
+
+        // A host showing up later still enumerates normally.
+        handler.configured(true);
+        assert_eq!(current_usb_state(), UsbState::Configured);
+    }
+
+    /// A genuinely suspended (previously enumerated) host keeps the Suspended
+    /// state so it stays routable for remote wakeup, and resume restores
+    /// Configured.
+    #[test]
+    fn suspend_after_configured_publishes_suspended_and_resume_restores() {
+        let mut handler = UsbDeviceHandler::new();
+        handler.enabled(true);
+        handler.configured(true);
+
+        handler.suspended(true);
+        assert_eq!(current_usb_state(), UsbState::Suspended);
+
+        handler.suspended(false);
+        assert_eq!(current_usb_state(), UsbState::Configured);
+    }
+
+    /// A stray duplicate `suspended(true)` while already Suspended must not
+    /// clobber the pre-suspend snapshot that resume restores.
+    #[test]
+    fn duplicate_suspend_preserves_pre_suspend_state() {
+        let mut handler = UsbDeviceHandler::new();
+        handler.enabled(true);
+        handler.configured(true);
+
+        handler.suspended(true);
+        handler.suspended(true);
+        assert_eq!(current_usb_state(), UsbState::Suspended);
+
+        handler.suspended(false);
+        assert_eq!(current_usb_state(), UsbState::Configured);
+    }
+
+    /// Out-of-order resume while not suspended must not overwrite the live
+    /// state.
+    #[test]
+    fn resume_without_suspend_is_a_no_op() {
+        let mut handler = UsbDeviceHandler::new();
+        set_usb_state(UsbState::Configured);
+
+        handler.suspended(false);
+        assert_eq!(current_usb_state(), UsbState::Configured);
     }
 }


### PR DESCRIPTION
Fixes #910 (follow-up to #681 / #829).

## Problem

On charge-only USB power (charge-only cable, wall charger, power bank) the device is enabled by VBUS but never enumerated, and the idle D+/D− bus then triggers a suspend — on nRF52840 the USBD peripheral raises SUSPEND after 3 ms of bus inactivity. `UsbDeviceHandler::suspended(true)` published `UsbState::Suspended` unconditionally, and since 6c2328b1 `usb_ready()` treats `Suspended` as routable (so a sleeping host stays reachable for remote wakeup). A never-enumerated device therefore counted as a live USB transport: reports were routed to endpoints that were never configured and silently dropped, while a connected BLE host received nothing. To the user this looks like "Bluetooth breaks while charging".

## Fix

Only publish `Suspended` when the device was `Configured` before the suspend; a never-enumerated device stays in `Enabled`, which doesn't count as `usb_ready()`. The handler already tracked this distinction in `pre_suspend` — this uses it at publish time instead of only on resume.

- Charge-only / charger: state stays `Enabled` → BLE keeps working, and a host that shows up later still enumerates normally.
- Genuinely suspended (previously configured) host: still published as `Suspended` → remote wakeup (#825) and the `preferred` tie-break are unaffected.

## Tests

Four new unit tests in `rmk/src/usb/mod.rs` covering: never-enumerated suspend stays `Enabled` (the regression), configured suspend/resume round-trip, duplicate-suspend snapshot preservation, and out-of-order resume as a no-op. `cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble`: 540 passed.

Hardware verification on an nRF52840 BLE split board (Cornix) is underway: charger → BLE keeps typing; PC → enumerates and types over USB; sleeping PC → remote wakeup. I'll report results on #910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
