### PR TITLE
fix: expose rynk layout API to wasm

### DIFF
--- a/rynk/Cargo.toml
+++ b/rynk/Cargo.toml
@@ -20,10 +20,11 @@ log.workspace = true
 miniz_oxide = "0.9"
 wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true }
+tsify = { version = "0.5", optional = true, default-features = false, features = ["js"] }
 
 [features]
 # Enable rmk-types' wasm/TS type generation (tsify). Turned on by the rynk-wasm build.
-wasm = ["rmk-types/wasm", "dep:wasm-bindgen", "dep:js-sys"]
+wasm = ["rmk-types/wasm", "dep:wasm-bindgen", "dep:js-sys", "dep:tsify"]
 
 [dev-dependencies]
 rmk = { path = "../rmk", default-features = false, features = [

--- a/rynk/rynk-wasm/README.md
+++ b/rynk/rynk-wasm/README.md
@@ -173,7 +173,8 @@ Available method groups mirror the native `rynk::Client` API:
 - System: `get_version`, `get_capabilities`, `reboot`, `bootloader_jump`,
   `storage_reset`
 - Keymap: `get_key`, `set_key`, `get_default_layer`, `set_default_layer`,
-  `get_encoder`, `set_encoder`, `get_keymap_bulk`, `set_keymap_bulk`
+  `get_encoder`, `set_encoder`, `get_keymap_bulk`, `set_keymap_bulk`,
+  `get_layout`
 - Combos/forks/morse/macros: `get_combo`, `set_combo`, `get_combo_bulk`,
   `set_combo_bulk`, `get_fork`, `set_fork`, `get_morse`, `set_morse`,
   `get_morse_bulk`, `set_morse_bulk`, `get_macro`, `set_macro`

--- a/rynk/rynk-wasm/src/client.rs
+++ b/rynk/rynk-wasm/src/client.rs
@@ -20,7 +20,7 @@ use rynk::rmk_types::protocol::rynk::{
     MacroData, MatrixState, PeripheralStatus, ProtocolVersion, SetComboBulkRequest, SetKeymapBulkRequest,
     SetMorseBulkRequest, StorageResetMode,
 };
-use rynk::{Client, IncomingTopic, RynkDevice, TopicEvent};
+use rynk::{Client, IncomingTopic, LayoutInfo, RynkDevice, TopicEvent};
 use wasm_bindgen::prelude::*;
 
 use crate::device::WebDevice;
@@ -116,6 +116,7 @@ endpoints! {
     set_encoder(encoder_id: u8, layer: u8; action: EncoderAction) -> (),
     get_keymap_bulk(layer: u8, start_row: u8, start_col: u8) -> GetKeymapBulkResponse,
     set_keymap_bulk(; request: SetKeymapBulkRequest) -> (),
+    get_layout() -> LayoutInfo,
     // combos / forks / morse / macros
     get_combo(index: u8) -> Combo,
     set_combo(index: u8; config: Combo) -> (),

--- a/rynk/src/layout.rs
+++ b/rynk/src/layout.rs
@@ -11,6 +11,8 @@
 
 /// A key's outline rectangle in key-units.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Rect {
     pub x: f32,
     pub y: f32,
@@ -22,6 +24,8 @@ pub struct Rect {
 /// rotation, and an optional second rectangle for L-shaped keys (ISO/big-ass
 /// Enter). `r` rotates the whole key, `rect2` included.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Key {
     pub row: u8,
     pub col: u8,
@@ -33,6 +37,8 @@ pub struct Key {
 /// One encoder's placement within a variant: a fixed 1u knob, so just its
 /// center — never resized, rotated, or L-shaped.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Encoder {
     pub id: u8,
     pub x: f32,
@@ -43,6 +49,8 @@ pub struct Encoder {
 /// reflows the tokens after it — encoders included — so each variant carries its
 /// own encoder positions.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Variant {
     pub name: String,
     pub keys: Vec<Key>,
@@ -51,6 +59,8 @@ pub struct Variant {
 
 /// The decoded physical layout: one entry per render variant.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct LayoutInfo {
     pub default_variant: u8,
     pub variants: Vec<Variant>,


### PR DESCRIPTION
Summary:
- Add typed wasm bindings for Rynk layout structs.
- Expose Client::get_layout through rynk-wasm.
- Update the wasm README API list.

Validation:
- cargo check -p rynk-wasm --target wasm32-unknown-unknown