### PR TITLE
fix: emit valid WASM object type descriptors

### DIFF
--- a/.github/ci/host.sh
+++ b/.github/ci/host.sh
@@ -24,6 +24,10 @@ log_section "Wasm package build"
 # wasm-pack emits the JS package plus generated .d.ts files under rynk-wasm/pkg/.
 # The generated package is intentionally ignored rather than checked in.
 (cd rynk-wasm && wasm-pack build --target web >/dev/null)
+npx --yes --package typescript@5.9.3 tsc \
+    --noEmit --strict --target ES2022 --lib ES2022,DOM,ESNext.Disposable \
+    --module ES2022 --moduleResolution bundler \
+    rynk-wasm/wasm-smoke.ts
 
 log_section "Clippy"
 cargo +stable clippy --workspace --lib --tests --examples -- -D warnings

--- a/.github/ci/host.sh
+++ b/.github/ci/host.sh
@@ -21,13 +21,14 @@ cargo +stable check -p rynk --lib --target wasm32-unknown-unknown
 cargo +stable check -p rynk-wasm --target wasm32-unknown-unknown
 
 log_section "Wasm package build"
-# wasm-pack emits the JS package plus generated .d.ts files under rynk-wasm/pkg/.
-# The generated package is intentionally ignored rather than checked in.
-(cd rynk-wasm && wasm-pack build --target web >/dev/null)
+# wasm-pack emits the JS package + generated .d.ts under rynk-wasm/pkg/ (ignored, not checked in).
+# --dev keeps wasm-bindgen's type descriptors un-optimized, so a malformed one surfaces as invalid TS below.
+(cd rynk-wasm && wasm-pack build --dev --target web >/dev/null)
+# Typecheck the whole generated .d.ts: a broken descriptor for any exported type fails CI.
 npx --yes --package typescript@5.9.3 tsc \
     --noEmit --strict --target ES2022 --lib ES2022,DOM,ESNext.Disposable \
     --module ES2022 --moduleResolution bundler \
-    rynk-wasm/wasm-smoke.ts
+    rynk-wasm/pkg/rynk_wasm.d.ts
 
 log_section "Clippy"
 cargo +stable clippy --workspace --lib --tests --examples -- -D warnings

