### PR TITLE
fix: reflect cancellation poison in is_alive and next_event docs

### DIFF
--- a/rynk/src/api.rs
+++ b/rynk/src/api.rs
@@ -39,7 +39,8 @@ pub enum IncomingTopic {
 
 impl<T: Read + Write> Client<T> {
     /// Read the next topic push, decoded into a typed [`IncomingTopic`].
-    /// Queued topics are returned first. Cancel-safe.
+    /// Queued topics are returned first. Cancelling this poisons the client:
+    /// drop it and reconnect rather than calling again.
     pub async fn next_event(&mut self) -> Result<IncomingTopic, RynkHostError> {
         let frame = self.next_topic_frame().await?;
         Ok(match TopicEvent::decode(frame.cmd, &frame.payload) {

--- a/rynk/src/driver.rs
+++ b/rynk/src/driver.rs
@@ -231,9 +231,10 @@ impl<T: Read + Write> Client<T> {
         &self.transport
     }
 
-    /// `false` once the link is dead — drop the client and reconnect.
+    /// `false` once the link is unusable. A cancelled read or write poisons the
+    /// client — this reads `false` immediately, before the next call latches `dead`.
     pub fn is_alive(&self) -> bool {
-        !self.dead
+        !self.dead && !self.send_in_flight && !self.receive_in_flight
     }
 
     /// Topics evicted while [`next_event`](crate::Client::next_event) lagged.
@@ -378,7 +379,6 @@ impl<T: Read + Write> Client<T> {
                 }
             }
 
-            // Commit scratch only after `read` returns for cancel safety.
             let n = match self.transport.read(&mut self.read_scratch[..]).await {
                 Ok(0) => {
                     self.dead = true;
@@ -601,7 +601,7 @@ mod tests {
         let mut c = raw_client(vec![Step::Chunk(header(Cmd::GetWpm.raw(), 0xEE, 100)), Step::Hang]);
         let r1 = timeout(Duration::from_millis(10), c.get_wpm()).await;
         assert!(r1.is_err());
-        assert!(c.is_alive(), "cancellation is detected by the next operation");
+        assert!(!c.is_alive(), "a cancelled read poisons the link");
         let r2 = c.get_wpm().await;
         assert!(matches!(r2, Err(RynkHostError::Disconnected)));
         assert!(!c.is_alive());
@@ -654,10 +654,7 @@ mod tests {
         c.transport.hang_send = true;
         let cancelled = timeout(Duration::from_millis(10), c.get_wpm()).await;
         assert!(cancelled.is_err(), "the hung send must be cancelled by the timeout");
-        assert!(
-            c.is_alive(),
-            "death is detected on the next op, not from the drop itself"
-        );
+        assert!(!c.is_alive(), "a cancelled send poisons the link");
 
         c.transport.hang_send = false;
         let r = c.get_wpm().await;
@@ -724,7 +721,7 @@ mod tests {
         let mut c = raw_client(vec![Step::Hang]);
         let cancelled = timeout(Duration::from_millis(10), c.get_wpm()).await;
         assert!(cancelled.is_err(), "outer timeout cancels request 1 mid-wait");
-        assert!(c.is_alive());
+        assert!(!c.is_alive(), "the cancelled read poisons the link immediately");
         assert!(matches!(c.get_wpm().await, Err(RynkHostError::Disconnected)));
         assert!(!c.is_alive());
     }
@@ -737,6 +734,7 @@ mod tests {
         ]);
         let cancelled = timeout(Duration::from_millis(10), c.next_event()).await;
         assert!(cancelled.is_err());
+        assert!(!c.is_alive(), "a cancelled next_event poisons the link");
         assert!(matches!(c.get_wpm().await, Err(RynkHostError::Disconnected)));
         assert!(!c.is_alive());
     }


### PR DESCRIPTION
## Summary

Follow-up to #943, which made the Rynk host client fail closed after a cancelled read. That change was sound, but it shipped two internal inconsistencies (flagged in review): the client reported itself healthy right after a cancellation, and a public doc still promised the old behavior.

- **`is_alive()` now reflects the poison flags.** It was `!self.dead`, so immediately after a cancelled read/write it returned `true` even though the next call is guaranteed to fail with `Disconnected`. It now also checks `send_in_flight` / `receive_in_flight`, so it reads `false` the instant an operation is cancelled. (These flags are only ever observably set after a cancellation — during normal use they're set and cleared within a single `&mut` borrow — so this only changes the poisoned-but-not-yet-observed case.)
- **Corrected the `next_event()` doc.** It still said `Cancel-safe`, which #943 made false — cancelling it now poisons the client. The doc now says to drop and reconnect.
- **Dropped the stale `// Commit scratch only after read returns for cancel safety` comment** in the read loop; the fail-closed design no longer relies on that.
- **Updated the four cancellation tests** that codified the old `is_alive() == true`-after-cancellation state, and added an assertion tying a cancelled `next_event()` to the corrected doc.

Not addressed here (out of scope, pre-existing): a first-class reconnect abstraction and multi-transport reconnect tests. Reconnect is already the recovery path for every fatal case (IO error, EOF, cancelled write), so that belongs in its own issue rather than gated on this fix.

## Verification

- `cargo +stable test -p rynk --lib` — 37 passed
- `cargo +stable test -p rynk --doc` — 1 passed
- `cargo +stable clippy -p rynk --lib --tests -- -D warnings` — clean