### PR TITLE
refactor: drop the vial_lock feature, use host_lock directly

### DIFF
--- a/.github/ci/_lib.sh
+++ b/.github/ci/_lib.sh
@@ -38,7 +38,7 @@ RMK_FEATURESETS=(
     "log,std"
     "storage"
     "async_matrix,storage"
-    "vial,storage"
+    "vial,host_lock,storage"
     "vial,_ble"
     "split,async_matrix"
     "split,async_matrix,_ble"

--- a/docs/docs/main/docs/features/vial_support.mdx
+++ b/docs/docs/main/docs/features/vial_support.mdx
@@ -94,4 +94,4 @@ For development and testing it can be convenient to skip this step. Setting `ins
 insecure = true
 ```
 
-::: Note `insecure` (formerly `vial_insecure`; the old name still parses) only takes effect for Vial with the `vial_lock` Cargo feature. Since v0.9 `vial_lock` is no longer a default feature, so enable it explicitly in `Cargo.toml` (it also pulls in `vial`). It does not replace `unlock_keys`: the host can still lock and re-unlock a session that started unlocked, so you may keep `unlock_keys` configured alongside it. :::
+::: Note `insecure` (formerly `vial_insecure`; the old name still parses) only takes effect for Vial with the `host_lock` Cargo feature (enabled alongside `vial`). Since v0.9 the lock is no longer a default feature, so enable it explicitly in `Cargo.toml`. It does not replace `unlock_keys`: the host can still lock and re-unlock a session that started unlocked, so you may keep `unlock_keys` configured alongside it. :::

--- a/docs/docs/main/docs/migration/v08_v09.md
+++ b/docs/docs/main/docs/migration/v08_v09.md
@@ -34,8 +34,8 @@ enabled by default. The `rmk` crate's default features changed:
 | --------------------------------------------------- | -------------------------------------- |
 | `defmt`, `storage`, `vial`, `vial_lock`, `watchdog` | `defmt`, `storage`, `rynk`, `watchdog` |
 
-Rynk and Vial are mutually exclusive — enable exactly one. Note that `vial_lock` is also no longer a
-default feature; add it back explicitly if you use Vial's unlock keys.
+Rynk and Vial are mutually exclusive — enable exactly one. The `vial_lock` feature is gone: Vial's
+unlock keys now ride the shared `host_lock` feature, so enable `host_lock` alongside `vial` instead.
 
 **If you relied on the defaults, your firmware now uses Rynk instead of Vial.** Pick one of the paths
 below.
@@ -54,7 +54,7 @@ vial_enabled = false
 rynk_enabled = true
 ```
 
-**Option B — keep Vial.** Turn off default features and re-enable `vial` (plus `vial_lock` if you use
+**Option B — keep Vial.** Turn off default features and re-enable `vial` (plus `host_lock` if you use
 unlock keys), and keep `vial_enabled = true` (the default) in `keyboard.toml`:
 
 ```toml title="Cargo.toml"
@@ -62,7 +62,7 @@ rmk = { version = "0.9", default-features = false, features = [
     "defmt",
     "storage",
     "vial",
-    "vial_lock",
+    "host_lock",
     "watchdog",
     # ...your chip and other features
 ] }

--- a/examples/use_rust/rp2040_oled/Cargo.toml
+++ b/examples/use_rust/rp2040_oled/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-rmk = { path = "../../../rmk", features = ["host", "log", "rp2040", "storage", "usb_log", "vial", "vial_lock", "sh1106"], version = "0.8.2", default-features = false }
+rmk = { path = "../../../rmk", features = ["host", "log", "rp2040", "storage", "usb_log", "vial", "host_lock", "sh1106"], version = "0.8.2", default-features = false }
 oled_async = { version = "0.2.1", features = ["i2c"] }
 display-interface-i2c = "0.5"
 embedded-graphics = "0.8"

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -120,14 +120,12 @@ host = ["dep:byteorder"]
 ## Enable vial support
 vial = ["host"]
 
-## Enable vial lock feature. TODO: remove it, use `host_lock`
-vial_lock = ["vial", "host_lock"]
-
 ## Enable DFU lock feature — physical key unlock for DFU firmware download
 dfu_lock = ["host_lock"]
 
 ## Enable physical key unlock and matrix state tracking — the shared base of the
-## lock features (`vial_lock`, `dfu_lock`, and `rynk` all imply it).
+## lock features (`dfu_lock` and `rynk` imply it; combine with `vial` for the
+## Vial lock).
 host_lock = []
 
 ## Enable Rynk protocol support (RMK-native protocol, mutually exclusive with vial).

--- a/rmk/src/host/mod.rs
+++ b/rmk/src/host/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod context;
-// Physical-presence unlock gate, shared by the Vial (`vial_lock`) and Rynk
-// (`rynk` ⇒ `host_lock`) services. Both features imply `host_lock`.
+// Physical-presence unlock gate, shared by the Vial (`vial` + `host_lock`)
+// and Rynk (`rynk` ⇒ `host_lock`) services.
 #[cfg(feature = "host_lock")]
 pub(crate) mod lock;
 #[cfg(feature = "rynk")]

--- a/rmk/src/host/via/mod.rs
+++ b/rmk/src/host/via/mod.rs
@@ -17,7 +17,7 @@ mod vial;
 pub struct VialService<'a> {
     ctx: KeyboardContext<'a>,
     vial_config: VialConfig<'static>,
-    #[cfg(feature = "vial_lock")]
+    #[cfg(feature = "host_lock")]
     locker: crate::host::lock::HostLock<'a>,
 }
 