--- a/rmk-types/src/fmt.rs
+++ b/rmk-types/src/fmt.rs
@@ -39,7 +39,7 @@ macro_rules! impl_debug_list {
 /// wire), the `.d.ts` decl, and the self-describing wasm ABI — all from one field table.
 #[macro_export]
 macro_rules! bitfield_named_serde {
-    ($bitfield:ident, { $( $field:ident = $setter:ident ),+ $(,)? }) => {
+    ($bitfield:ident, $typescript_type:literal, { $( $field:ident = $setter:ident ),+ $(,)? }) => {
         impl serde::Serialize for $bitfield {
             fn serialize<S: serde::Serializer>(&self, serializer: S) -> ::core::result::Result<S::Ok, S::Error> {
                 if serializer.is_human_readable() {
@@ -77,7 +77,7 @@ macro_rules! bitfield_named_serde {
         };
 
         // Self-describing wasm ABI, marshaled via the human-readable `Serialize` object.
-        $crate::wasm_object_abi!($bitfield);
+        $crate::wasm_object_abi!($bitfield, $typescript_type);
     };
 }
 
@@ -90,12 +90,18 @@ macro_rules! bitfield_named_serde {
 /// its TS shape with a `typescript_custom_section` (`export type <Type> = …`).
 #[macro_export]
 macro_rules! wasm_object_abi {
-    ($ty:ident) => {
+    ($ty:ident, $typescript_type:literal) => {
         #[cfg(feature = "wasm")]
         const _: () = {
             use ::wasm_bindgen::convert::{IntoWasmAbi, OptionIntoWasmAbi};
-            use ::wasm_bindgen::describe::{NAMED_EXTERNREF, WasmDescribe, inform};
+            use ::wasm_bindgen::describe::WasmDescribe;
             use ::wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            extern "C" {
+                #[wasm_bindgen(typescript_type = $typescript_type)]
+                type WasmObject;
+            }
 
             impl From<$ty> for JsValue {
                 #[inline]
@@ -107,12 +113,7 @@ macro_rules! wasm_object_abi {
             impl WasmDescribe for $ty {
                 #[inline]
                 fn describe() {
-                    let name = stringify!($ty);
-                    inform(NAMED_EXTERNREF);
-                    inform(name.len() as u32);
-                    for c in name.chars() {
-                        inform(c as u32);
-                    }
+                    WasmObject::describe();
                 }
             }
 

--- a/rmk-types/src/led_indicator.rs
+++ b/rmk-types/src/led_indicator.rs
@@ -36,7 +36,7 @@ pub struct LedIndicator {
 }
 
 // u8 on the wire (postcard); named bools on serde-wasm-bindgen / serde_json (TS).
-crate::bitfield_named_serde!(LedIndicator, {
+crate::bitfield_named_serde!(LedIndicator, "LedIndicator", {
     num_lock = with_num_lock,
     caps_lock = with_caps_lock,
     scroll_lock = with_scroll_lock,

--- a/rmk-types/src/modifier.rs
+++ b/rmk-types/src/modifier.rs
@@ -46,7 +46,7 @@ crate::impl_debug_list!(ModifierCombination, |self| [
 .filter_map(|(state, label)| state.then_some(label)));
 
 // u8 on the wire (postcard); named bools on serde-wasm-bindgen / serde_json (TS).
-crate::bitfield_named_serde!(ModifierCombination, {
+crate::bitfield_named_serde!(ModifierCombination, "ModifierCombination", {
     left_ctrl = with_left_ctrl,
     left_shift = with_left_shift,
     left_alt = with_left_alt,

--- a/rmk-types/src/morse.rs
+++ b/rmk-types/src/morse.rs
@@ -275,7 +275,7 @@ const _: () = {
     #[::wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
     const TS_APPEND_CONTENT: &'static str = "export type MorseProfile = { unilateral_tap: boolean | undefined; enable_flow_tap: boolean | undefined; mode: MorseMode | undefined; hold_timeout_ms: number | undefined; gap_timeout_ms: number | undefined; };";
 };
-crate::wasm_object_abi!(MorseProfile);
+crate::wasm_object_abi!(MorseProfile, "MorseProfile");
 
 // ---------------------------------------------------------------------------
 // MorsePattern & Morse — pattern encoding and key definition

--- a/rmk-types/src/mouse_button.rs
+++ b/rmk-types/src/mouse_button.rs
@@ -30,7 +30,7 @@ pub struct MouseButtons {
 }
 
 // u8 on the wire (postcard); named bools on serde-wasm-bindgen / serde_json (TS).
-crate::bitfield_named_serde!(MouseButtons, {
+crate::bitfield_named_serde!(MouseButtons, "MouseButtons", {
     button1 = with_button1,
     button2 = with_button2,
     button3 = with_button3,

--- a/rynk/rynk-wasm/wasm-smoke.ts
+++ b/rynk/rynk-wasm/wasm-smoke.ts
@@ -1,5 +1,0 @@
-import { RynkClient, type LedIndicator } from "./pkg/rynk_wasm.js";
-
-declare const client: RynkClient;
-const indicator: Promise<LedIndicator> = client.get_led_indicator();
-void indicator;

--- a/rynk/rynk-wasm/wasm-smoke.ts
+++ b/rynk/rynk-wasm/wasm-smoke.ts
@@ -1,0 +1,5 @@
+import { RynkClient, type LedIndicator } from "./pkg/rynk_wasm.js";
+
+declare const client: RynkClient;
+const indicator: Promise<LedIndicator> = client.get_led_indicator();
+void indicator;


### PR DESCRIPTION
## Summary

- describe named object ABI types through wasm-bindgen extern types instead of runtime loops
- keep the Rust type and generated TypeScript name tied together at each macro invocation
- compile the generated package declarations with strict TypeScript in host CI

## Verification

- cargo +stable check -p rynk-wasm --target wasm32-unknown-unknown
- wasm-pack build --target web
- npx --yes --package typescript@5.9.3 tsc --noEmit --strict --target ES2022 --lib ES2022,DOM,ESNext.Disposable --module ES2022 --moduleResolution bundler wasm-smoke.ts