### PR TITLE
fix(keyboard): implement ClearEeprom keycode (storage reset + Vial mapping)

### DIFF
--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `ClearEeprom` keycode being defined but not functional: pressing the key now resets the storage on release (same operation as `ViaCommand::EepromReset`, requires the `storage` feature), and the keycode round-trips through Vial as `0x7C03` (QMK's `QK_CLEAR_EEPROM`) instead of being rendered as a raw hex literal ([#929](https://github.com/HaoboGu/rmk/issues/929))
 - Fix Vial keycode conversion truncating user keycodes to 4 bits: `User16`–`User31` silently aliased to `User0`–`User15` on the Vial side (assign, view, and save-back). Widen the mask and accepted range to 5 bits (`0x7E00..=0x7E1F`, matching QMK's `QK_KB_0..QK_KB_31`) ([#918](https://github.com/HaoboGu/rmk/issues/918))
 - Fix BLE output stopping while the keyboard is on charge-only USB power (charge-only cable, wall charger, power bank). A never-enumerated device's bus-idle suspend was published as `Suspended`, which `usb_ready()` treats as routable, so reports were routed to USB endpoints that were never configured and silently dropped ([#910](https://github.com/HaoboGu/rmk/issues/910))
 - Fix stuck key when a combo key is re-pressed while the combo is still held. Previously the re-press overwrote the combo output's HID slot, and on combo release the output couldn't be unregistered, leaving the re-pressed key stuck on the host.

--- a/rmk/src/host/via/keycode_convert.rs
+++ b/rmk/src/host/via/keycode_convert.rs
@@ -78,6 +78,7 @@ pub(crate) fn to_via_keycode(key_action: KeyAction) -> u16 {
             Action::KeyboardControl(c) => match c {
                 KeyboardAction::Bootloader => 0x7c00,
                 KeyboardAction::Reboot => 0x7c01,
+                KeyboardAction::ClearEeprom => 0x7c03,
                 KeyboardAction::ComboOn => 0x7c50,
                 KeyboardAction::ComboOff => 0x7c51,
                 KeyboardAction::ComboToggle => 0x7c52,
@@ -228,6 +229,7 @@ pub(crate) fn from_via_keycode(via_keycode: u16) -> KeyAction {
         }
         0x7C00 => KeyAction::Single(Action::KeyboardControl(KeyboardAction::Bootloader)),
         0x7C01 => KeyAction::Single(Action::KeyboardControl(KeyboardAction::Reboot)),
+        0x7C03 => KeyAction::Single(Action::KeyboardControl(KeyboardAction::ClearEeprom)),
         0x7C50 => KeyAction::Single(Action::KeyboardControl(KeyboardAction::ComboOn)),
         0x7C51 => KeyAction::Single(Action::KeyboardControl(KeyboardAction::ComboOff)),
         0x7C52 => KeyAction::Single(Action::KeyboardControl(KeyboardAction::ComboToggle)),
@@ -289,6 +291,13 @@ mod test {
         // User31 (QK_KB_31)
         let via_keycode = 0x7E1F;
         assert_eq!(KeyAction::Single(Action::User(31)), from_via_keycode(via_keycode));
+
+        // ClearEeprom (QK_CLEAR_EEPROM)
+        let via_keycode = 0x7C03;
+        assert_eq!(
+            KeyAction::Single(Action::KeyboardControl(KeyboardAction::ClearEeprom)),
+            from_via_keycode(via_keycode)
+        );
 
         // Mo(3)
         let via_keycode = 0x5223;
@@ -522,6 +531,10 @@ mod test {
         // User31 (QK_KB_31)
         let a = KeyAction::Single(Action::User(31));
         assert_eq!(0x7E1F, to_via_keycode(a));
+
+        // ClearEeprom (QK_CLEAR_EEPROM)
+        let a = KeyAction::Single(Action::KeyboardControl(KeyboardAction::ClearEeprom));
+        assert_eq!(0x7C03, to_via_keycode(a));
 
         // OSL(3)
         let a = KeyAction::Single(Action::OneShotLayer(3));

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1504,6 +1504,16 @@ impl<'a> Keyboard<'a> {
                     boot::reboot_keyboard();
                 }
             }
+            #[cfg(feature = "storage")]
+            KeyboardAction::ClearEeprom => {
+                // When releasing the key, reset the storage — the same operation
+                // `ViaCommand::EepromReset` performs from the host side
+                if !event.pressed {
+                    crate::channel::FLASH_CHANNEL
+                        .send(crate::storage::FlashOperationMessage::Reset)
+                        .await;
+                }
+            }
 
             _ => warn!("KeyboardAction: {:?} is not supported yet", keyboard_control),
         }


### PR DESCRIPTION
Fixes #929

### Changes

- Handle `KeyboardAction::ClearEeprom` next to the other boot-style actions: on key **release**, send `FlashOperationMessage::Reset` through `FLASH_CHANNEL` — the same operation `ViaCommand::EepromReset` performs from the host side. The arm is gated on the `storage` feature.
- Map `ClearEeprom ⇄ 0x7C03` in both VIA conversion directions, matching QMK's `QK_CLEAR_EEPROM` (previously the key rendered as a raw hex literal and editing it in Vial wrote `KC_NO` back).
- Add `ClearEeprom` round-trip cases to both conversion tests, and a CHANGELOG entry.

### Testing

Ran the full `rmk` test suite with the CI feature set (`--no-default-features --features split,vial,storage`): **530/530 passed**.

Not verified on hardware against `main` (our production config is pinned to 0.8.2); the key-side change reuses the exact message `ViaCommand::EepromReset` already sends.