### PR TITLE
refactor: rename GATT service structs, document blob versioning

### DIFF
--- a/rmk-types/src/protocol/rynk/payload/layout.rs
+++ b/rmk-types/src/protocol/rynk/payload/layout.rs
@@ -6,6 +6,11 @@
 //! decodes them into its own `LayoutInfo` (defined in the host crate, not here,
 //! so this `#![no_std]` crate stays alloc-free). Only [`LayoutChunk`] is a wire
 //! type, so only it needs `MaxSize`.
+//!
+//! The blob carries no version byte of its own: its postcard schema (the host
+//! `LayoutInfo` and its `rmk-config` mirror) is part of the wire contract, so
+//! reshaping it — including appending a field — is a protocol **major** bump,
+//! exactly like reshaping any response payload.
 
 use heapless::Vec;
 use postcard::experimental::max_size::MaxSize;

--- a/rmk/src/ble/ble_server.rs
+++ b/rmk/src/ble/ble_server.rs
@@ -23,7 +23,7 @@ use rmk_types::protocol::rynk::{
 pub(crate) struct Server {
     pub(crate) battery_service: BatteryService,
     pub(crate) hid_service: HidService,
-    pub(crate) vial_service: VialService,
+    pub(crate) vial_service: VialGattService,
     pub(crate) composite_service: CompositeService,
     pub(crate) device_config_service: DeviceConfigurationService,
 }
@@ -33,7 +33,7 @@ pub(crate) struct Server {
 pub(crate) struct Server {
     pub(crate) battery_service: BatteryService,
     pub(crate) hid_service: HidService,
-    pub(crate) rynk_service: RynkService,
+    pub(crate) rynk_service: RynkGattService,
     pub(crate) rynk_hid_service: RynkHidService,
     pub(crate) composite_service: CompositeService,
     pub(crate) device_config_service: DeviceConfigurationService,
@@ -57,7 +57,7 @@ pub(crate) struct Server {
 /// [`crate::channel::RYNK_BLE_RX_PIPE`] for [`crate::ble::host::HostGattHandler::run`] to drain.
 #[cfg(feature = "rynk")]
 #[gatt_service(uuid = RYNK_SERVICE_UUID)]
-pub(crate) struct RynkService {
+pub(crate) struct RynkGattService {
     // ATT enforces encryption; the event loop still filters the data path.
     #[descriptor(uuid = "2908", read, value = [0u8, 1u8])]
     #[characteristic(uuid = RYNK_INPUT_CHAR_UUID, read, notify, permissions(encrypted))]
@@ -96,7 +96,7 @@ pub(crate) struct RynkHidService {
 /// [`crate::ble::host::HostGattHandler::run`] to drain.
 #[cfg(feature = "vial")]
 #[gatt_service(uuid = service::HUMAN_INTERFACE_DEVICE)]
-pub(crate) struct VialService {
+pub(crate) struct VialGattService {
     #[characteristic(uuid = "2a4a", read, value = [0x01, 0x01, 0x00, 0x03])]
     pub(crate) hid_info: [u8; 4],
     #[characteristic(uuid = "2a4b", read, value = ViaReport::desc().try_into().expect("Failed to convert ViaReport to [u8; 27]"))]

--- a/rmk/src/ble/host/rynk.rs
+++ b/rmk/src/ble/host/rynk.rs
@@ -1,5 +1,5 @@
 //! Rynk config over BLE GATT — a single per-connection session shared by both
-//! transports: the custom 128-bit GATT [`RynkService`] (native bluest hosts) and
+//! transports: the custom 128-bit `RynkGattService` (native bluest hosts) and
 //! the vendor HID-over-GATT `RynkHidService` (browsers via WebHID).
 //!
 //! A connection is one host on one transport, so [`HostGattHandler::run`] runs ONE
@@ -120,7 +120,7 @@ impl HostGattHandler {
 pub(crate) enum RynkBleSource {
     /// No transport yet — drop topic pushes (no subscriber).
     None,
-    /// Custom 128-bit GATT `RynkService` (native hosts).
+    /// Custom 128-bit `RynkGattService` (native hosts).
     Custom,
     /// Vendor HID-over-GATT `RynkHidService` (browsers over WebHID).
     Hid,


### PR DESCRIPTION
Two small polish items from the #848 branch review — no behavior change, no wire change:

- The GATT service structs `RynkService` / `VialService` become `RynkGattService` / `VialGattService`, ending the type-name collision with the protocol services of the same names in `host/rynk` / `host/via` (all `pub(crate)`, field names unchanged)
- `payload/layout.rs` now documents that the layout blob has no version byte of its own — its postcard schema rides the protocol-major rule like any response payload

The encoder payload reshape originally in this PR was dropped by review feedback (`GetEncoderRequest` keeps its name and shape).

**Verification:** rmk rynk suite (617) and vial+BLE suite (546) pass. +11/−6.

Part of the post-review follow-ups for #848.