### PR TITLE
fix: support peripheral status on wired split keyboards

### DIFF
--- a/rynk/src/api.rs
+++ b/rynk/src/api.rs
@@ -466,14 +466,14 @@ impl<T: Read + Write> Client<T> {
         self.request::<command::GetBatteryStatus>(&()).await
     }
 
-    /// Read one split peripheral's status by slot. Split BLE keyboards only
-    /// ([`DeviceCapabilities::is_split`] and `ble_enabled`); returns
+    /// Read one split peripheral's status by slot. Split keyboards only
+    /// ([`DeviceCapabilities::is_split`]); returns
     /// [`RynkHostError::Unsupported`] otherwise, without touching the wire.
     pub async fn get_peripheral_status(&mut self, slot: u8) -> Result<PeripheralStatus, RynkHostError> {
-        if !(self.capabilities().is_split && self.capabilities().ble_enabled) {
+        if !self.capabilities().is_split {
             return Err(RynkHostError::Unsupported(
                 Cmd::GetPeripheralStatus,
-                "not a split BLE keyboard",
+                "not a split keyboard",
             ));
         }
         self.request::<command::GetPeripheralStatus>(&slot).await

--- a/rynk/src/driver.rs
+++ b/rynk/src/driver.rs
@@ -393,10 +393,11 @@ mod tests {
 
     use embedded_io_async::ErrorKind;
     use rmk_types::action::KeyAction;
+    use rmk_types::battery::BatteryStatus;
     use rmk_types::connection::{ConnectionStatus, ConnectionType};
     use rmk_types::protocol::rynk::{
-        GetComboBulkResponse, GetKeymapBulkResponse, GetMorseBulkResponse, SetComboBulkRequest, SetKeymapBulkRequest,
-        SetMorseBulkRequest, TopicEvent,
+        GetComboBulkResponse, GetKeymapBulkResponse, GetMorseBulkResponse, PeripheralStatus, SetComboBulkRequest,
+        SetKeymapBulkRequest, SetMorseBulkRequest, TopicEvent,
     };
     use tokio::time::timeout;
 
@@ -766,6 +767,24 @@ mod tests {
         let r = client.get_battery_status().await;
         assert!(matches!(r, Err(RynkHostError::Unsupported(Cmd::GetBatteryStatus, _))));
         assert!(client.is_alive(), "a locally-gated reject must not kill the link");
+    }
+
+    #[tokio::test]
+    async fn wired_split_peripheral_status_is_supported() {
+        let status = PeripheralStatus {
+            connected: true,
+            battery: BatteryStatus::Unavailable,
+        };
+        let mut capabilities = caps();
+        capabilities.is_split = true;
+        capabilities.ble_enabled = false;
+        let t = MockTransport::new(vec![
+            Step::Chunk(reply(Cmd::GetVersion, 1, ProtocolVersion::CURRENT)),
+            Step::Chunk(reply(Cmd::GetCapabilities, 2, capabilities)),
+            Step::Chunk(reply(Cmd::GetPeripheralStatus, 3, status)),
+        ]);
+        let mut client = Client::connect(t).await.unwrap();
+        assert_eq!(client.get_peripheral_status(0).await.unwrap(), status);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- gate peripheral status on split capability instead of requiring BLE
- align the host API with the firmware endpoint, which also supports serial split peripherals
- add a wired split handshake and status round-trip regression test

## Verification

- cargo +stable test -p rynk --lib