### PR TITLE
fix: validate rynk capability bounds

### DIFF
--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -304,9 +304,9 @@ where
     D: de::Deserializer<'de>,
 {
     let value = Deserialize::deserialize(deserializer)?;
-    if value > 256 {
+    if value > u8::MAX as usize {
         return Err(de::Error::custom(format!(
-            "combo_max_num must be between 0 and 256, got {value}"
+            "combo_max_num must be between 0 and 255, got {value}"
         )));
     }
     Ok(value)
@@ -317,9 +317,9 @@ where
     D: de::Deserializer<'de>,
 {
     let value = Deserialize::deserialize(deserializer)?;
-    if value > 256 {
+    if value > u8::MAX as usize {
         return Err(de::Error::custom(format!(
-            "morse_max_num must be between 0 and 256, got {value}"
+            "morse_max_num must be between 0 and 255, got {value}"
         )));
     }
     Ok(value)
@@ -343,9 +343,9 @@ where
     D: de::Deserializer<'de>,
 {
     let value = Deserialize::deserialize(deserializer)?;
-    if value > 256 {
+    if value > u8::MAX as usize {
         return Err(de::Error::custom(format!(
-            "fork_max_num must be between 0 and 256, got {value}"
+            "fork_max_num must be between 0 and 255, got {value}"
         )));
     }
     Ok(value)
@@ -1419,6 +1419,32 @@ channel_size = 32
         assert_eq!(config.event.modifier.channel_size, 8);
         assert_eq!(config.event.modifier.subs, 2);
         assert_eq!(config.event.layer_change.subs, 1);
+    }
+
+    #[test]
+    fn rmk_count_limits_fit_u8_capability_fields() {
+        let ok: KeyboardTomlConfig = toml::from_str(
+            r#"
+[rmk]
+combo_max_num = 255
+morse_max_num = 255
+fork_max_num = 255
+"#,
+        )
+        .unwrap();
+        assert_eq!(ok.rmk.combo_max_num, 255);
+        assert_eq!(ok.rmk.morse_max_num, 255);
+        assert_eq!(ok.rmk.fork_max_num, 255);
+
+        for (field, message) in [
+            ("combo_max_num", "combo_max_num must be between 0 and 255"),
+            ("morse_max_num", "morse_max_num must be between 0 and 255"),
+            ("fork_max_num", "fork_max_num must be between 0 and 255"),
+        ] {
+            let toml = format!("[rmk]\n{field} = 256\n");
+            let err = toml::from_str::<KeyboardTomlConfig>(&toml).unwrap_err();
+            assert!(err.to_string().contains(message), "{err}");
+        }
     }
 
     #[test]

--- a/rmk-config/src/resolved/build_constants.rs
+++ b/rmk-config/src/resolved/build_constants.rs
@@ -149,6 +149,16 @@ impl crate::KeyboardTomlConfig {
                 protocol_limits::MAX_MACRO_DATA_SIZE
             ));
         }
+        validate_u8_capability("combo_max_num", rmk.combo_max_num)?;
+        validate_u8_capability("combo_max_length", rmk.combo_max_length)?;
+        validate_u8_capability("fork_max_num", rmk.fork_max_num)?;
+        validate_u8_capability("morse_max_num", rmk.morse_max_num)?;
+        validate_u8_capability("max_patterns_per_key", rmk.max_patterns_per_key)?;
+        validate_u8_capability("split_peripherals_num", split_peripherals_num)?;
+        validate_u8_capability("ble_profiles_num", rmk.ble_profiles_num)?;
+        validate_u16_capability("macro_space_size", rmk.macro_space_size)?;
+        validate_u16_capability("protocol_macro_chunk_size", rmk.protocol_macro_chunk_size)?;
+        validate_u16_capability("rynk_buffer_size", rmk.rynk_buffer_size)?;
         Ok(BuildConstants {
             combo_max_num: rmk.combo_max_num,
             combo_max_length: rmk.combo_max_length,
@@ -171,6 +181,20 @@ impl crate::KeyboardTomlConfig {
             passkey,
         })
     }
+}
+
+fn validate_u8_capability(name: &str, value: usize) -> Result<(), String> {
+    if value > u8::MAX as usize {
+        return Err(format!("{name} ({value}) exceeds Rynk u8 capability field"));
+    }
+    Ok(())
+}
+
+fn validate_u16_capability(name: &str, value: usize) -> Result<(), String> {
+    if value > u16::MAX as usize {
+        return Err(format!("{name} ({value}) exceeds Rynk u16 capability field"));
+    }
+    Ok(())
 }
 
 /// Bump event subscriber counts based on feature flags declared in `subscriber_default.toml`.
@@ -211,7 +235,7 @@ fn resolve_passkey_enabled(ble: &crate::BleConfig) -> Result<Passkey, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_passkey_enabled;
+    use super::{resolve_passkey_enabled, validate_u8_capability, validate_u16_capability};
     use crate::{BleConfig, DEFAULT_PASSKEY_ENTRY_TIMEOUT_SECS, MIN_PASSKEY_ENTRY_TIMEOUT_SECS};
 
     #[test]
@@ -242,5 +266,20 @@ mod tests {
 
         assert!(!passkey.enabled);
         assert_eq!(passkey.timeout_secs, DEFAULT_PASSKEY_ENTRY_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn validates_rynk_capability_wire_widths() {
+        assert!(validate_u8_capability("combo_max_num", 255).is_ok());
+        assert_eq!(
+            validate_u8_capability("combo_max_num", 256),
+            Err("combo_max_num (256) exceeds Rynk u8 capability field".to_string())
+        );
+
+        assert!(validate_u16_capability("macro_space_size", 65535).is_ok());
+        assert_eq!(
+            validate_u16_capability("macro_space_size", 65536),
+            Err("macro_space_size (65536) exceeds Rynk u16 capability field".to_string())
+        );
     }
 }

--- a/rmk-config/src/resolved/build_constants.rs
+++ b/rmk-config/src/resolved/build_constants.rs
@@ -149,15 +149,12 @@ impl crate::KeyboardTomlConfig {
                 protocol_limits::MAX_MACRO_DATA_SIZE
             ));
         }
-        validate_u8_capability("combo_max_num", rmk.combo_max_num)?;
-        validate_u8_capability("combo_max_length", rmk.combo_max_length)?;
-        validate_u8_capability("fork_max_num", rmk.fork_max_num)?;
+        // Host capability fields are u8/u16 on the wire; check the values no deserializer bound
+        // covers (morse_max_num and split_peripherals_num can also be auto-raised past 255).
         validate_u8_capability("morse_max_num", rmk.morse_max_num)?;
-        validate_u8_capability("max_patterns_per_key", rmk.max_patterns_per_key)?;
         validate_u8_capability("split_peripherals_num", split_peripherals_num)?;
         validate_u8_capability("ble_profiles_num", rmk.ble_profiles_num)?;
         validate_u16_capability("macro_space_size", rmk.macro_space_size)?;
-        validate_u16_capability("protocol_macro_chunk_size", rmk.protocol_macro_chunk_size)?;
         validate_u16_capability("rynk_buffer_size", rmk.rynk_buffer_size)?;
         Ok(BuildConstants {
             combo_max_num: rmk.combo_max_num,
@@ -185,14 +182,18 @@ impl crate::KeyboardTomlConfig {
 
 fn validate_u8_capability(name: &str, value: usize) -> Result<(), String> {
     if value > u8::MAX as usize {
-        return Err(format!("{name} ({value}) exceeds Rynk u8 capability field"));
+        return Err(format!(
+            "{name} ({value}) exceeds the u8 host capability field (max 255)"
+        ));
     }
     Ok(())
 }
 
 fn validate_u16_capability(name: &str, value: usize) -> Result<(), String> {
     if value > u16::MAX as usize {
-        return Err(format!("{name} ({value}) exceeds Rynk u16 capability field"));
+        return Err(format!(
+            "{name} ({value}) exceeds the u16 host capability field (max 65535)"
+        ));
     }
     Ok(())
 }
@@ -269,17 +270,17 @@ mod tests {
     }
 
     #[test]
-    fn validates_rynk_capability_wire_widths() {
-        assert!(validate_u8_capability("combo_max_num", 255).is_ok());
+    fn validates_capability_wire_widths() {
+        assert!(validate_u8_capability("ble_profiles_num", 255).is_ok());
         assert_eq!(
-            validate_u8_capability("combo_max_num", 256),
-            Err("combo_max_num (256) exceeds Rynk u8 capability field".to_string())
+            validate_u8_capability("ble_profiles_num", 256),
+            Err("ble_profiles_num (256) exceeds the u8 host capability field (max 255)".to_string())
         );
 
         assert!(validate_u16_capability("macro_space_size", 65535).is_ok());
         assert_eq!(
             validate_u16_capability("macro_space_size", 65536),
-            Err("macro_space_size (65536) exceeds Rynk u16 capability field".to_string())
+            Err("macro_space_size (65536) exceeds the u16 host capability field (max 65535)".to_string())
         );
     }
 }

--- a/rmk/src/host/rynk/handlers/system.rs
+++ b/rmk/src/host/rynk/handlers/system.rs
@@ -12,6 +12,14 @@ use rmk_types::protocol::rynk::{
 use super::super::{RMK_VERSION, RynkService};
 use super::Handle;
 
+fn capability_u8(value: usize) -> Result<u8, RynkError> {
+    u8::try_from(value).map_err(|_| RynkError::Invalid)
+}
+
+fn capability_u16(value: usize) -> Result<u16, RynkError> {
+    u16::try_from(value).map_err(|_| RynkError::Invalid)
+}
+
 impl Handle<GetVersion> for RynkService<'_> {
     async fn handle(&self, _: ()) -> Result<ProtocolVersion, RynkError> {
         Ok(ProtocolVersion::CURRENT)
@@ -21,20 +29,23 @@ impl Handle<GetVersion> for RynkService<'_> {
 impl Handle<GetCapabilities> for RynkService<'_> {
     async fn handle(&self, _: ()) -> Result<DeviceCapabilities, RynkError> {
         let (rows, cols, num_layers) = self.ctx.keymap_dimensions();
+        let max_payload_size = constants::RYNK_BUFFER_SIZE
+            .checked_sub(RYNK_HEADER_SIZE)
+            .ok_or(RynkError::Invalid)?;
         Ok(DeviceCapabilities {
             // Layout (live, from the configured keymap)
-            num_layers: num_layers as u8,
-            num_rows: rows as u8,
-            num_cols: cols as u8,
+            num_layers: capability_u8(num_layers)?,
+            num_rows: capability_u8(rows)?,
+            num_cols: capability_u8(cols)?,
 
             // Input device limits (compile-time from keyboard.toml)
-            num_encoders: self.ctx.num_encoders() as u8,
-            max_combos: constants::COMBO_MAX_NUM as u8,
-            max_combo_keys: constants::COMBO_MAX_LENGTH as u8,
-            macro_space_size: constants::MACRO_SPACE_SIZE as u16,
-            max_morse: constants::MORSE_MAX_NUM as u8,
-            max_patterns_per_key: constants::MAX_PATTERNS_PER_KEY as u8,
-            max_forks: constants::FORK_MAX_NUM as u8,
+            num_encoders: capability_u8(self.ctx.num_encoders())?,
+            max_combos: capability_u8(constants::COMBO_MAX_NUM)?,
+            max_combo_keys: capability_u8(constants::COMBO_MAX_LENGTH)?,
+            macro_space_size: capability_u16(constants::MACRO_SPACE_SIZE)?,
+            max_morse: capability_u8(constants::MORSE_MAX_NUM)?,
+            max_patterns_per_key: capability_u8(constants::MAX_PATTERNS_PER_KEY)?,
+            max_forks: capability_u8(constants::FORK_MAX_NUM)?,
 
             // Feature flags
             storage_enabled: cfg!(feature = "storage"),
@@ -42,20 +53,20 @@ impl Handle<GetCapabilities> for RynkService<'_> {
 
             // Connectivity
             is_split: cfg!(feature = "split"),
-            num_split_peripherals: constants::SPLIT_PERIPHERALS_NUM as u8,
+            num_split_peripherals: capability_u8(constants::SPLIT_PERIPHERALS_NUM)?,
             ble_enabled: cfg!(feature = "_ble"),
-            num_ble_profiles: constants::NUM_BLE_PROFILE as u8,
+            num_ble_profiles: capability_u8(constants::NUM_BLE_PROFILE)?,
 
             // Protocol limits
-            max_payload_size: (constants::RYNK_BUFFER_SIZE - RYNK_HEADER_SIZE) as u16,
-            macro_chunk_size: constants::MACRO_DATA_SIZE as u16,
+            max_payload_size: capability_u16(max_payload_size)?,
+            macro_chunk_size: capability_u16(constants::MACRO_DATA_SIZE)?,
             // The BULK_* constants only exist under `bulk`, hence #[cfg] over cfg!().
             #[cfg(feature = "bulk")]
-            max_bulk_keys: constants::BULK_KEYMAP_SIZE as u8,
+            max_bulk_keys: capability_u8(constants::BULK_KEYMAP_SIZE)?,
             #[cfg(not(feature = "bulk"))]
             max_bulk_keys: 0,
             #[cfg(feature = "bulk")]
-            max_bulk_configs: constants::BULK_SIZE as u8,
+            max_bulk_configs: capability_u8(constants::BULK_SIZE)?,
             #[cfg(not(feature = "bulk"))]
             max_bulk_configs: 0,
             bulk_transfer_supported: cfg!(feature = "bulk"),

--- a/rmk/src/host/rynk/handlers/system.rs
+++ b/rmk/src/host/rynk/handlers/system.rs
@@ -12,14 +12,6 @@ use rmk_types::protocol::rynk::{
 use super::super::{RMK_VERSION, RynkService};
 use super::Handle;
 
-fn capability_u8(value: usize) -> Result<u8, RynkError> {
-    u8::try_from(value).map_err(|_| RynkError::Invalid)
-}
-
-fn capability_u16(value: usize) -> Result<u16, RynkError> {
-    u16::try_from(value).map_err(|_| RynkError::Invalid)
-}
-
 impl Handle<GetVersion> for RynkService<'_> {
     async fn handle(&self, _: ()) -> Result<ProtocolVersion, RynkError> {
         Ok(ProtocolVersion::CURRENT)
@@ -29,23 +21,20 @@ impl Handle<GetVersion> for RynkService<'_> {
 impl Handle<GetCapabilities> for RynkService<'_> {
     async fn handle(&self, _: ()) -> Result<DeviceCapabilities, RynkError> {
         let (rows, cols, num_layers) = self.ctx.keymap_dimensions();
-        let max_payload_size = constants::RYNK_BUFFER_SIZE
-            .checked_sub(RYNK_HEADER_SIZE)
-            .ok_or(RynkError::Invalid)?;
         Ok(DeviceCapabilities {
             // Layout (live, from the configured keymap)
-            num_layers: capability_u8(num_layers)?,
-            num_rows: capability_u8(rows)?,
-            num_cols: capability_u8(cols)?,
+            num_layers: num_layers as u8,
+            num_rows: rows as u8,
+            num_cols: cols as u8,
 
             // Input device limits (compile-time from keyboard.toml)
-            num_encoders: capability_u8(self.ctx.num_encoders())?,
-            max_combos: capability_u8(constants::COMBO_MAX_NUM)?,
-            max_combo_keys: capability_u8(constants::COMBO_MAX_LENGTH)?,
-            macro_space_size: capability_u16(constants::MACRO_SPACE_SIZE)?,
-            max_morse: capability_u8(constants::MORSE_MAX_NUM)?,
-            max_patterns_per_key: capability_u8(constants::MAX_PATTERNS_PER_KEY)?,
-            max_forks: capability_u8(constants::FORK_MAX_NUM)?,
+            num_encoders: self.ctx.num_encoders() as u8,
+            max_combos: constants::COMBO_MAX_NUM as u8,
+            max_combo_keys: constants::COMBO_MAX_LENGTH as u8,
+            macro_space_size: constants::MACRO_SPACE_SIZE as u16,
+            max_morse: constants::MORSE_MAX_NUM as u8,
+            max_patterns_per_key: constants::MAX_PATTERNS_PER_KEY as u8,
+            max_forks: constants::FORK_MAX_NUM as u8,
 
             // Feature flags
             storage_enabled: cfg!(feature = "storage"),
@@ -53,20 +42,20 @@ impl Handle<GetCapabilities> for RynkService<'_> {
 
             // Connectivity
             is_split: cfg!(feature = "split"),
-            num_split_peripherals: capability_u8(constants::SPLIT_PERIPHERALS_NUM)?,
+            num_split_peripherals: constants::SPLIT_PERIPHERALS_NUM as u8,
             ble_enabled: cfg!(feature = "_ble"),
-            num_ble_profiles: capability_u8(constants::NUM_BLE_PROFILE)?,
+            num_ble_profiles: constants::NUM_BLE_PROFILE as u8,
 
             // Protocol limits
-            max_payload_size: capability_u16(max_payload_size)?,
-            macro_chunk_size: capability_u16(constants::MACRO_DATA_SIZE)?,
+            max_payload_size: (constants::RYNK_BUFFER_SIZE - RYNK_HEADER_SIZE) as u16,
+            macro_chunk_size: constants::MACRO_DATA_SIZE as u16,
             // The BULK_* constants only exist under `bulk`, hence #[cfg] over cfg!().
             #[cfg(feature = "bulk")]
-            max_bulk_keys: capability_u8(constants::BULK_KEYMAP_SIZE)?,
+            max_bulk_keys: constants::BULK_KEYMAP_SIZE as u8,
             #[cfg(not(feature = "bulk"))]
             max_bulk_keys: 0,
             #[cfg(feature = "bulk")]
-            max_bulk_configs: capability_u8(constants::BULK_SIZE)?,
+            max_bulk_configs: constants::BULK_SIZE as u8,
             #[cfg(not(feature = "bulk"))]
             max_bulk_configs: 0,
             bulk_transfer_supported: cfg!(feature = "bulk"),


### PR DESCRIPTION
Config values reported in Rynk capability fields must fit their u8/u16 wire width. Enforce this once, at build time, so overflow surfaces as a build error naming the offending field instead of a runtime protocol error.

Summary:
- Tighten the combo/morse/fork deserializer caps from 256 to 255 — the count is reported as a u8 on the wire, so 256 cannot be represented. (Breaking for configs that used exactly 256.)
- Validate in `build_constants` the values no deserializer bound covers: `morse_max_num` and `split_peripherals_num` (auto-raised after deserialization by `auto_calculate_parameters`), `ble_profiles_num`, `macro_space_size`, and `rynk_buffer_size`.
- Leave `GetCapabilities` with plain casts: every constant is provably in range at build time. `BULK_*` are capped at 255 by `BULK_COUNT_CEILING`, `MACRO_DATA_SIZE` by the `MAX_MACRO_DATA_SIZE` ceiling, `combo_max_length`/`max_patterns_per_key` by the protocol ceilings (16/32), and `RYNK_BUFFER_SIZE - RYNK_HEADER_SIZE` cannot underflow thanks to the `RYNK_MIN_BUFFER_SIZE` const assert in `rynk/mod.rs`.

Validation:
- `cargo test` (rmk-config)
- `cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble` (rmk, 546 passed)
- `cargo check --no-default-features --features=rynk,storage,std` (rmk)