### PR TITLE
fix(vial): widen user keycode mask to 5 bits so User16-31 don't alias to User0-15

### DIFF
--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix Vial keycode conversion truncating user keycodes to 4 bits: `User16`–`User31` silently aliased to `User0`–`User15` on the Vial side (assign, view, and save-back). Widen the mask and accepted range to 5 bits (`0x7E00..=0x7E1F`, matching QMK's `QK_KB_0..QK_KB_31`) ([#918](https://github.com/HaoboGu/rmk/issues/918))
 - Fix BLE output stopping while the keyboard is on charge-only USB power (charge-only cable, wall charger, power bank). A never-enumerated device's bus-idle suspend was published as `Suspended`, which `usb_ready()` treats as routable, so reports were routed to USB endpoints that were never configured and silently dropped ([#910](https://github.com/HaoboGu/rmk/issues/910))
 - Fix stuck key when a combo key is re-pressed while the combo is still held. Previously the re-press overwrote the combo output's HID slot, and on combo release the output couldn't be unregistered, leaving the re-pressed key stuck on the host.
 - Fix stuck combo output when overlapping triggered combos share a key (e.g. `M+,` and `,+.` both containing Comma). Releasing the shared key now dispatches the release of every fully-unwound combo output, not just the first.

--- a/rmk/src/host/via/keycode_convert.rs
+++ b/rmk/src/host/via/keycode_convert.rs
@@ -95,7 +95,7 @@ pub(crate) fn to_via_keycode(key_action: KeyAction) -> u16 {
                     0
                 }
             },
-            Action::User(id) => (id as u16 & 0xF) | 0x7E00,
+            Action::User(id) => (id as u16 & 0x1F) | 0x7E00,
             _ => {
                 warn!("Action: {:?} in vial is not supported yet", a);
                 0
@@ -245,9 +245,9 @@ pub(crate) fn from_via_keycode(via_keycode: u16) -> KeyAction {
             );
             KeyAction::No
         }
-        0x7E00..=0x7E0F => {
+        0x7E00..=0x7E1F => {
             // QK_KB_N, aka UserN
-            KeyAction::Single(Action::User(via_keycode as u8 & 0xF))
+            KeyAction::Single(Action::User(via_keycode as u8 & 0x1F))
         }
         _ => {
             warn!("Via keycode {:#X} is not processed", via_keycode);
@@ -277,6 +277,18 @@ mod test {
             KeyAction::Single(Action::Key(KeyCode::Hid(HidKeyCode::RShift))),
             from_via_keycode(via_keycode)
         );
+
+        // User0 (QK_KB_0)
+        let via_keycode = 0x7E00;
+        assert_eq!(KeyAction::Single(Action::User(0)), from_via_keycode(via_keycode));
+
+        // User16 (QK_KB_16) — must not alias to User0
+        let via_keycode = 0x7E10;
+        assert_eq!(KeyAction::Single(Action::User(16)), from_via_keycode(via_keycode));
+
+        // User31 (QK_KB_31)
+        let via_keycode = 0x7E1F;
+        assert_eq!(KeyAction::Single(Action::User(31)), from_via_keycode(via_keycode));
 
         // Mo(3)
         let via_keycode = 0x5223;
@@ -498,6 +510,18 @@ mod test {
         // Mo(3)
         let a = KeyAction::Single(Action::LayerOn(3));
         assert_eq!(0x5223, to_via_keycode(a));
+
+        // User0 (QK_KB_0)
+        let a = KeyAction::Single(Action::User(0));
+        assert_eq!(0x7E00, to_via_keycode(a));
+
+        // User16 (QK_KB_16) — must not alias to User0's 0x7E00
+        let a = KeyAction::Single(Action::User(16));
+        assert_eq!(0x7E10, to_via_keycode(a));
+
+        // User31 (QK_KB_31)
+        let a = KeyAction::Single(Action::User(31));
+        assert_eq!(0x7E1F, to_via_keycode(a));
 
         // OSL(3)
         let a = KeyAction::Single(Action::OneShotLayer(3));


### PR DESCRIPTION
Fixes #918

The VIA/Vial conversion masked user keycodes with `0xF` in both directions, so only 16 of the 32 defined user keycodes survived the Vial round-trip: User16–31 aliased onto User0–15 when displayed, and editing such a key in Vial silently wrote the aliased value back.

### Changes

- Widen the forward mask to `0x1F` and the accepted reverse range to `0x7E00..=0x7E1F`, matching QMK's `QK_KB_0..QK_KB_31`.
- Add `User0` / `User16` / `User31` round-trip cases to both conversion tests (`User16` must not alias to `User0`'s 0x7E00).
- CHANGELOG entry under Unreleased → Fixed.

### Testing

Ran the full `rmk` test suite with the CI feature set (`--no-default-features --features split,vial,storage`, via cargo-nextest): **530/530 passed**, including the new round-trip cases.