### PR TITLE
docs(rynk): generate the protocol reference from the command tables

### DIFF
--- a/docs/docs/main/docs/development/rynk_protocol.md
+++ b/docs/docs/main/docs/development/rynk_protocol.md
@@ -1,0 +1,90 @@
+<!-- GENERATED — do not edit. Rendered from the `endpoints!`/`topics!` tables in
+     rmk-types/src/protocol/rynk/command.rs. Regenerate with:
+     UPDATE_SNAPSHOTS=1 cargo test -p rmk-types --features rynk protocol_reference -->
+
+# Rynk Protocol Reference
+
+Current protocol version: **0.1**.
+
+Every transport (USB CDC, BLE GATT, BLE HID) carries the same frame — a 5-byte header plus a [postcard](https://docs.rs/postcard)-encoded payload:
+
+```text
+┌──────────────┬───────────┬────────────────────┐
+│ CMD u16 LE   │ SEQ u8    │ LEN u16 LE         │  ← 5-byte header
+├──────────────┴───────────┴────────────────────┤
+│              postcard-encoded payload         │  ← LEN bytes
+└───────────────────────────────────────────────┘
+```
+
+- **Requests** use CMD `0x0000..=0x7FFF`. The response echoes CMD and SEQ and wraps its payload in postcard `Result<T, RynkError>` (`T = ()` for `Set*`).
+- **Topics** use CMD `0x8000..=0xFFFF` (server → host push, SEQ `0`, bare payload).
+
+Which commands a firmware answers depends on the RMK Cargo features it was built with: a row with no **Feature** is present once `rynk` is on, and the rest need their feature (`_ble`, `bulk`, `split`, …) compiled in. A command the firmware wasn't built with answers `UnknownCmd`.
+
+## Endpoints
+
+| CMD      | Name                  | Request                | Response                | Feature | Notes                                                                        |
+| -------- | --------------------- | ---------------------- | ----------------------- | ------- | ---------------------------------------------------------------------------- |
+| `0x0001` | `GetVersion`          | `()`                   | `ProtocolVersion`       |         |                                                                              |
+| `0x0002` | `GetCapabilities`     | `()`                   | `DeviceCapabilities`    |         |                                                                              |
+| `0x0003` | `Reboot`              | `()`                   | `()`                    |         |                                                                              |
+| `0x0004` | `BootloaderJump`      | `()`                   | `()`                    |         |                                                                              |
+| `0x0005` | `StorageReset`        | `StorageResetMode`     | `()`                    |         |                                                                              |
+| `0x0006` | `GetLockStatus`       | `()`                   | `LockStatus`            |         | Pure read of the current lock state — no side effects.                       |
+| `0x0007` | `UnlockPoll`          | `()`                   | `LockStatus`            |         | Arms/refreshes the unlock attempt and samples the held challenge keys.       |
+| `0x0008` | `Lock`                | `()`                   | `()`                    |         | Relock immediately.                                                          |
+| `0x0009` | `GetLayout`           | `u32`                  | `LayoutChunk`           |         | Get layout blob chunk. `u32` is the byte offset.                             |
+| `0x000A` | `GetDeviceInfo`       | `()`                   | `DeviceInfo`            |         | Identity strings and USB ids; feature gating stays in `GetCapabilities`.     |
+| `0x0101` | `GetKeyAction`        | `KeyPosition`          | `KeyAction`             |         |                                                                              |
+| `0x0102` | `SetKeyAction`        | `SetKeyRequest`        | `()`                    |         |                                                                              |
+| `0x0103` | `GetDefaultLayer`     | `()`                   | `u8`                    |         |                                                                              |
+| `0x0104` | `SetDefaultLayer`     | `u8`                   | `()`                    |         |                                                                              |
+| `0x0105` | `GetEncoderAction`    | `GetEncoderRequest`    | `EncoderAction`         |         |                                                                              |
+| `0x0106` | `SetEncoderAction`    | `SetEncoderRequest`    | `()`                    |         |                                                                              |
+| `0x0107` | `GetKeymapBulk`       | `GetKeymapBulkRequest` | `GetKeymapBulkResponse` | `bulk`  |                                                                              |
+| `0x0108` | `SetKeymapBulk`       | `SetKeymapBulkRequest` | `()`                    | `bulk`  |                                                                              |
+| `0x0201` | `GetMacro`            | `GetMacroRequest`      | `MacroData`             |         |                                                                              |
+| `0x0202` | `SetMacro`            | `SetMacroRequest`      | `()`                    |         |                                                                              |
+| `0x0301` | `GetCombo`            | `u8`                   | `Combo`                 |         |                                                                              |
+| `0x0302` | `SetCombo`            | `SetComboRequest`      | `()`                    |         |                                                                              |
+| `0x0303` | `GetComboBulk`        | `GetComboBulkRequest`  | `GetComboBulkResponse`  | `bulk`  |                                                                              |
+| `0x0304` | `SetComboBulk`        | `SetComboBulkRequest`  | `()`                    | `bulk`  |                                                                              |
+| `0x0401` | `GetMorse`            | `u8`                   | `Morse`                 |         |                                                                              |
+| `0x0402` | `SetMorse`            | `SetMorseRequest`      | `()`                    |         |                                                                              |
+| `0x0403` | `GetMorseBulk`        | `GetMorseBulkRequest`  | `GetMorseBulkResponse`  | `bulk`  |                                                                              |
+| `0x0404` | `SetMorseBulk`        | `SetMorseBulkRequest`  | `()`                    | `bulk`  |                                                                              |
+| `0x0501` | `GetFork`             | `u8`                   | `Fork`                  |         |                                                                              |
+| `0x0502` | `SetFork`             | `SetForkRequest`       | `()`                    |         |                                                                              |
+| `0x0601` | `GetBehaviorConfig`   | `()`                   | `BehaviorConfig`        |         |                                                                              |
+| `0x0602` | `SetBehaviorConfig`   | `BehaviorConfig`       | `()`                    |         |                                                                              |
+| `0x0701` | `GetConnectionType`   | `()`                   | `ConnectionType`        |         |                                                                              |
+| `0x0702` | `GetConnectionStatus` | `()`                   | `ConnectionStatus`      |         | Full `ConnectionStatus` snapshot.                                            |
+| `0x0703` | `GetBleStatus`        | `()`                   | `BleStatus`             | `_ble`  |                                                                              |
+| `0x0704` | `SwitchBleProfile`    | `u8`                   | `()`                    | `_ble`  |                                                                              |
+| `0x0705` | `ClearBleProfile`     | `u8`                   | `()`                    | `_ble`  |                                                                              |
+| `0x0801` | `GetCurrentLayer`     | `()`                   | `u8`                    |         |                                                                              |
+| `0x0802` | `GetMatrixState`      | `()`                   | `MatrixState`           |         |                                                                              |
+| `0x0803` | `GetBatteryStatus`    | `()`                   | `BatteryStatus`         | `_ble`  |                                                                              |
+| `0x0804` | `GetPeripheralStatus` | `u8`                   | `PeripheralStatus`      | `split` |                                                                              |
+| `0x0805` | `GetWpm`              | `()`                   | `u16`                   |         | Latest WPM, sourced from the `WpmUpdate` topic snapshot.                     |
+| `0x0806` | `GetSleepState`       | `()`                   | `bool`                  |         | Latest sleep flag, sourced from the `SleepState` topic snapshot.             |
+| `0x0807` | `GetLedIndicator`     | `()`                   | `LedIndicator`          |         | Latest HID LED bitmap, sourced from the `LedIndicatorChange` topic snapshot. |
+
+## Topics
+
+Topics are best-effort pushes; the `Get*` endpoints above mirror their payloads so a host can recover a missed push.
+
+| CMD      | Name                  | Payload            | Feature | Notes |
+| -------- | --------------------- | ------------------ | ------- | ----- |
+| `0x8001` | `LayerChange`         | `u8`               |         |       |
+| `0x8002` | `WpmUpdate`           | `u16`              |         |       |
+| `0x8003` | `ConnectionChange`    | `ConnectionStatus` |         |       |
+| `0x8004` | `SleepState`          | `bool`             |         |       |
+| `0x8005` | `LedIndicatorChange`  | `LedIndicator`     |         |       |
+| `0x8006` | `BatteryStatusChange` | `BatteryStatus`    | `_ble`  |       |
+
+## Compatibility
+
+- `GetVersion` (`0x0001`) and its `Result<ProtocolVersion, RynkError>` reply are frozen across all versions.
+- Within a major version, adding a CMD or topic is a `minor` bump: old firmware answers `UnknownCmd`, old hosts ignore unknown topics.
+- Reshaping an existing request/response — including appending a field — is a `major` bump.

--- a/rmk-types/src/protocol/rynk/command.rs
+++ b/rmk-types/src/protocol/rynk/command.rs
@@ -81,6 +81,34 @@ impl defmt::Format for Cmd {
     }
 }
 
