### PR TITLE
feat(rmk-config): derive rmk cargo features from keyboard.toml

### DIFF
--- a/rmk-config/src/resolved/features.rs
+++ b/rmk-config/src/resolved/features.rs
@@ -1,0 +1,316 @@
+//! Resolved `rmk` cargo features — the single source of truth for which features
+//! a generated firmware project must enable, derived from `keyboard.toml`.
+//!
+//! `rmkit` calls [`KeyboardTomlConfig::firmware_features`] at project-generation
+//! time to write the `rmk` dependency line, and the proc-macro reuses
+//! [`RMK_DEFAULT_FEATURES`], so the feature list is never hand-copied outside
+//! `rmk/Cargo.toml`.
+
+use std::collections::BTreeSet;
+
+use crate::KeyboardTomlConfig;
+use crate::chip::ChipSeries;
+
+/// rmk's default feature set. Mirrors `default = [...]` in `rmk/Cargo.toml`; a
+/// test in this module asserts the two stay equal, so bumping rmk's defaults
+/// without updating this fails CI.
+pub const RMK_DEFAULT_FEATURES: &[&str] = &["defmt", "storage", "vial", "host_lock", "watchdog"];
+
+/// The `rmk` cargo features a firmware project needs, resolved from config.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FirmwareFeatures {
+    /// Canonical chip id (e.g. `"rp2040"`, `"nrf52840"`, `"esp32c3"`).
+    pub chip: String,
+    /// Chip family — picks the HAL template.
+    pub series: ChipSeries,
+    /// Board id when a supported board is used — drives template overlays.
+    pub board: Option<String>,
+    /// Whether this is a split keyboard.
+    pub is_split: bool,
+    /// When true, keep `default-features = true` and `rmk_features` lists only
+    /// the extra non-default features. When false, `rmk_features` is the
+    /// complete explicit set and the caller emits `default-features = false`.
+    pub use_rmk_default_features: bool,
+    /// Features for the `rmk` dependency line, sorted and deduped.
+    pub rmk_features: Vec<String>,
+}
+
+impl KeyboardTomlConfig {
+    /// Derive the complete `rmk` cargo feature set from `keyboard.toml`.
+    ///
+    /// This is the single source of truth for config→feature mapping: `rmkit`
+    /// writes the returned set onto the generated project's `rmk` dependency.
+    pub fn firmware_features(&self) -> Result<FirmwareFeatures, String> {
+        let chip = self.get_chip_model()?;
+        let host = self.get_host_config();
+        if host.rynk_enabled && host.vial_enabled {
+            return Err(
+                "[host]: `rynk_enabled = true` requires `vial_enabled = false` — Vial and Rynk use mutually-exclusive rmk features"
+                    .to_string(),
+            );
+        }
+        let is_split = self.split.is_some();
+
+        // 1. Chip baseline. ESP curates its own set (`default-features = false`);
+        //    every other family builds on rmk's defaults.
+        let default_on = chip.series != ChipSeries::Esp32;
+        let mut features: BTreeSet<String> = BTreeSet::new();
+        if default_on {
+            features.extend(RMK_DEFAULT_FEATURES.iter().map(|s| s.to_string()));
+        }
+        let is_pico_w = chip
+            .board
+            .as_deref()
+            .is_some_and(|b| matches!(b, "Pi Pico W" | "Pico W" | "pi_pico_w" | "pico_w"));
+        match &chip.series {
+            ChipSeries::Rp2040 => {
+                if is_pico_w {
+                    features.insert("pico_w_ble".to_string());
+                }
+                features.insert("rp2040".to_string());
+            }
+            ChipSeries::Nrf52 => {
+                features.insert("async_matrix".to_string());
+                features.insert(format!("{}_ble", chip.chip));
+                if chip.chip == "nrf52840" {
+                    features.insert("adafruit_bl".to_string());
+                }
+            }
+            ChipSeries::Esp32 => {
+                features.insert(format!("{}_ble", chip.chip));
+                features.insert("log".to_string());
+                features.insert("storage".to_string());
+                features.insert("vial".to_string());
+            }
+            // STM32's HAL is embassy-stm32, selected by its own chip feature; rmk
+            // has no stm32 chip feature.
+            ChipSeries::Stm32 => {}
+        }
+
+        // 2. Toggles from keyboard.toml, layered on the baseline.
+        if is_split {
+            features.insert("split".to_string());
+        }
+        if self.ble.as_ref().and_then(|b| b.passkey_entry).unwrap_or(false) {
+            features.insert("passkey_entry".to_string());
+        }
+        if !host.vial_enabled {
+            features.remove("vial");
+            if !host.rynk_enabled {
+                // Vial off and no Rynk: nothing consumes the lock gate, drop it.
+                features.remove("host_lock");
+            }
+        }
+        if host.rynk_enabled {
+            features.insert("rynk".to_string());
+            features.insert("host_lock".to_string());
+        }
+        if !self.get_storage_config().enabled {
+            if features.iter().any(|f| f.ends_with("_ble")) {
+                eprintln!(
+                    "warning: `[storage].enabled = false` ignored — BLE requires storage; keeping `storage`."
+                );
+            } else {
+                features.remove("storage");
+            }
+        }
+        if !self.get_dependency_config().defmt_log {
+            features.remove("defmt");
+        }
+
+        // 3. Emit. Keep `default-features` on when nothing default was dropped,
+        //    so the generated Cargo.toml stays minimal; otherwise list the full
+        //    set explicitly with defaults off.
+        let (use_rmk_default_features, rmk_features) = if default_on {
+            let defaults: BTreeSet<&str> = RMK_DEFAULT_FEATURES.iter().copied().collect();
+            let dropped_a_default = defaults.iter().any(|d| !features.contains(*d));
+            if dropped_a_default {
+                (false, features.into_iter().collect())
+            } else {
+                (
+                    true,
+                    features.into_iter().filter(|f| !defaults.contains(f.as_str())).collect(),
+                )
+            }
+        } else {
+            (false, features.into_iter().collect())
+        };
+
+        Ok(FirmwareFeatures {
+            chip: chip.chip,
+            series: chip.series,
+            board: chip.board,
+            is_split,
+            use_rmk_default_features,
+            rmk_features,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    /// Resolve through the real layered pipeline (chip defaults applied), exactly
+    /// as rmkit does. `new_from_toml_path` takes a path, so write to a temp file;
+    /// chip defaults are what supply `[storage].enabled = true`, etc.
+    fn features(body: &str) -> FirmwareFeatures {
+        try_features(body).expect("derive features")
+    }
+
+    fn try_features(body: &str) -> Result<FirmwareFeatures, String> {
+        let mut hasher = DefaultHasher::new();
+        body.hash(&mut hasher);
+        let path = std::env::temp_dir().join(format!("rmk_ff_{:016x}.toml", hasher.finish()));
+        std::fs::write(&path, body).expect("write temp keyboard.toml");
+        let cfg = KeyboardTomlConfig::new_from_toml_path(&path);
+        let _ = std::fs::remove_file(&path);
+        cfg.firmware_features()
+    }
+
+    /// Minimal keyboard.toml body with a `chip = ...`.
+    fn chip_toml(chip: &str) -> String {
+        format!("[keyboard]\nname = \"t\"\nvendor_id = 0x4c4b\nproduct_id = 0x4643\nchip = \"{chip}\"\n")
+    }
+
+    // --- Oracle: stock per-chip configs reproduce the frozen template feature lists ---
+
+    #[test]
+    fn rp2040_matches_template() {
+        let f = features(&chip_toml("rp2040"));
+        assert!(f.use_rmk_default_features);
+        assert_eq!(f.rmk_features, vec!["rp2040"]);
+    }
+
+    #[test]
+    fn pico_w_board_matches_template() {
+        let f = features("[keyboard]\nname = \"t\"\nvendor_id = 1\nproduct_id = 1\nboard = \"pico_w\"\n");
+        assert!(f.use_rmk_default_features);
+        assert_eq!(f.rmk_features, vec!["pico_w_ble", "rp2040"]);
+    }
+
+    #[test]
+    fn nrf52840_matches_template() {
+        let f = features(&chip_toml("nrf52840"));
+        assert!(f.use_rmk_default_features);
+        assert_eq!(f.rmk_features, vec!["adafruit_bl", "async_matrix", "nrf52840_ble"]);
+    }
+
+    #[test]
+    fn nrf52832_has_no_adafruit_bl() {
+        let f = features(&chip_toml("nrf52832"));
+        assert_eq!(f.rmk_features, vec!["async_matrix", "nrf52832_ble"]);
+    }
+
+    #[test]
+    fn esp32c3_matches_template() {
+        let f = features(&chip_toml("esp32c3"));
+        assert!(!f.use_rmk_default_features, "esp uses default-features = false");
+        assert_eq!(f.rmk_features, vec!["esp32c3_ble", "log", "storage", "vial"]);
+    }
+
+    #[test]
+    fn esp32s3_matches_template() {
+        let f = features(&chip_toml("esp32s3"));
+        assert!(!f.use_rmk_default_features);
+        assert_eq!(f.rmk_features, vec!["esp32s3_ble", "log", "storage", "vial"]);
+    }
+
+    #[test]
+    fn stm32_has_no_rmk_chip_feature() {
+        let f = features(&chip_toml("stm32f103"));
+        assert!(f.use_rmk_default_features);
+        assert!(f.rmk_features.is_empty());
+    }
+
+    #[test]
+    fn split_adds_split_feature() {
+        let matrix = "matrix = { matrix_type = \"normal\", row_pins = [\"PIN_0\"], col_pins = [\"PIN_1\"] }";
+        let toml = format!(
+            "{base}\n[split]\nconnection = \"serial\"\n\
+             [split.central]\nrows = 1\ncols = 1\nrow_offset = 0\ncol_offset = 0\n{matrix}\n\
+             [[split.peripheral]]\nrows = 1\ncols = 1\nrow_offset = 0\ncol_offset = 0\n{matrix}\n",
+            base = chip_toml("rp2040"),
+        );
+        let f = features(&toml);
+        assert!(f.is_split);
+        assert!(f.rmk_features.contains(&"split".to_string()));
+    }
+
+    // --- Regressions for the two feature-drift bugs ---
+
+    #[test]
+    fn light_pins_do_not_add_controller() {
+        // Bug (a): `controller` is not a real rmk feature; setting [light] pins
+        // must never emit it.
+        let toml = format!("{}\n[light]\ncapslock = {{ pin = \"PIN_0\", low_active = true }}\n", chip_toml("rp2040"));
+        let f = features(&toml);
+        assert!(!f.rmk_features.iter().any(|x| x == "controller"));
+    }
+
+    #[test]
+    fn vial_disabled_drops_vial_and_host_lock() {
+        // Bug (b): with Vial off (and no Rynk) both `vial` and `host_lock` go.
+        let toml = format!("{}\n[host]\nvial_enabled = false\n", chip_toml("rp2040"));
+        let f = features(&toml);
+        assert!(!f.use_rmk_default_features);
+        assert!(!f.rmk_features.iter().any(|x| x == "vial"));
+        assert!(!f.rmk_features.iter().any(|x| x == "host_lock"));
+        assert_eq!(f.rmk_features, vec!["defmt", "rp2040", "storage", "watchdog"]);
+    }
+
+    #[test]
+    fn rynk_enables_rynk_and_host_lock_without_vial() {
+        let toml = format!("{}\n[host]\nvial_enabled = false\nrynk_enabled = true\n", chip_toml("rp2040"));
+        let f = features(&toml);
+        assert!(f.rmk_features.contains(&"rynk".to_string()));
+        assert!(f.rmk_features.contains(&"host_lock".to_string()));
+        assert!(!f.rmk_features.iter().any(|x| x == "vial"));
+    }
+
+    #[test]
+    fn vial_and_rynk_both_enabled_is_an_error() {
+        let toml = format!("{}\n[host]\nvial_enabled = true\nrynk_enabled = true\n", chip_toml("rp2040"));
+        assert!(try_features(&toml).is_err());
+    }
+
+    #[test]
+    fn storage_off_usb_chip_drops_storage() {
+        let toml = format!("{}\n[storage]\nenabled = false\n", chip_toml("rp2040"));
+        let f = features(&toml);
+        assert!(!f.rmk_features.iter().any(|x| x == "storage"));
+    }
+
+    #[test]
+    fn storage_off_ble_chip_keeps_storage() {
+        // BLE implies storage; the toggle is ignored with a warning.
+        let toml = format!("{}\n[storage]\nenabled = false\n", chip_toml("nrf52840"));
+        let f = features(&toml);
+        assert!(f.rmk_features.contains(&"storage".to_string()) || f.use_rmk_default_features);
+    }
+
+    #[test]
+    fn defmt_log_off_drops_defmt() {
+        let toml = format!("{}\n[dependency]\ndefmt_log = false\n", chip_toml("rp2040"));
+        let f = features(&toml);
+        assert!(!f.rmk_features.iter().any(|x| x == "defmt"));
+    }
+
+    // --- The const stays aligned with rmk/Cargo.toml ---
+
+    #[test]
+    fn rmk_default_features_mirror_cargo_toml() {
+        let manifest = std::fs::read_to_string("../rmk/Cargo.toml").expect("read ../rmk/Cargo.toml");
+        let value: toml::Value = toml::from_str(&manifest).expect("parse rmk/Cargo.toml");
+        let default = value["features"]["default"].as_array().expect("[features].default array");
+        let actual: BTreeSet<String> = default.iter().map(|v| v.as_str().unwrap().to_string()).collect();
+        let expected: BTreeSet<String> = RMK_DEFAULT_FEATURES.iter().map(|s| s.to_string()).collect();
+        assert_eq!(
+            actual, expected,
+            "RMK_DEFAULT_FEATURES is out of sync with rmk/Cargo.toml [features].default"
+        );
+    }
+}

--- a/rmk-config/src/resolved/mod.rs
+++ b/rmk-config/src/resolved/mod.rs
@@ -3,7 +3,7 @@
 //! These types represent the final, validated, defaults-applied output of the
 //! 3-layer TOML merge (event defaults → chip defaults → user config).
 //!
-//! There are seven resolved entry points, each consumed at a different stage:
+//! There are eight resolved entry points, each consumed at a different stage:
 //!
 //! - [`BuildConstants`] — compile-time constants emitted by `rmk-types/build.rs`
 //! - [`Identity`] — keyboard identity for USB descriptors and BLE advertising
@@ -12,6 +12,7 @@
 //! - [`Behavior`] — behavioral config (combos, macros, morse, forks, etc.)
 //! - [`Keymap`] — keymap and encoder data for keymap generation
 //! - [`Layout`] — the physical layout blob streamed over `GetLayout`
+//! - [`FirmwareFeatures`] — the `rmk` cargo features a firmware project needs
 //!
 //! Consumers call resolution methods on [`KeyboardTomlConfig`](crate::KeyboardTomlConfig):
 //! - `.build_constants(active_features)` → `Result<BuildConstants, String>`
@@ -21,12 +22,14 @@
 //! - `.behavior()` → `Result<Behavior, String>`
 //! - `.keymap()` → `Result<Keymap, String>`
 //! - `.layout()` → `Result<Layout, String>`
+//! - `.firmware_features()` → `Result<FirmwareFeatures, String>`
 //!
 //! Supporting types stay namespaced under their module to avoid flattening the
 //! public API with overly generic names.
 
 pub mod behavior;
 pub mod build_constants;
+pub mod features;
 pub mod hardware;
 pub mod host;
 pub mod identity;
@@ -35,6 +38,7 @@ pub mod layout;
 
 pub use behavior::Behavior;
 pub use build_constants::BuildConstants;
+pub use features::{FirmwareFeatures, RMK_DEFAULT_FEATURES};
 pub use hardware::Hardware;
 pub use host::Host;
 pub use identity::Identity;

--- a/rmk-macro/src/codegen/feature.rs
+++ b/rmk-macro/src/codegen/feature.rs
@@ -25,14 +25,12 @@ pub(crate) fn get_rmk_features() -> Option<Vec<String>> {
 
                 let mut feature_set = dep.req_features().to_vec();
 
-                // Add default features to the feature list.
-                // Must mirror `default = [...]` in rmk/Cargo.toml.
+                // Add default features. Sourced from rmk-config so the set is
+                // never hand-copied — `rmk/Cargo.toml` stays the single source.
                 if default_features {
-                    feature_set.push("defmt".to_string());
-                    feature_set.push("storage".to_string());
-                    feature_set.push("vial".to_string());
-                    feature_set.push("host_lock".to_string());
-                    feature_set.push("watchdog".to_string());
+                    feature_set.extend(
+                        rmk_config::resolved::RMK_DEFAULT_FEATURES.iter().map(|s| s.to_string()),
+                    );
                 }
                 feature_set
             }),


### PR DESCRIPTION
## What

Adds `KeyboardTomlConfig::firmware_features()` — an 8th `resolved/` entry point that is the single source of truth for which `rmk` cargo features a generated firmware project needs, derived from `keyboard.toml`. This replaces the hand-maintained string rules that currently live in `rmkit` and drift out of sync with `rmk`'s real `[features]` table.

## Changes

- **New `rmk-config/src/resolved/features.rs`** — `FirmwareFeatures` + derivation from chip (rp/nrf/esp/stm32) plus toggles (`[storage]`, `[dependency].defmt_log`, `[host].vial_enabled`/`rynk_enabled`, `[ble].passkey_entry`, split). The per-chip baseline reproduces each stock template's frozen feature list (the test oracle).
- **`RMK_DEFAULT_FEATURES`** — mirrors `rmk/Cargo.toml` `default = [...]`, kept in lockstep by a drift test. `rmk-macro`'s codegen now consumes it instead of its own hardcoded copy (the second stale mirror).

## Fixes two feature-drift bugs by construction

- Never emits the nonexistent `controller` feature (a hard build failure today when `[light]` pins are set).
- Drops `host_lock` (renamed from `vial_lock`) when Vial is disabled — the old string is a silent no-op on this branch, leaving the lock on.

## Testing

- `rmk-config`: 92 tests pass (16 new — per-chip oracle, both bug regressions, storage/defmt/rynk toggles, drift test).
- `rmk`: 546 tests pass (macro change is safe).

## Follow-ups (out of this PR)

- Version bump `rmk-config` → 0.7.0 (+ update the `=0.6.1` pins in rmk-types/rmk-macro) is deferred to the publish step; path deps make the code work locally without it.
- `rmkit` gets rewired to consume `firmware_features()` in a later PR (blocked on this being published).
