### PR TITLE
fix: reject storage reset when storage is disabled

### DIFF
--- a/rmk/src/host/rynk/handlers/system.rs
+++ b/rmk/src/host/rynk/handlers/system.rs
@@ -81,6 +81,9 @@ impl Handle<BootloaderJump> for RynkService<'_> {
 
 impl Handle<StorageReset> for RynkService<'_> {
     async fn handle(&self, mode: StorageResetMode) -> Result<(), RynkError> {
+        if !cfg!(feature = "storage") {
+            return Err(RynkError::Unimplemented);
+        }
         if mode != StorageResetMode::Full {
             // TODO: Reset required storage range
             return Err(RynkError::Unimplemented);

--- a/rmk/tests/rynk_loopback.rs
+++ b/rmk/tests/rynk_loopback.rs
@@ -194,7 +194,11 @@ fn storage_reset_acks() {
         let r = client
             .request::<StorageResetMode, ()>(Cmd::StorageReset, 0x62, &StorageResetMode::Full)
             .await;
-        assert_eq!(r, Ok(()));
+        if cfg!(feature = "storage") {
+            assert_eq!(r, Ok(()));
+        } else {
+            assert_eq!(r, Err(RynkError::Unimplemented));
+        }
     });
 }
 


### PR DESCRIPTION
## Summary

- return Unimplemented for full storage reset when the firmware has no storage feature
- keep the existing asynchronous acknowledgement behavior when storage is enabled
- verify both feature configurations through the loopback protocol suite

## Verification

- cargo nextest run --no-default-features --features=rynk --test rynk_loopback
- cargo nextest run --no-default-features --features=rynk,storage --test rynk_loopback