+/// A command-table row as data for the generated protocol reference. Not
+/// feature-gated — the reference lists the whole protocol; a row's gate rides
+/// along in [`attrs`](Self::attrs)/[`bulk`](Self::bulk). `#[cfg(test)]`, so
+/// these stringified names never reach a firmware binary.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy)]
+pub struct EndpointMeta {
+    pub name: &'static str,
+    pub cmd: u16,
+    pub request: &'static str,
+    pub response: &'static str,
+    /// Stringified row attributes: doc comments and the `cfg` gate.
+    pub attrs: &'static str,
+    /// Carries the `@bulk` marker (gated behind the `bulk` feature).
+    pub bulk: bool,
+}
+
+/// Push counterpart of [`EndpointMeta`]; test-only, same rules.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy)]
+pub struct TopicMeta {
+    pub name: &'static str,
+    pub cmd: u16,
+    pub payload: &'static str,
+    /// Stringified row attributes: doc comments and the `cfg` gate.
+    pub attrs: &'static str,
+}
+
 /// Compile-time guard: Check whether the command value is unique.
 const fn assert_unique(cmds: &[u16]) {
     let mut i = 0;
@@ -108,6 +136,9 @@ macro_rules! endpoints {
     // Gate one generated item on the feature named by the row's marker.
     (@gate bulk $item:item) => { #[cfg(feature = "bulk")] $item };
     (@gate $item:item) => { $item };
+    // Whether the row carries the `@bulk` marker.
+    (@is_bulk bulk) => { true };
+    (@is_bulk) => { false };
     ($( $(#[$meta:meta])* $(@ $marker:ident)? $name:ident = $cmd:literal : $req:ty => $resp:ty; )*) => {
         #[allow(non_upper_case_globals)]
         impl Cmd {
@@ -135,6 +166,19 @@ macro_rules! endpoints {
             $( $(#[$meta])* { m = max_const(m, endpoints!(@floor $($marker)? $name)); } )*
             m
         };
+        /// Endpoint rows as data, in table order — the protocol-reference source
+        /// (see [`EndpointMeta`]).
+        #[cfg(test)]
+        pub const ENDPOINT_META: &[EndpointMeta] = &[
+            $( EndpointMeta {
+                name: stringify!($name),
+                cmd: $cmd,
+                request: stringify!($req),
+                response: stringify!($resp),
+                attrs: stringify!($(#[$meta])*),
+                bulk: endpoints!(@is_bulk $($marker)?),
+            }, )*
+        ];
     };
 }
 
@@ -165,6 +209,16 @@ macro_rules! topics {
             $( $(#[$meta])* { m = max_const(m, <$name as Topic>::MAX_PAYLOAD); } )*
             m
         };
+        /// Topic rows as data, in table order (see [`ENDPOINT_META`]).
+        #[cfg(test)]
+        pub const TOPIC_META: &[TopicMeta] = &[
+            $( TopicMeta {
+                name: stringify!($name),
+                cmd: $cmd,
+                payload: stringify!($payload),
+                attrs: stringify!($(#[$meta])*),
+            }, )*
+        ];
 
         /// A decoded topic push (server → host), one variant per row of the
         /// topic table above — generated from it. `Serialize` lets the host

--- a/rmk-types/src/protocol/rynk/tests.rs
+++ b/rmk-types/src/protocol/rynk/tests.rs
@@ -126,10 +126,17 @@ mod snapshot {
     /// Compare actual snapshot text against the on-disk file.
     /// When `UPDATE_SNAPSHOTS` is set, write the file instead.
     pub fn assert_snapshot(rel_path: &str, actual: String) {
-        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("src/protocol/rynk")
-            .join(rel_path);
+        assert_snapshot_at(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("src/protocol/rynk")
+                .join(rel_path),
+            actual,
+        );
+    }
 
+    /// [`assert_snapshot`] for a generated file at an arbitrary path (e.g. the
+    /// protocol reference under `docs/`).
+    pub fn assert_snapshot_at(path: PathBuf, actual: String) {
         if env::var_os("UPDATE_SNAPSHOTS").is_some() {
             if let Some(parent) = path.parent() {
                 fs::create_dir_all(parent)
@@ -939,4 +946,177 @@ fn wire_frames_locked() {
         &view,
     );
     snapshot::assert_snapshot("snapshots/wire_frames.snap", actual);
+}
+
+/// The human-readable protocol reference under `docs/`, rendered from the
+/// `ENDPOINT_META`/`TOPIC_META` tables. Those tables are not feature-gated, so
+/// every feature set renders identical output; a diff fails CI (regenerate with
+/// `UPDATE_SNAPSHOTS=1`), keeping the doc in lockstep with the wire contract.
+mod protocol_reference {
+    extern crate alloc;
+    extern crate std;
+
+    use alloc::format;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+    use std::path::PathBuf;
+
+    use super::super::command::{ENDPOINT_META, EndpointMeta, TOPIC_META, TopicMeta};
+    use super::ProtocolVersion;
+    use super::snapshot::assert_snapshot_at;
+
+    /// Repo-relative location of the generated page.
+    const DOC_PATH: &str = "docs/docs/main/docs/development/rynk_protocol.md";
+
+    /// Pull the doc text (Notes) and `cfg` feature out of a row's stringified
+    /// attributes. `///` docs stringify as raw strings `#[doc = r"…"]`, wrapping
+    /// after `doc =` when long — hence the whitespace skip and raw-delimiter scan.
+    fn parse_attrs(attrs: &str) -> (String, Option<&str>) {
+        let mut notes = String::new();
+        let mut rest = attrs;
+        while let Some(i) = rest.find("doc =") {
+            rest = rest[i + 5..].trim_start();
+            rest = rest.strip_prefix('r').unwrap_or(rest);
+            let hashes = rest.len() - rest.trim_start_matches('#').len();
+            rest = &rest[hashes..]; // now at the opening quote
+            let close = format!("\"{}", "#".repeat(hashes));
+            let Some(body) = rest.strip_prefix('"').and_then(|s| s.split(&close).next()) else {
+                break;
+            };
+            if !notes.is_empty() {
+                notes.push(' ');
+            }
+            notes.push_str(body.trim());
+            rest = &rest[1 + body.len() + close.len()..];
+        }
+        // Rustdoc intra-links render as broken md links; keep just the code span.
+        let notes = notes.replace("[`", "`").replace("`]", "`");
+        let feature = attrs.find("feature = \"").and_then(|i| {
+            let s = &attrs[i + 11..];
+            s.find('"').map(|end| &s[..end])
+        });
+        (notes, feature)
+    }
+
+    /// Render `rows` as a column-aligned GFM table.
+    fn table(header: &[&str], rows: &[Vec<String>]) -> String {
+        let mut widths: Vec<usize> = header.iter().map(|h| h.chars().count()).collect();
+        for row in rows {
+            for (w, cell) in widths.iter_mut().zip(row) {
+                *w = (*w).max(cell.chars().count());
+            }
+        }
+        let mut out = String::new();
+        let emit = |out: &mut String, cells: &[String]| {
+            out.push('|');
+            for (w, cell) in widths.iter().zip(cells) {
+                out.push_str(&format!(" {:w$} |", cell, w = w));
+            }
+            out.push('\n');
+        };
+        emit(&mut out, &header.iter().map(|h| String::from(*h)).collect::<Vec<_>>());
+        emit(&mut out, &widths.iter().map(|w| "-".repeat(*w)).collect::<Vec<_>>());
+        for row in rows {
+            emit(&mut out, row);
+        }
+        out
+    }
+
+    fn endpoint_rows() -> Vec<Vec<String>> {
+        ENDPOINT_META
+            .iter()
+            .map(
+                |EndpointMeta {
+                     name,
+                     cmd,
+                     request,
+                     response,
+                     attrs,
+                     bulk,
+                 }| {
+                    let (notes, feature) = parse_attrs(attrs);
+                    let feature = if *bulk {
+                        String::from("`bulk`")
+                    } else {
+                        feature.map(|f| format!("`{f}`")).unwrap_or_default()
+                    };
+                    alloc::vec![
+                        format!("`0x{cmd:04X}`"),
+                        format!("`{name}`"),
+                        format!("`{request}`"),
+                        format!("`{response}`"),
+                        feature,
+                        notes,
+                    ]
+                },
+            )
+            .collect()
+    }
+
+    fn topic_rows() -> Vec<Vec<String>> {
+        TOPIC_META
+            .iter()
+            .map(
+                |TopicMeta {
+                     name,
+                     cmd,
+                     payload,
+                     attrs,
+                 }| {
+                    let (notes, feature) = parse_attrs(attrs);
+                    alloc::vec![
+                        format!("`0x{cmd:04X}`"),
+                        format!("`{name}`"),
+                        format!("`{payload}`"),
+                        feature.map(|f| format!("`{f}`")).unwrap_or_default(),
+                        notes,
+                    ]
+                },
+            )
+            .collect()
+    }
+
+    fn render() -> String {
+        let v = ProtocolVersion::CURRENT;
+        format!(
+            "{header}\n\n\
+             # Rynk Protocol Reference\n\n\
+             Current protocol version: **{major}.{minor}**.\n\n\
+             Every transport (USB CDC, BLE GATT, BLE HID) carries the same frame — a 5-byte header plus a [postcard](https://docs.rs/postcard)-encoded payload:\n\n\
+             ```text\n\
+             ┌──────────────┬───────────┬────────────────────┐\n\
+             │ CMD u16 LE   │ SEQ u8    │ LEN u16 LE         │  ← 5-byte header\n\
+             ├──────────────┴───────────┴────────────────────┤\n\
+             │              postcard-encoded payload         │  ← LEN bytes\n\
+             └───────────────────────────────────────────────┘\n\
+             ```\n\n\
+             - **Requests** use CMD `0x0000..=0x7FFF`. The response echoes CMD and SEQ and wraps its payload in postcard `Result<T, RynkError>` (`T = ()` for `Set*`).\n\
+             - **Topics** use CMD `0x8000..=0xFFFF` (server → host push, SEQ `0`, bare payload).\n\n\
+             Which commands a firmware answers depends on the RMK Cargo features it was built with: a row with no **Feature** is present once `rynk` is on, and the rest need their feature (`_ble`, `bulk`, `split`, …) compiled in. A command the firmware wasn't built with answers `UnknownCmd`.\n\n\
+             ## Endpoints\n\n\
+             {endpoints}\n\
+             ## Topics\n\n\
+             Topics are best-effort pushes; the `Get*` endpoints above mirror their payloads so a host can recover a missed push.\n\n\
+             {topics}\n\
+             ## Compatibility\n\n\
+             - `GetVersion` (`0x0001`) and its `Result<ProtocolVersion, RynkError>` reply are frozen across all versions.\n\
+             - Within a major version, adding a CMD or topic is a `minor` bump: old firmware answers `UnknownCmd`, old hosts ignore unknown topics.\n\
+             - Reshaping an existing request/response — including appending a field — is a `major` bump.\n",
+            header = "<!-- GENERATED — do not edit. Rendered from the `endpoints!`/`topics!` tables in\n     rmk-types/src/protocol/rynk/command.rs. Regenerate with:\n     UPDATE_SNAPSHOTS=1 cargo test -p rmk-types --features rynk protocol_reference -->",
+            major = v.major,
+            minor = v.minor,
+            endpoints = table(
+                &["CMD", "Name", "Request", "Response", "Feature", "Notes"],
+                &endpoint_rows()
+            ),
+            topics = table(&["CMD", "Name", "Payload", "Feature", "Notes"], &topic_rows()),
+        )
+    }
+
+    #[test]
+    fn protocol_reference_is_current() {
+        // rmk-types/../ is the repo root.
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..").join(DOC_PATH);
+        assert_snapshot_at(path, render());
+    }
 }


### PR DESCRIPTION
Generate a human-readable Rynk protocol reference from the command tables, so the docs can't drift from the wire contract.

## What it does

- New `ENDPOINT_META` / `TOPIC_META` tables, emitted by the existing `endpoints!` / `topics!` macros — each row's id, name, request/response (or payload) types, `@bulk`/`cfg` feature gate, and doc comment, as data.
- A rendering test in `rmk-types` turns those into `docs/development/rynk_protocol.md` (frame layout, endpoint table, topic table, compatibility rules). It runs `UPDATE_SNAPSHOTS`-style: a diff fails CI, and regenerating is one command — the same idiom as the existing `wire_*.snap` golden files.
- The tables are feature-independent, so every feature set renders identical output; the reference documents the full protocol and shows each command's gating feature in a column.

## Scope

Additive to `rmk-types` only — no protocol, wire-format, firmware, or host changes. Just `command.rs` (the meta tables), `tests.rs` (the generator + drift gate), and the generated `.md`.

## Testing

`rmk-types` default / `host` / `steno` all green (wire snapshots unchanged); the `protocol_reference` drift test passes under both `rynk` and `rynk,bulk,_ble,split`; `rmk` and the `rynk` workspace still build against the additive change; `cargo +nightly fmt --check` clean.