@@ -27,7 +27,7 @@ impl<'a> VialService<'a> {
             ctx: KeyboardContext::new(keymap),
             vial_config: config.vial_config,
             // Vial's poll cadence is ~100 ms (`VialCommand::UnlockPoll`).
-            #[cfg(feature = "vial_lock")]
+            #[cfg(feature = "host_lock")]
             locker: crate::host::lock::HostLock::new(
                 config.vial_config.unlock_keys,
                 keymap,
@@ -59,11 +59,11 @@ impl<'a> VialService<'a> {
                             let layout_option: u32 = 0;
                             BigEndian::write_u32(&mut report.input_data[2..6], layout_option);
                         }
-                        #[cfg(not(feature = "vial_lock"))]
+                        #[cfg(not(feature = "host_lock"))]
                         ViaKeyboardInfo::SwitchMatrixState => {
                             error!("It is not secure to use matrix tester without vial lock");
                         }
-                        #[cfg(feature = "vial_lock")]
+                        #[cfg(feature = "host_lock")]
                         ViaKeyboardInfo::SwitchMatrixState if self.locker.is_unlocked() => {
                             self.ctx.read_matrix_state(&mut report.input_data[2..]);
                         }
@@ -218,7 +218,7 @@ impl<'a> VialService<'a> {
                 process_vial(
                     report,
                     &self.vial_config,
-                    #[cfg(feature = "vial_lock")]
+                    #[cfg(feature = "host_lock")]
                     &self.locker,
                     &self.ctx,
                 )

--- a/rmk/src/host/via/vial.rs
+++ b/rmk/src/host/via/vial.rs
@@ -13,7 +13,7 @@ use crate::host::via::keycode_convert::{from_via_keycode, to_via_keycode};
 pub(crate) async fn process_vial<'a>(
     report: &mut ViaReport,
     vial_config: &VialConfig<'a>,
-    #[cfg(feature = "vial_lock")] locker: &crate::host::lock::HostLock<'_>,
+    #[cfg(feature = "host_lock")] locker: &crate::host::lock::HostLock<'_>,
     ctx: &KeyboardContext<'_>,
 ) {
     // report.output_data[0] == 0xFE -> vial commands
@@ -51,7 +51,7 @@ pub(crate) async fn process_vial<'a>(
         VialCommand::GetUnlockStatus => {
             // Reset all data to 0xFF(it's required!)
             report.input_data.fill(0xFF);
-            #[cfg(feature = "vial_lock")]
+            #[cfg(feature = "host_lock")]
             {
                 // Unlocked
                 report.input_data[0] = locker.is_unlocked() as u8;
@@ -63,7 +63,7 @@ pub(crate) async fn process_vial<'a>(
                     report.input_data[3 + idx * 2] = *col;
                 }
             }
-            #[cfg(not(feature = "vial_lock"))]
+            #[cfg(not(feature = "host_lock"))]
             {
                 // Unlocked
                 report.input_data[0] = 1;
@@ -73,26 +73,26 @@ pub(crate) async fn process_vial<'a>(
             }
         }
         VialCommand::UnlockStart => {
-            #[cfg(feature = "vial_lock")]
+            #[cfg(feature = "host_lock")]
             locker.unlocking();
-            #[cfg(not(feature = "vial_lock"))]
+            #[cfg(not(feature = "host_lock"))]
             error!("Vial lock feature is not enabled");
         }
         VialCommand::UnlockPoll => {
-            #[cfg(feature = "vial_lock")]
+            #[cfg(feature = "host_lock")]
             {
                 locker.unlocking();
                 report.input_data[0] = locker.is_unlocked() as u8;
                 report.input_data[1] = locker.is_unlocking() as u8;
                 report.input_data[2] = locker.check_unlock();
             }
-            #[cfg(not(feature = "vial_lock"))]
+            #[cfg(not(feature = "host_lock"))]
             error!("Vial lock feature is not enabled");
         }
         VialCommand::Lock => {
-            #[cfg(feature = "vial_lock")]
+            #[cfg(feature = "host_lock")]
             locker.lock();
-            #[cfg(not(feature = "vial_lock"))]
+            #[cfg(not(feature = "host_lock"))]
             error!("Vial lock feature is not enabled");
         }
         VialCommand::BehaviorSettingQuery => {


### PR DESCRIPTION
Executes the in-tree TODO on the `vial_lock` feature: it was a pure alias tier (`vial` + `host_lock`) with no code of its own.

- Vial's lock paths now key off `host_lock` (they only compile under `vial` anyway)
- `rp2040_oled` example and the v0.9 migration/vial docs now say `vial` + `host_lock`
- The CI matrix row `vial,storage` gains `host_lock` so the Vial lock arms stay covered

**Verification:** `cargo check` passes with and without `host_lock`; the `vial,host_lock,storage` suite passes (530 tests). +25/−27.

Part of the post-review follow-ups for #848.