### PR TITLE
fix: model rynk macros as a flat buffer

### DIFF
--- a/rmk-types/src/protocol/rynk/payload/macro_data.rs
+++ b/rmk-types/src/protocol/rynk/payload/macro_data.rs
@@ -24,7 +24,6 @@ impl MaxSize for MacroData {
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct GetMacroRequest {
-    pub index: u8,
     pub offset: u16,
 }
 
@@ -36,7 +35,6 @@ pub struct GetMacroRequest {
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct SetMacroRequest {
-    pub index: u8,
     pub offset: u16,
     pub data: MacroData,
 }
@@ -66,8 +64,8 @@ mod tests {
 
     #[test]
     fn round_trip_get_macro_request() {
-        round_trip(&GetMacroRequest { index: 0, offset: 0 });
-        round_trip(&GetMacroRequest { index: 3, offset: 256 });
+        round_trip(&GetMacroRequest { offset: 0 });
+        round_trip(&GetMacroRequest { offset: 256 });
     }
 
     #[test]
@@ -75,7 +73,6 @@ mod tests {
         let mut data: Vec<u8, MACRO_DATA_SIZE> = Vec::new();
         data.extend_from_slice(&[0x01, 0x02]).unwrap();
         round_trip(&SetMacroRequest {
-            index: 1,
             offset: 0,
             data: MacroData { data },
         });

--- a/rmk-types/src/protocol/rynk/payload/system.rs
+++ b/rmk-types/src/protocol/rynk/payload/system.rs
@@ -41,10 +41,7 @@ pub struct DeviceCapabilities {
     pub num_encoders: u8,
     pub max_combos: u8,
     pub max_combo_keys: u8,
-    /// Number of macros supported, set by the user at compile time. `0`
-    /// disables macros: the host MUST NOT use them or consult `macro_space_size`.
-    pub max_macros: u8,
-    /// Byte size of the flat macro region; only meaningful when `max_macros > 0`.
+    /// Byte size of the flat macro region. `0` disables macro data endpoints.
     pub macro_space_size: u16,
     pub max_morse: u8,
     pub max_patterns_per_key: u8,
@@ -181,7 +178,6 @@ mod tests {
             num_encoders: 2,
             max_combos: 16,
             max_combo_keys: 4,
-            max_macros: 32,
             macro_space_size: 2048,
             max_morse: 8,
             max_patterns_per_key: 8,
@@ -205,7 +201,6 @@ mod tests {
             num_encoders: 0,
             max_combos: 0,
             max_combo_keys: 0,
-            max_macros: 0,
             macro_space_size: 0,
             max_morse: 0,
             max_patterns_per_key: 0,

--- a/rmk-types/src/protocol/rynk/snapshots/wire_frames.snap
+++ b/rmk-types/src/protocol/rynk/snapshots/wire_frames.snap
@@ -12,7 +12,7 @@ BootloaderJump request ()                                               04 00 01
 ConnectionChange topic ConnectionStatus{Configured,{1,Adv},Ble}         03 80 00 04 00 02 01 00 01
 GetBehaviorConfig reply Ok(BehaviorConfig{50,500,200,20})               01 06 01 07 00 00 32 f4 03 c8 01 14
 GetBehaviorConfig request ()                                            01 06 01 00 00
-GetCapabilities reply Ok(DeviceCapabilities{1..17})                     02 00 01 17 00 00 01 02 03 04 05 06 07 08 09 0a 0b 01 00 01 0c 00 0d 0e 0f 10 11 01
+GetCapabilities reply Ok(DeviceCapabilities{1..16})                     02 00 01 16 00 00 01 02 03 04 05 06 07 08 09 0a 01 00 01 0b 00 0c 0d 0e 0f 10 01
 GetCapabilities request ()                                              02 00 01 00 00
 GetCombo reply Ok(Combo{[Single(A)],Morse(1),L2})                       01 03 01 0a 00 00 01 02 01 00 04 05 01 01 02
 GetCombo request 3                                                      01 03 01 01 00 03
@@ -37,7 +37,7 @@ GetLedIndicator request ()                                              07 08 01
 GetLockStatus reply Ok(LockStatus{true,false,2,[(1,2),(3,4)]})          06 00 01 09 00 00 01 00 02 02 01 02 03 04
 GetLockStatus request ()                                                06 00 01 00 00
 GetMacro reply Ok(MacroData{[0x01,0x02,0x03]})                          01 02 01 05 00 00 03 01 02 03
-GetMacro request GetMacroRequest{1,256}                                 01 02 01 03 00 01 80 02
+GetMacro request GetMacroRequest{256}                                   01 02 01 02 00 80 02
 GetMatrixState reply Ok(MatrixState{[0x05,0x00,0x20]})                  02 08 01 05 00 00 03 05 00 20
 GetMatrixState request ()                                               02 08 01 00 00
 GetMorse reply Ok(Morse{TAP->Key(A)})                                   01 04 01 07 00 00 00 01 02 01 00 04
@@ -68,7 +68,7 @@ SetKeyAction reply Err(Invalid)                                         02 01 01
 SetKeyAction reply Ok(())                                               02 01 01 01 00 00
 SetKeyAction request SetKeyRequest{{0,5,13},Morse(7)}                   02 01 01 05 00 00 05 0d 05 07
 SetMacro reply Ok(())                                                   02 02 01 01 00 00
-SetMacro request SetMacroRequest{1,2,[0x01,0x02,0x03]}                  02 02 01 06 00 01 02 03 01 02 03
+SetMacro request SetMacroRequest{2,[0x01,0x02,0x03]}                    02 02 01 05 00 02 03 01 02 03
 SetMorse reply Ok(())                                                   02 04 01 01 00 00
 SetMorse request SetMorseRequest{0,morse}                               02 04 01 07 00 00 00 01 02 01 00 04
 SleepState topic true                                                   04 80 00 01 00 01

--- a/rmk-types/src/protocol/rynk/snapshots/wire_values.snap
+++ b/rmk-types/src/protocol/rynk/snapshots/wire_values.snap
@@ -40,12 +40,12 @@ Combo{[Single(A)],Morse(1),L2}            01 02 01 00 04 05 01 01 02
 ConnectionStatus{Configured,{1,Adv},Ble}  02 01 00 01
 ConnectionType::Ble                       01
 ConnectionType::Usb                       00
-DeviceCapabilities{1..17}                 01 02 03 04 05 06 07 08 09 0a 0b 01 00 01 0c 00 0d 0e 0f 10 11 01
+DeviceCapabilities{1..16}                 01 02 03 04 05 06 07 08 09 0a 01 00 01 0b 00 0c 0d 0e 0f 10 01
 DeviceInfo{1.2.3,4,5,RMK,..}              01 02 03 04 05 03 52 4d 4b 0c 52 4d 4b 20 4b 65 79 62 6f 61 72 64 09 72 79 6e 6b 3a 30 30 30 31
 EncoderAction{Morse(3),No}                05 03 00
 Fork{Single(A),No,Morse(2)}               02 01 00 04 00 05 02 01 02 01 00 00 00 02 01
 GetEncoderRequest{1,2}                    01 02
-GetMacroRequest{1,256}                    01 80 02
+GetMacroRequest{256}                      80 02
 KeyAction::Morse(3)                       05 03
 KeyAction::No                             00
 KeyAction::Single(Action::Key(Hid(A)))    02 01 00 04
@@ -80,7 +80,7 @@ SetComboRequest{3,combo}                  03 01 02 01 00 04 05 01 01 02
 SetEncoderRequest{1,2,{Morse(3),No}}      01 02 05 03 00
 SetForkRequest{2,fork}                    02 02 01 00 04 00 05 02 01 02 01 00 00 00 02 01
 SetKeyRequest{{0,5,13},Morse(7)}          00 05 0d 05 07
-SetMacroRequest{1,2,[0x01,0x02,0x03]}     01 02 03 01 02 03
+SetMacroRequest{2,[0x01,0x02,0x03]}       02 03 01 02 03
 SetMorseRequest{0,morse}                  00 00 01 02 01 00 04
 StateBits{LCtrl,Caps,B1}                  01 02 01
 StorageResetMode::Full                    00

--- a/rmk-types/src/protocol/rynk/tests.rs
+++ b/rmk-types/src/protocol/rynk/tests.rs
@@ -220,21 +220,20 @@ fn exemplars() -> Exemplars {
         num_encoders: 4,
         max_combos: 5,
         max_combo_keys: 6,
-        max_macros: 7,
-        macro_space_size: 8,
-        max_morse: 9,
-        max_patterns_per_key: 10,
-        max_forks: 11,
+        macro_space_size: 7,
+        max_morse: 8,
+        max_patterns_per_key: 9,
+        max_forks: 10,
         storage_enabled: true,
         lighting_enabled: false,
         is_split: true,
-        num_split_peripherals: 12,
+        num_split_peripherals: 11,
         ble_enabled: false,
-        num_ble_profiles: 13,
-        max_payload_size: 14,
-        max_bulk_keys: 15,
-        max_bulk_configs: 16,
-        macro_chunk_size: 17,
+        num_ble_profiles: 12,
+        max_payload_size: 13,
+        max_bulk_keys: 14,
+        max_bulk_configs: 15,
+        macro_chunk_size: 16,
         bulk_transfer_supported: true,
     };
     // Ascending version/id values; distinct strings so a field swap shows.
@@ -462,7 +461,7 @@ fn wire_values_locked() {
         ("MacroData{[0x01,0x02,0x03]}", encode(&ex.macro_data)),
         // --- Status / system responses ---
         ("MatrixState{[0x05,0x00,0x20]}", encode(&ex.matrix)),
-        ("DeviceCapabilities{1..17}", encode(&ex.capabilities)),
+        ("DeviceCapabilities{1..16}", encode(&ex.capabilities)),
         ("DeviceInfo{1.2.3,4,5,RMK,..}", encode(&ex.device_info)),
         ("BehaviorConfig{50,500,200,20}", encode(&ex.behavior)),
         ("ConnectionStatus{Configured,{1,Adv},Ble}", encode(&ex.connection)),
@@ -523,14 +522,10 @@ fn wire_values_locked() {
                 action: ex.encoder
             }),
         ),
+        ("GetMacroRequest{256}", encode(&GetMacroRequest { offset: 256 })),
         (
-            "GetMacroRequest{1,256}",
-            encode(&GetMacroRequest { index: 1, offset: 256 })
-        ),
-        (
-            "SetMacroRequest{1,2,[0x01,0x02,0x03]}",
+            "SetMacroRequest{2,[0x01,0x02,0x03]}",
             encode(&SetMacroRequest {
-                index: 1,
                 offset: 2,
                 data: ex.macro_data.clone()
             }),
@@ -626,7 +621,7 @@ fn wire_frames_locked() {
             encode_frame(Cmd::GetCapabilities, SEQ, &())
         ),
         (
-            "GetCapabilities reply Ok(DeviceCapabilities{1..17})",
+            "GetCapabilities reply Ok(DeviceCapabilities{1..16})",
             encode_frame(
                 Cmd::GetCapabilities,
                 SEQ,
@@ -749,20 +744,19 @@ fn wire_frames_locked() {
         ),
         // Macro (0x02xx).
         (
-            "GetMacro request GetMacroRequest{1,256}",
-            encode_frame(Cmd::GetMacro, SEQ, &GetMacroRequest { index: 1, offset: 256 }),
+            "GetMacro request GetMacroRequest{256}",
+            encode_frame(Cmd::GetMacro, SEQ, &GetMacroRequest { offset: 256 }),
         ),
         (
             "GetMacro reply Ok(MacroData{[0x01,0x02,0x03]})",
             encode_frame(Cmd::GetMacro, SEQ, &Ok::<MacroData, RynkError>(ex.macro_data.clone())),
         ),
         (
-            "SetMacro request SetMacroRequest{1,2,[0x01,0x02,0x03]}",
+            "SetMacro request SetMacroRequest{2,[0x01,0x02,0x03]}",
             encode_frame(
                 Cmd::SetMacro,
                 SEQ,
                 &SetMacroRequest {
-                    index: 1,
                     offset: 2,
                     data: ex.macro_data.clone()
                 },

--- a/rmk/src/host/rynk/handlers/macro_data.rs
+++ b/rmk/src/host/rynk/handlers/macro_data.rs
@@ -11,7 +11,6 @@ use super::Handle;
 impl Handle<GetMacro> for RynkService<'_> {
     async fn handle(&self, r: GetMacroRequest) -> Result<MacroData, RynkError> {
         // Full chunks are zero-filled; length is not an end signal.
-        let _ = r.index; // reserved for a future per-macro indirection layer
         let mut data: Vec<u8, MACRO_DATA_SIZE> = Vec::new();
         data.resize_default(MACRO_DATA_SIZE).expect("MACRO_DATA_SIZE matches");
         self.ctx.read_macro_buffer(r.offset as usize, &mut data);
@@ -21,7 +20,6 @@ impl Handle<GetMacro> for RynkService<'_> {
 
 impl Handle<SetMacro> for RynkService<'_> {
     async fn handle(&self, r: SetMacroRequest) -> Result<(), RynkError> {
-        let _ = r.index;
         self.ctx.write_macro_buffer(r.offset as usize, &r.data.data).await;
         Ok(())
     }

--- a/rmk/src/host/rynk/handlers/system.rs
+++ b/rmk/src/host/rynk/handlers/system.rs
@@ -31,8 +31,6 @@ impl Handle<GetCapabilities> for RynkService<'_> {
             num_encoders: self.ctx.num_encoders() as u8,
             max_combos: constants::COMBO_MAX_NUM as u8,
             max_combo_keys: constants::COMBO_MAX_LENGTH as u8,
-            // TODO: make this a user-defined constant in keyboard.toml ([rmk] section).
-            max_macros: 16,
             macro_space_size: constants::MACRO_SPACE_SIZE as u16,
             max_morse: constants::MORSE_MAX_NUM as u8,
             max_patterns_per_key: constants::MAX_PATTERNS_PER_KEY as u8,

--- a/rmk/tests/rynk_loopback.rs
+++ b/rmk/tests/rynk_loopback.rs
@@ -688,14 +688,13 @@ fn get_set_macro_round_trip() {
         let mut data: HVec<u8, 64> = HVec::new();
         data.extend_from_slice(&[0xAA, 0xBB, 0xCC]).unwrap();
         let set = SetMacroRequest {
-            index: 0,
             offset: 0,
             data: MacroData { data },
         };
         let r = client.request::<_, ()>(Cmd::SetMacro, 0x20, &set).await;
         assert_eq!(r, Ok(()));
 
-        let get = GetMacroRequest { index: 0, offset: 0 };
+        let get = GetMacroRequest { offset: 0 };
         let got = client
             .request::<_, MacroData>(Cmd::GetMacro, 0x21, &get)
             .await

--- a/rynk/examples/hw_test.rs
+++ b/rynk/examples/hw_test.rs
@@ -252,16 +252,15 @@ async fn run_all<T: Read + Write>(mut client: Client<T>, over_ble: bool) -> Resu
     }
 
     info!("── macros ──");
-    if caps.max_macros == 0 {
-        info!("  (no macro slots — exercising dispatch at index 0)");
+    if caps.macro_space_size == 0 {
+        info!("  (no macro storage — exercising dispatch at offset 0)");
     }
-    report(&mut fails, "get_macro 0", client.get_macro(0, 0).await);
+    report(&mut fails, "get_macro 0", client.get_macro(0).await);
     ack(
         &mut fails,
         "set_macro 0",
         client
             .set_macro(
-                0,
                 0,
                 MacroData {
                     data: Default::default(),

--- a/rynk/examples/qemu_behavior.rs
+++ b/rynk/examples/qemu_behavior.rs
@@ -131,7 +131,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(caps.num_encoders, 1);
     assert_eq!(caps.max_combos, 8);
     assert_eq!(caps.max_combo_keys, 4);
-    assert_eq!(caps.max_macros, 16);
     assert_eq!(caps.macro_space_size, 256);
     assert_eq!(caps.macro_chunk_size, 64);
     assert_eq!(caps.max_morse, 8);
@@ -210,8 +209,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut macro_bytes = heapless::Vec::new();
     macro_bytes.extend_from_slice(&[1, 2, 3, 4]).unwrap();
-    client.set_macro(0, 0, MacroData { data: macro_bytes }).await?;
-    let got_macro = client.get_macro(0, 0).await?;
+    client.set_macro(0, MacroData { data: macro_bytes }).await?;
+    let got_macro = client.get_macro(0).await?;
     assert_eq!(got_macro.data.len(), caps.macro_chunk_size as usize);
     assert_eq!(&got_macro.data[..4], &[1, 2, 3, 4]);
     assert!(got_macro.data[4..].iter().all(|&b| b == 0));

--- a/rynk/rynk-serial/src/lib.rs
+++ b/rynk/rynk-serial/src/lib.rs
@@ -184,7 +184,6 @@ mod tests {
             num_cols: 14,
             max_combos: 8,
             max_combo_keys: 4,
-            max_macros: 8,
             macro_space_size: 1024,
             max_morse: 4,
             max_patterns_per_key: 4,

--- a/rynk/rynk-wasm/src/client.rs
+++ b/rynk/rynk-wasm/src/client.rs
@@ -127,8 +127,8 @@ endpoints! {
     set_morse(index: u8; config: Morse) -> (),
     get_morse_bulk(start_index: u8) -> GetMorseBulkResponse,
     set_morse_bulk(; request: SetMorseBulkRequest) -> (),
-    get_macro(index: u8, offset: u16) -> MacroData,
-    set_macro(index: u8, offset: u16; data: MacroData) -> (),
+    get_macro(offset: u16) -> MacroData,
+    set_macro(offset: u16; data: MacroData) -> (),
     // behavior
     get_behavior() -> BehaviorConfig,
     set_behavior(; config: BehaviorConfig) -> (),

--- a/rynk/src/api.rs
+++ b/rynk/src/api.rs
@@ -307,15 +307,14 @@ impl<T: Read + Write> Client<T> {
     /// always replies with exactly its build-time chunk size, zero-filling
     /// past the end of its macro space — a short chunk is **not** an
     /// end-of-data signal; parse the macro encoding itself for termination.
-    pub async fn get_macro(&mut self, index: u8, offset: u16) -> Result<MacroData, RynkHostError> {
-        self.request::<command::GetMacro>(&GetMacroRequest { index, offset })
-            .await
+    pub async fn get_macro(&mut self, offset: u16) -> Result<MacroData, RynkHostError> {
+        self.request::<command::GetMacro>(&GetMacroRequest { offset }).await
     }
 
     /// Write one chunk of macro data starting at byte `offset`. Writes past
     /// the end of the device's macro space are truncated by the firmware.
-    pub async fn set_macro(&mut self, index: u8, offset: u16, data: MacroData) -> Result<(), RynkHostError> {
-        self.request::<command::SetMacro>(&SetMacroRequest { index, offset, data })
+    pub async fn set_macro(&mut self, offset: u16, data: MacroData) -> Result<(), RynkHostError> {
+        self.request::<command::SetMacro>(&SetMacroRequest { offset, data })
             .await
     }
 

--- a/rynk/src/driver.rs
+++ b/rynk/src/driver.rs
@@ -504,7 +504,6 @@ mod tests {
             num_cols: 14,
             max_combos: 8,
             max_combo_keys: 4,
-            max_macros: 8,
             macro_space_size: 1024,
             max_morse: 4,
             max_patterns_per_key: 4,

--- a/rynk/tests/loopback.rs
+++ b/rynk/tests/loopback.rs
@@ -157,8 +157,8 @@ async fn client_against_run_session() {
         // Macro zero-fill chunk contract.
         let mut macro_bytes: heapless::Vec<u8, MACRO_DATA_SIZE> = heapless::Vec::new();
         macro_bytes.extend_from_slice(&[1, 2, 3, 4]).unwrap();
-        client.set_macro(0, 0, MacroData { data: macro_bytes }).await.unwrap();
-        let got = client.get_macro(0, 0).await.unwrap();
+        client.set_macro(0, MacroData { data: macro_bytes }).await.unwrap();
+        let got = client.get_macro(0).await.unwrap();
         assert_eq!(got.data.len(), caps.macro_chunk_size as usize, "reply is a full chunk");
         assert_eq!(&got.data[..4], &[1, 2, 3, 4], "written prefix preserved");
         assert!(got.data[4..].iter().all(|&b| b == 0), "tail zero-filled past the write");


### PR DESCRIPTION
Summary:
- Remove the unused macro index from Rynk macro requests.
- Treat macro transfer as flat-buffer offset reads/writes.
- Remove max_macros from capabilities and regenerate wire snapshots while keeping ProtocolVersion::CURRENT unchanged.

Validation:
- UPDATE_SNAPSHOTS=1 cargo test --features rynk wire_
- cargo test --lib --tests
- cargo nextest run --no-default-features --features=rynk,storage,std get_set_macro_round_trip