### PR TITLE
refactor(rynk): stream bulk transfer, drop the `bulk` feature

### DIFF
--- a/.github/ci/_lib.sh
+++ b/.github/ci/_lib.sh
@@ -49,7 +49,7 @@ RMK_FEATURESETS=(
     "split,vial,storage,passkey_entry"
     "vial,storage,steno"
     "split,vial,storage,async_matrix,_ble,steno"
-    "rynk,bulk,_ble,split,storage,async_matrix"
+    "rynk,_ble,split,storage,async_matrix"
     "rynk,storage"
 )
 

--- a/docs/docs/main/docs/development/rynk_protocol.md
+++ b/docs/docs/main/docs/development/rynk_protocol.md
@@ -19,7 +19,7 @@ Every transport (USB CDC, BLE GATT, BLE HID) carries the same frame — a 5-byte
 - **Requests** use CMD `0x0000..=0x7FFF`. The response echoes CMD and SEQ and wraps its payload in postcard `Result<T, RynkError>` (`T = ()` for `Set*`).
 - **Topics** use CMD `0x8000..=0xFFFF` (server → host push, SEQ `0`, bare payload).
 
-Which commands a firmware answers depends on the RMK Cargo features it was built with: a row with no **Feature** is present once `rynk` is on, and the rest need their feature (`_ble`, `bulk`, `split`, …) compiled in. A command the firmware wasn't built with answers `UnknownCmd`.
+Which commands a firmware answers depends on the RMK Cargo features it was built with: a row with no **Feature** is present once `rynk` is on, and the rest need their feature (`_ble`, `split`, …) compiled in. A command the firmware wasn't built with answers `UnknownCmd`.
 
 ## Endpoints
 
@@ -41,18 +41,18 @@ Which commands a firmware answers depends on the RMK Cargo features it was built
 | `0x0104` | `SetDefaultLayer`     | `u8`                   | `()`                    |         |                                                                              |
 | `0x0105` | `GetEncoderAction`    | `GetEncoderRequest`    | `EncoderAction`         |         |                                                                              |
 | `0x0106` | `SetEncoderAction`    | `SetEncoderRequest`    | `()`                    |         |                                                                              |
-| `0x0107` | `GetKeymapBulk`       | `GetKeymapBulkRequest` | `GetKeymapBulkResponse` | `bulk`  |                                                                              |
-| `0x0108` | `SetKeymapBulk`       | `SetKeymapBulkRequest` | `()`                    | `bulk`  |                                                                              |
+| `0x0107` | `GetKeymapBulk`       | `GetKeymapBulkRequest` | `GetKeymapBulkResponse` |         |                                                                              |
+| `0x0108` | `SetKeymapBulk`       | `SetKeymapBulkRequest` | `()`                    |         |                                                                              |
 | `0x0201` | `GetMacro`            | `GetMacroRequest`      | `MacroData`             |         |                                                                              |
 | `0x0202` | `SetMacro`            | `SetMacroRequest`      | `()`                    |         |                                                                              |
 | `0x0301` | `GetCombo`            | `u8`                   | `Combo`                 |         |                                                                              |
 | `0x0302` | `SetCombo`            | `SetComboRequest`      | `()`                    |         |                                                                              |
-| `0x0303` | `GetComboBulk`        | `GetComboBulkRequest`  | `GetComboBulkResponse`  | `bulk`  |                                                                              |
-| `0x0304` | `SetComboBulk`        | `SetComboBulkRequest`  | `()`                    | `bulk`  |                                                                              |
+| `0x0303` | `GetComboBulk`        | `GetComboBulkRequest`  | `GetComboBulkResponse`  |         |                                                                              |
+| `0x0304` | `SetComboBulk`        | `SetComboBulkRequest`  | `()`                    |         |                                                                              |
 | `0x0401` | `GetMorse`            | `u8`                   | `Morse`                 |         |                                                                              |
 | `0x0402` | `SetMorse`            | `SetMorseRequest`      | `()`                    |         |                                                                              |
-| `0x0403` | `GetMorseBulk`        | `GetMorseBulkRequest`  | `GetMorseBulkResponse`  | `bulk`  |                                                                              |
-| `0x0404` | `SetMorseBulk`        | `SetMorseBulkRequest`  | `()`                    | `bulk`  |                                                                              |
+| `0x0403` | `GetMorseBulk`        | `GetMorseBulkRequest`  | `GetMorseBulkResponse`  |         |                                                                              |
+| `0x0404` | `SetMorseBulk`        | `SetMorseBulkRequest`  | `()`                    |         |                                                                              |
 | `0x0501` | `GetFork`             | `u8`                   | `Fork`                  |         |                                                                              |
 | `0x0502` | `SetFork`             | `SetForkRequest`       | `()`                    |         |                                                                              |
 | `0x0601` | `GetBehaviorConfig`   | `()`                   | `BehaviorConfig`        |         |                                                                              |

--- a/examples/use_rust/qemu-riscv-rynk/Cargo.toml
+++ b/examples/use_rust/qemu-riscv-rynk/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-rmk = { path = "../../../rmk", default-features = false, features = ["rynk", "bulk"] }
+rmk = { path = "../../../rmk", default-features = false, features = ["rynk"] }
 embassy-executor = { version = "0.10", features = ["platform-riscv32", "executor-thread"] }
 embassy-futures = { version = "0.1" }
 embassy-time = { version = "0.5", features = ["mock-driver", "generic-queue-8"] }

--- a/rmk-types/Cargo.toml
+++ b/rmk-types/Cargo.toml
@@ -37,9 +37,7 @@ defmt = [
 ]
 # Feature for proc-macro code generation only, not included in firmware
 _codegen = []
-# Feature for RMK native (rynk) protocol support. Bulk transfer endpoints
-# (multi-element keymap/combo/morse) are always included; they stream over the
-# session buffer, so they add no RAM over the single-element endpoints.
+# Enable RMK's Rynk protocol
 rynk = []
 # Host tool
 host = ["rynk", "_ble", "split", "steno", "serde/alloc"]

--- a/rmk-types/Cargo.toml
+++ b/rmk-types/Cargo.toml
@@ -37,13 +37,12 @@ defmt = [
 ]
 # Feature for proc-macro code generation only, not included in firmware
 _codegen = []
-# Feature for RMK native (rynk) protocol support
+# Feature for RMK native (rynk) protocol support. Bulk transfer endpoints
+# (multi-element keymap/combo/morse) are always included; they stream over the
+# session buffer, so they add no RAM over the single-element endpoints.
 rynk = []
-# Bulk transfer endpoints for MCUs with sufficient RAM.
-# Enables multi-element bulk keymap/combo/morse endpoints and BULK_SIZE constant.
-bulk = ["rynk"]
 # Host tool
-host = ["rynk", "bulk", "_ble", "split", "steno", "serde/alloc"]
+host = ["rynk", "_ble", "split", "steno", "serde/alloc"]
 # TypeScript type + wasm ABI export for the web client. Enabled by a codegen/wasm
 # build, never by firmware.
 wasm = ["dep:tsify", "dep:wasm-bindgen", "dep:serde-wasm-bindgen", "host"]

--- a/rmk-types/build.rs
+++ b/rmk-types/build.rs
@@ -82,7 +82,6 @@ fn generate_constants(bc: &BuildConstants) -> String {
 
     // Host uses protocol ceilings; firmware uses keyboard.toml/default capacities.
     let is_host = env::var("CARGO_FEATURE_HOST").is_ok();
-    let is_bulk = env::var("CARGO_FEATURE_BULK").is_ok();
 
     // Protocol ceilings — always emitted so rmk-types source code can reference them.
     lines.push(format!(
@@ -129,7 +128,7 @@ fn generate_constants(bc: &BuildConstants) -> String {
     }
 
     // Bulk counts derive from the buffer and must hold at least one element.
-    if is_bulk {
+    if env::var("CARGO_FEATURE_RYNK").is_ok() {
         lines.push(
             "pub const BULK_SIZE: usize = \
              crate::protocol::rynk::bulk_size_for_buffer(RYNK_BUFFER_SIZE);"

--- a/rmk-types/src/protocol/rynk/command.rs
+++ b/rmk-types/src/protocol/rynk/command.rs
@@ -10,14 +10,11 @@
 use super::endpoint::{Endpoint, Topic, max_const};
 use super::message::RynkMessage;
 use super::{
-    BehaviorConfig, DeviceCapabilities, DeviceInfo, GetEncoderRequest, GetMacroRequest, KeyPosition, LayoutChunk,
-    LockStatus, MacroData, MatrixState, ProtocolVersion, RynkError, SetComboRequest, SetEncoderRequest, SetForkRequest,
-    SetKeyRequest, SetMacroRequest, SetMorseRequest, StorageResetMode,
-};
-#[cfg(feature = "bulk")]
-use super::{
-    GetComboBulkRequest, GetComboBulkResponse, GetKeymapBulkRequest, GetKeymapBulkResponse, GetMorseBulkRequest,
-    GetMorseBulkResponse, SetComboBulkRequest, SetKeymapBulkRequest, SetMorseBulkRequest,
+    BehaviorConfig, DeviceCapabilities, DeviceInfo, GetComboBulkRequest, GetComboBulkResponse, GetEncoderRequest,
+    GetKeymapBulkRequest, GetKeymapBulkResponse, GetMacroRequest, GetMorseBulkRequest, GetMorseBulkResponse,
+    KeyPosition, LayoutChunk, LockStatus, MacroData, MatrixState, ProtocolVersion, RynkError, SetComboBulkRequest,
+    SetComboRequest, SetEncoderRequest, SetForkRequest, SetKeyRequest, SetKeymapBulkRequest, SetMacroRequest,
+    SetMorseBulkRequest, SetMorseRequest, StorageResetMode,
 };
 use crate::action::{EncoderAction, KeyAction};
 #[cfg(feature = "_ble")]
@@ -124,17 +121,16 @@ const fn assert_unique(cmds: &[u16]) {
 
 /// Macro for defining the endpoint (request/response) table.
 ///
-/// A row may carry an optional `@bulk` marker before its name: the endpoint
-/// is gated behind the `bulk` feature and left out of the
-/// `MAX_ENDPOINT_PAYLOAD` fold. Its payload is sized dynamically (bulk
-/// transfer, whose element count tracks `RYNK_BUFFER_SIZE`), so it must not
+/// A row may carry an optional `@bulk` marker before its name: the endpoint is
+/// left out of the `MAX_ENDPOINT_PAYLOAD` fold. Its payload is sized dynamically
+/// (bulk transfer, whose element count tracks `RYNK_BUFFER_SIZE`), so it must not
 /// drive the buffer floor — the buffer drives it, not the other way around.
 macro_rules! endpoints {
     // Fold contribution of one row: its max payload, or 0 when marked `@bulk`.
     (@floor $name:ident) => { <$name as Endpoint>::MAX_PAYLOAD };
     (@floor $marker:ident $name:ident) => { 0 };
-    // Gate one generated item on the feature named by the row's marker.
-    (@gate bulk $item:item) => { #[cfg(feature = "bulk")] $item };
+    // The `@bulk` marker only affects the fold above; items are always emitted.
+    (@gate bulk $item:item) => { $item };
     (@gate $item:item) => { $item };
     // Whether the row carries the `@bulk` marker.
     (@is_bulk bulk) => { true };
@@ -360,7 +356,6 @@ topics! {
 pub const RYNK_MAX_PAYLOAD: usize = max_const(MAX_ENDPOINT_PAYLOAD, MAX_TOPIC_PAYLOAD);
 
 // Bulk counts live here because they need payload `POSTCARD_MAX_SIZE`.
-#[cfg(feature = "bulk")]
 mod bulk_capacity {
     use postcard::experimental::max_size::MaxSize;
 
@@ -396,7 +391,6 @@ mod bulk_capacity {
     }
 }
 
-#[cfg(feature = "bulk")]
 pub use bulk_capacity::{bulk_keymap_size_for_buffer, bulk_size_for_buffer};
 
 #[cfg(test)]
@@ -478,7 +472,6 @@ mod tests {
     /// buffer, and — crucially — their worst-case encoded frame fits the buffer
     /// they were derived from. That fit is what lets the firmware serve a full
     /// bulk message out of its `RYNK_BUFFER_SIZE` buffer.
-    #[cfg(feature = "bulk")]
     #[test]
     fn bulk_counts_derive_from_buffer_and_fit() {
         use super::{bulk_keymap_size_for_buffer, bulk_size_for_buffer};

--- a/rmk-types/src/protocol/rynk/command.rs
+++ b/rmk-types/src/protocol/rynk/command.rs
@@ -7,7 +7,10 @@
 //! - `0x8000..=0xFFFF` (Bit 15 = 1): Topics (Server -> Host push).
 //!
 
-use super::endpoint::{Endpoint, Topic, max_const};
+#[cfg(not(feature = "host"))]
+use postcard::experimental::max_size::MaxSize;
+
+use super::endpoint::{Endpoint, Topic};
 use super::message::RynkMessage;
 use super::{
     BehaviorConfig, DeviceCapabilities, DeviceInfo, GetComboBulkRequest, GetComboBulkResponse, GetEncoderRequest,
@@ -28,6 +31,16 @@ use crate::led_indicator::LedIndicator;
 use crate::morse::Morse;
 #[cfg(feature = "split")]
 use crate::protocol::rynk::PeripheralStatus;
+
+/// `const fn` max/min used by the firmware payload-size fold and the bulk
+/// capacity math below.
+pub(crate) const fn max_const(a: usize, b: usize) -> usize {
+    if a > b { a } else { b }
+}
+
+pub(crate) const fn min_const(a: usize, b: usize) -> usize {
+    if a < b { a } else { b }
+}
 
 /// CMD high bit marking a topic (server → host push).
 const RYNK_TOPIC_BIT: u16 = 0x8000;
@@ -91,8 +104,6 @@ pub struct EndpointMeta {
     pub response: &'static str,
     /// Stringified row attributes: doc comments and the `cfg` gate.
     pub attrs: &'static str,
-    /// Carries the `@bulk` marker (gated behind the `bulk` feature).
-    pub bulk: bool,
 }
 
 /// Push counterpart of [`EndpointMeta`]; test-only, same rules.
@@ -121,42 +132,45 @@ const fn assert_unique(cmds: &[u16]) {
 
 /// Macro for defining the endpoint (request/response) table.
 ///
-/// `@bulk` excludes an endpoint from `MAX_ENDPOINT_PAYLOAD`.
-/// `RYNK_BUFFER_SIZE` determines bulk capacity, so bulk endpoints cannot also set the buffer floor.
+/// Rows are uniform `Name = cmd: Req => Resp;`. Under non-`host` builds the table
+/// folds every request and wrapped response into `MAX_ENDPOINT_PAYLOAD`,
+/// which the firmware buffer must hold; host builds skip the fold, since bulk
+/// payloads are unbounded there and carry no `MaxSize`.
 macro_rules! endpoints {
-    // Fold contribution of one row: its max payload, or 0 when marked `@bulk`.
-    (@floor $name:ident) => { <$name as Endpoint>::MAX_PAYLOAD };
-    (@floor $marker:ident $name:ident) => { 0 };
-    (@gate bulk $item:item) => { $item };
-    (@gate $item:item) => { $item };
-    // Whether the row carries the `@bulk` marker.
-    (@is_bulk bulk) => { true };
-    (@is_bulk) => { false };
-    ($( $(#[$meta:meta])* $(@ $marker:ident)? $name:ident = $cmd:literal : $req:ty => $resp:ty; )*) => {
+    // Per-row size: the larger of its request and its wrapped response.
+    (@size $req:ty, $resp:ty) => {
+        max_const(
+            <$req as MaxSize>::POSTCARD_MAX_SIZE,
+            <Result<$resp, RynkError> as MaxSize>::POSTCARD_MAX_SIZE,
+        )
+    };
+    ($( $(#[$meta:meta])* $name:ident = $cmd:literal : $req:ty => $resp:ty; )*) => {
         #[allow(non_upper_case_globals)]
         impl Cmd {
-            $( endpoints!(@gate $($marker)? $(#[$meta])* pub const $name: Self = Cmd::from_raw($cmd);); )*
+            $( $(#[$meta])* pub const $name: Self = Cmd::from_raw($cmd); )*
         }
         $(
-            endpoints!(@gate $($marker)? $(#[$meta])* pub enum $name {});
-            endpoints!(@gate $($marker)?
-                $(#[$meta])*
-                impl Endpoint for $name {
-                    const CMD: Cmd = Cmd::$name;
-                    type Request = $req;
-                    type Response = $resp;
-                }
-            );
+            $(#[$meta])*
+            pub enum $name {}
+            $(#[$meta])*
+            impl Endpoint for $name {
+                const CMD: Cmd = Cmd::$name;
+                type Request = $req;
+                type Response = $resp;
+            }
         )*
         const _: () = {
             $( core::assert!(!Cmd::from_raw($cmd).is_topic(), "request CMD value in the topic range"); )*
             assert_unique(&[$($cmd),*]);
         };
-        /// Largest non-bulk payload across the endpoint table — the buffer floor.
+        /// Largest request-or-wrapped-response across the whole endpoint table
+        /// (bulk included) — folded firmware-side only, where every payload is a
+        /// bounded type with a `MaxSize`.
+        #[cfg(not(feature = "host"))]
         #[allow(unused_doc_comments)] // row docs also land on the fold statements
         const MAX_ENDPOINT_PAYLOAD: usize = {
             let mut m = 0;
-            $( $(#[$meta])* { m = max_const(m, endpoints!(@floor $($marker)? $name)); } )*
+            $( $(#[$meta])* { m = max_const(m, endpoints!(@size $req, $resp)); } )*
             m
         };
         /// Endpoint rows as data, in table order — the protocol-reference source
@@ -169,7 +183,6 @@ macro_rules! endpoints {
                 request: stringify!($req),
                 response: stringify!($resp),
                 attrs: stringify!($(#[$meta])*),
-                bulk: endpoints!(@is_bulk $($marker)?),
             }, )*
         ];
     };
@@ -195,11 +208,13 @@ macro_rules! topics {
             $( core::assert!(Cmd::from_raw($cmd).is_topic(), "topic CMD value outside the topic range"); )*
             assert_unique(&[$($cmd),*]);
         };
-        /// Largest payload across the whole topic table.
+        /// Largest payload across the whole topic table — folded firmware-side
+        /// only, to feed the firmware buffer assertion.
+        #[cfg(not(feature = "host"))]
         #[allow(unused_doc_comments)]
         const MAX_TOPIC_PAYLOAD: usize = {
             let mut m = 0;
-            $( $(#[$meta])* { m = max_const(m, <$name as Topic>::MAX_PAYLOAD); } )*
+            $( $(#[$meta])* { m = max_const(m, <$payload as MaxSize>::POSTCARD_MAX_SIZE); } )*
             m
         };
         /// Topic rows as data, in table order (see [`ENDPOINT_META`]).
@@ -281,8 +296,8 @@ endpoints! {
     SetDefaultLayer = 0x0104: u8 => ();
     GetEncoderAction = 0x0105: GetEncoderRequest => EncoderAction;
     SetEncoderAction = 0x0106: SetEncoderRequest => ();
-    @bulk GetKeymapBulk = 0x0107: GetKeymapBulkRequest => GetKeymapBulkResponse;
-    @bulk SetKeymapBulk = 0x0108: SetKeymapBulkRequest => ();
+    GetKeymapBulk = 0x0107: GetKeymapBulkRequest => GetKeymapBulkResponse;
+    SetKeymapBulk = 0x0108: SetKeymapBulkRequest => ();
 
     // Macro (0x02xx).
     GetMacro = 0x0201: GetMacroRequest => MacroData;
@@ -291,14 +306,14 @@ endpoints! {
     // Combo (0x03xx).
     GetCombo = 0x0301: u8 => Combo;
     SetCombo = 0x0302: SetComboRequest => ();
-    @bulk GetComboBulk = 0x0303: GetComboBulkRequest => GetComboBulkResponse;
-    @bulk SetComboBulk = 0x0304: SetComboBulkRequest => ();
+    GetComboBulk = 0x0303: GetComboBulkRequest => GetComboBulkResponse;
+    SetComboBulk = 0x0304: SetComboBulkRequest => ();
 
     // Morse (0x04xx).
     GetMorse = 0x0401: u8 => Morse;
     SetMorse = 0x0402: SetMorseRequest => ();
-    @bulk GetMorseBulk = 0x0403: GetMorseBulkRequest => GetMorseBulkResponse;
-    @bulk SetMorseBulk = 0x0404: SetMorseBulkRequest => ();
+    GetMorseBulk = 0x0403: GetMorseBulkRequest => GetMorseBulkResponse;
+    SetMorseBulk = 0x0404: SetMorseBulkRequest => ();
 
     // Fork (0x05xx).
     GetFork = 0x0501: u8 => Fork;
@@ -346,18 +361,29 @@ topics! {
     BatteryStatusChange = 0x8006: BatteryStatus;
 }
 
-/// Maximum postcard-encoded payload size across every non-`@bulk` Rynk
-/// message, folded from the tables above so adding a command can never
-/// under-size the buffer. Bulk endpoints are excluded (see [`endpoints`]);
-/// their size derives from the buffer instead.
-pub const RYNK_MAX_PAYLOAD: usize = max_const(MAX_ENDPOINT_PAYLOAD, MAX_TOPIC_PAYLOAD);
+/// Largest rynk frame payload the firmware must buffer, folded from the tables
+/// above (bulk included) so adding a command can never under-size the buffer.
+/// Firmware-only: on `host` builds the bulk payloads are unbounded (no `MaxSize`).
+#[cfg(not(feature = "host"))]
+const FIRMWARE_MAX_PAYLOAD: usize = max_const(MAX_ENDPOINT_PAYLOAD, MAX_TOPIC_PAYLOAD);
+
+/// The configured buffer must hold every rynk frame this firmware build can send
+/// or receive, header included. Both operands are rmk-types constants — the
+/// buffer is generated from `keyboard.toml`, the fold from the command tables —
+/// so this self-check needs no cross-crate plumbing. `host` builds have unbounded
+/// bulk payloads (no `MaxSize`), so the fold and this assert are absent there.
+#[cfg(not(feature = "host"))]
+const _: () = core::assert!(
+    crate::constants::RYNK_BUFFER_SIZE >= super::message::RYNK_HEADER_SIZE + FIRMWARE_MAX_PAYLOAD,
+    "rynk_buffer_size is too small to hold the largest rynk frame (including bulk); increase it"
+);
 
 // Bulk counts live here because they need payload `POSTCARD_MAX_SIZE`.
 mod bulk_capacity {
     use postcard::experimental::max_size::MaxSize;
 
-    use super::super::endpoint::{max_const, min_const};
     use super::super::message::RYNK_HEADER_SIZE;
+    use super::{max_const, min_const};
     use crate::action::KeyAction;
     use crate::combo::Combo;
     use crate::morse::Morse;
@@ -399,7 +425,7 @@ mod tests {
     use postcard::experimental::max_size::MaxSize;
 
     use super::*;
-    use crate::protocol::rynk::{RYNK_HEADER_SIZE, RYNK_MIN_BUFFER_SIZE, RynkError};
+    use crate::protocol::rynk::{RYNK_HEADER_SIZE, RynkError};
 
     #[test]
     fn topic_mask_is_the_high_bit() {
@@ -435,7 +461,7 @@ mod tests {
     fn topic_event_round_trips_through_the_wire() {
         // The generated enum encodes to a topic frame the host decodes back to
         // the same variant — the producer and consumer halves share one table.
-        let mut buf = [0u8; RYNK_MIN_BUFFER_SIZE];
+        let mut buf = [0u8; 64];
         let ev = TopicEvent::LayerChange(7);
         let msg = ev.encode(&mut buf).unwrap();
 

--- a/rmk-types/src/protocol/rynk/command.rs
+++ b/rmk-types/src/protocol/rynk/command.rs
@@ -121,15 +121,12 @@ const fn assert_unique(cmds: &[u16]) {
 
 /// Macro for defining the endpoint (request/response) table.
 ///
-/// A row may carry an optional `@bulk` marker before its name: the endpoint is
-/// left out of the `MAX_ENDPOINT_PAYLOAD` fold. Its payload is sized dynamically
-/// (bulk transfer, whose element count tracks `RYNK_BUFFER_SIZE`), so it must not
-/// drive the buffer floor — the buffer drives it, not the other way around.
+/// `@bulk` excludes an endpoint from `MAX_ENDPOINT_PAYLOAD`.
+/// `RYNK_BUFFER_SIZE` determines bulk capacity, so bulk endpoints cannot also set the buffer floor.
 macro_rules! endpoints {
     // Fold contribution of one row: its max payload, or 0 when marked `@bulk`.
     (@floor $name:ident) => { <$name as Endpoint>::MAX_PAYLOAD };
     (@floor $marker:ident $name:ident) => { 0 };
-    // The `@bulk` marker only affects the fold above; items are always emitted.
     (@gate bulk $item:item) => { $item };
     (@gate $item:item) => { $item };
     // Whether the row carries the `@bulk` marker.

--- a/rmk-types/src/protocol/rynk/endpoint.rs
+++ b/rmk-types/src/protocol/rynk/endpoint.rs
@@ -15,9 +15,7 @@ pub(crate) const fn max_const(a: usize, b: usize) -> usize {
 }
 
 /// `const fn` min, paired with [`max_const`] to clamp the buffer-derived bulk
-/// counts between 1 and `u8::MAX` in [`super::command`]. Only the bulk capacity
-/// calc uses it, so it is gated with `bulk` to stay dead-code-free otherwise.
-#[cfg(feature = "bulk")]
+/// counts between 1 and `u8::MAX` in [`super::command`].
 pub(crate) const fn min_const(a: usize, b: usize) -> usize {
     if a < b { a } else { b }
 }

--- a/rmk-types/src/protocol/rynk/endpoint.rs
+++ b/rmk-types/src/protocol/rynk/endpoint.rs
@@ -14,8 +14,6 @@ pub(crate) const fn max_const(a: usize, b: usize) -> usize {
     if a > b { a } else { b }
 }
 
-/// `const fn` min, paired with [`max_const`] to clamp the buffer-derived bulk
-/// counts between 1 and `u8::MAX` in [`super::command`].
 pub(crate) const fn min_const(a: usize, b: usize) -> usize {
     if a < b { a } else { b }
 }

--- a/rmk-types/src/protocol/rynk/endpoint.rs
+++ b/rmk-types/src/protocol/rynk/endpoint.rs
@@ -1,39 +1,24 @@
 //! The Rynk endpoint/topic contracts: the [`Endpoint`] and [`Topic`] traits
 //! that bind a command to its payload types.
+//!
+//! These describe only the wire schema. Buffer sizing lives in
+//! [`super::command`]: postcard is slice-driven, so `MaxSize` matters only to
+//! the no-allocator firmware, which folds it there — the traits stay free of it.
 
-use postcard::experimental::max_size::MaxSize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-use super::RynkError;
 use super::command::Cmd;
-
-/// `const fn` max used by the compile-time payload-size folds (here for the
-/// trait `MAX_PAYLOAD` defaults; in [`super::command`] for the table folds).
-pub(crate) const fn max_const(a: usize, b: usize) -> usize {
-    if a > b { a } else { b }
-}
-
-pub(crate) const fn min_const(a: usize, b: usize) -> usize {
-    if a < b { a } else { b }
-}
 
 /// A request/response endpoint: its `Cmd` plus both payload types.
 pub trait Endpoint {
     const CMD: Cmd;
-    type Request: Serialize + DeserializeOwned + MaxSize;
-    type Response: Serialize + DeserializeOwned + MaxSize;
-    /// Largest payload this endpoint puts on the wire in either direction.
-    const MAX_PAYLOAD: usize = max_const(
-        <Self::Request as MaxSize>::POSTCARD_MAX_SIZE,
-        <Result<Self::Response, RynkError> as MaxSize>::POSTCARD_MAX_SIZE,
-    );
+    type Request: Serialize + DeserializeOwned;
+    type Response: Serialize + DeserializeOwned;
 }
 
 /// A topic (server → host push): its `Cmd` plus the bare payload type.
 pub trait Topic {
     const CMD: Cmd;
-    type Payload: Serialize + DeserializeOwned + MaxSize;
-    /// Largest payload this topic pushes.
-    const MAX_PAYLOAD: usize = <Self::Payload as MaxSize>::POSTCARD_MAX_SIZE;
+    type Payload: Serialize + DeserializeOwned;
 }

--- a/rmk-types/src/protocol/rynk/message.rs
+++ b/rmk-types/src/protocol/rynk/message.rs
@@ -100,9 +100,7 @@ impl<'a> RynkMessage<'a> {
         &self.buf[..self.frame_len()]
     }
 
-    /// The request payload bytes, bounded by the declared `LEN`. Public so bulk
-    /// handlers can stream-decode a variable-length payload element by element
-    /// instead of materializing the whole `Vec`.
+    /// Returns the payload bytes specified by the header length.
     pub fn payload(&self) -> &[u8] {
         let payload_len = self.header().payload_len as usize;
         &self.buf[RYNK_HEADER_SIZE..RYNK_HEADER_SIZE + payload_len]
@@ -127,21 +125,17 @@ impl<'a> RynkMessage<'a> {
         Ok(())
     }
 
-    /// Stream an `Ok`-wrapped bulk response into the payload without materializing
-    /// a `Vec`: the postcard `Ok` tag, the sequence length, then each item in turn.
-    /// These bytes match `Ok(Response { <field>: items })` exactly — postcard
-    /// encodes a `Vec` as `varint(len)` then its elements — so a host decoding the
-    /// owned response type interoperates unchanged.
+    /// Encodes a sequence directly into an `Ok` response without allocating a `Vec`.
+    /// The bytes match postcard's `Ok` tag, sequence length, and element encoding.
     pub fn encode_bulk_ok<T, I>(&mut self, count: usize, items: I) -> Result<(), RynkError>
     where
         T: Serialize,
         I: IntoIterator<Item = T>,
     {
         let body = &mut self.buf[RYNK_HEADER_SIZE..];
-        // postcard encodes `Result::Ok` as variant tag 0, then the payload.
+        // postcard encodes `Result::Ok` with tag 0.
         *body.first_mut().ok_or(RynkError::Internal)? = 0;
         let mut used = 1;
-        // Sequence length prefix: postcard writes a `Vec`'s length as this varint.
         used += postcard::to_slice(&count, &mut body[used..])
             .map_err(|_| RynkError::Internal)?
             .len();

--- a/rmk-types/src/protocol/rynk/message.rs
+++ b/rmk-types/src/protocol/rynk/message.rs
@@ -100,7 +100,10 @@ impl<'a> RynkMessage<'a> {
         &self.buf[..self.frame_len()]
     }
 
-    fn payload(&self) -> &[u8] {
+    /// The request payload bytes, bounded by the declared `LEN`. Public so bulk
+    /// handlers can stream-decode a variable-length payload element by element
+    /// instead of materializing the whole `Vec`.
+    pub fn payload(&self) -> &[u8] {
         let payload_len = self.header().payload_len as usize;
         &self.buf[RYNK_HEADER_SIZE..RYNK_HEADER_SIZE + payload_len]
     }
@@ -121,6 +124,36 @@ impl<'a> RynkMessage<'a> {
             .map(|s| s.len())
             .map_err(|_| RynkError::Internal)?;
         self.set_payload_len(n as u16);
+        Ok(())
+    }
+
+    /// Stream an `Ok`-wrapped bulk response into the payload without materializing
+    /// a `Vec`: writes the postcard `Ok` tag, the sequence length, then each item
+    /// from `items` in turn, and updates `LEN`.
+    ///
+    /// The bytes are identical to encoding `Ok(Response { <seq field>: items })`
+    /// — a single-field response struct flattens to its `Vec`, which postcard
+    /// encodes as `varint(len)` followed by the elements — so a host decoding the
+    /// owned response type interoperates unchanged.
+    pub fn encode_bulk_ok<T, I>(&mut self, count: usize, items: I) -> Result<(), RynkError>
+    where
+        T: Serialize,
+        I: IntoIterator<Item = T>,
+    {
+        let body = &mut self.buf[RYNK_HEADER_SIZE..];
+        // postcard encodes `Result::Ok` as variant tag 0, then the payload.
+        *body.first_mut().ok_or(RynkError::Internal)? = 0;
+        let mut used = 1;
+        // Sequence length prefix: postcard writes a `Vec`'s length as this varint.
+        used += postcard::to_slice(&count, &mut body[used..])
+            .map_err(|_| RynkError::Internal)?
+            .len();
+        for item in items {
+            used += postcard::to_slice(&item, &mut body[used..])
+                .map_err(|_| RynkError::Internal)?
+                .len();
+        }
+        self.set_payload_len(used as u16);
         Ok(())
     }
 

--- a/rmk-types/src/protocol/rynk/message.rs
+++ b/rmk-types/src/protocol/rynk/message.rs
@@ -16,14 +16,11 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use super::RynkError;
-use super::command::{Cmd, RYNK_MAX_PAYLOAD};
+use super::command::Cmd;
 use super::endpoint::Topic;
 
 /// Size in bytes of the fixed Rynk header.
 pub const RYNK_HEADER_SIZE: usize = 5;
-
-/// Minimum buffer size required to hold any single Rynk message (header + max-payload).
-pub const RYNK_MIN_BUFFER_SIZE: usize = RYNK_HEADER_SIZE + RYNK_MAX_PAYLOAD;
 
 /// The fixed header of a [`RynkMessage`].
 #[derive(Debug, Clone, Copy)]
@@ -174,18 +171,7 @@ impl<'a> TryFrom<&'a mut [u8]> for RynkMessage<'a> {
 
 #[cfg(test)]
 mod tests {
-    use postcard::experimental::max_size::MaxSize;
-
-    use super::super::DeviceInfo;
     use super::*;
-
-    #[test]
-    fn rynk_min_buffer_size_covers_largest_known_response() {
-        // DeviceInfo is the largest non-bulk response.
-        let wrapped = <Result<DeviceInfo, RynkError> as MaxSize>::POSTCARD_MAX_SIZE;
-        assert!(RYNK_MAX_PAYLOAD >= wrapped);
-        assert!(RYNK_MIN_BUFFER_SIZE >= wrapped + RYNK_HEADER_SIZE);
-    }
 
     #[test]
     fn build_round_trip() {

--- a/rmk-types/src/protocol/rynk/message.rs
+++ b/rmk-types/src/protocol/rynk/message.rs
@@ -128,12 +128,9 @@ impl<'a> RynkMessage<'a> {
     }
 
     /// Stream an `Ok`-wrapped bulk response into the payload without materializing
-    /// a `Vec`: writes the postcard `Ok` tag, the sequence length, then each item
-    /// from `items` in turn, and updates `LEN`.
-    ///
-    /// The bytes are identical to encoding `Ok(Response { <seq field>: items })`
-    /// — a single-field response struct flattens to its `Vec`, which postcard
-    /// encodes as `varint(len)` followed by the elements — so a host decoding the
+    /// a `Vec`: the postcard `Ok` tag, the sequence length, then each item in turn.
+    /// These bytes match `Ok(Response { <field>: items })` exactly — postcard
+    /// encodes a `Vec` as `varint(len)` then its elements — so a host decoding the
     /// owned response type interoperates unchanged.
     pub fn encode_bulk_ok<T, I>(&mut self, count: usize, items: I) -> Result<(), RynkError>
     where

--- a/rmk-types/src/protocol/rynk/mod.rs
+++ b/rmk-types/src/protocol/rynk/mod.rs
@@ -54,9 +54,7 @@ mod payload;
 #[cfg(test)]
 pub(crate) mod tests;
 
-pub use self::command::{Cmd, RYNK_MAX_PAYLOAD, TopicEvent};
-#[cfg(feature = "bulk")]
-pub use self::command::{bulk_keymap_size_for_buffer, bulk_size_for_buffer};
+pub use self::command::{Cmd, RYNK_MAX_PAYLOAD, TopicEvent, bulk_keymap_size_for_buffer, bulk_size_for_buffer};
 pub use self::error::RynkError;
 pub use self::message::{RYNK_HEADER_SIZE, RYNK_MIN_BUFFER_SIZE, RynkHeader, RynkMessage};
 pub use self::payload::*;

--- a/rmk-types/src/protocol/rynk/mod.rs
+++ b/rmk-types/src/protocol/rynk/mod.rs
@@ -54,9 +54,9 @@ mod payload;
 #[cfg(test)]
 pub(crate) mod tests;
 
-pub use self::command::{Cmd, RYNK_MAX_PAYLOAD, TopicEvent, bulk_keymap_size_for_buffer, bulk_size_for_buffer};
+pub use self::command::{Cmd, TopicEvent, bulk_keymap_size_for_buffer, bulk_size_for_buffer};
 pub use self::error::RynkError;
-pub use self::message::{RYNK_HEADER_SIZE, RYNK_MIN_BUFFER_SIZE, RynkHeader, RynkMessage};
+pub use self::message::{RYNK_HEADER_SIZE, RynkHeader, RynkMessage};
 pub use self::payload::*;
 
 /// Largest single GATT write/notification on the Rynk BLE characteristics.

--- a/rmk-types/src/protocol/rynk/payload/combo.rs
+++ b/rmk-types/src/protocol/rynk/payload/combo.rs
@@ -14,7 +14,6 @@ pub struct SetComboRequest {
     pub config: Combo,
 }
 
-// Bulk payloads grouped here; re-exported flat below.
 mod bulk {
     use postcard::experimental::max_size::MaxSize;
     use serde::{Deserialize, Serialize};

--- a/rmk-types/src/protocol/rynk/payload/combo.rs
+++ b/rmk-types/src/protocol/rynk/payload/combo.rs
@@ -14,8 +14,7 @@ pub struct SetComboRequest {
     pub config: Combo,
 }
 
-// Keep the bulk cfg on this module; public payloads are re-exported below.
-#[cfg(feature = "bulk")]
+// Bulk payloads grouped here; re-exported flat below.
 mod bulk {
     use postcard::experimental::max_size::MaxSize;
     use serde::{Deserialize, Serialize};
@@ -81,7 +80,6 @@ mod bulk {
     }
 }
 
-#[cfg(feature = "bulk")]
 pub use bulk::*;
 
 #[cfg(test)]
@@ -126,7 +124,7 @@ mod tests {
     }
 
     // Firmware-only: exercises heapless bulk capacity.
-    #[cfg(all(feature = "bulk", not(feature = "host")))]
+    #[cfg(not(feature = "host"))]
     mod bulk {
         use heapless::Vec;
 

--- a/rmk-types/src/protocol/rynk/payload/combo.rs
+++ b/rmk-types/src/protocol/rynk/payload/combo.rs
@@ -49,9 +49,13 @@ mod bulk {
         pub configs: BulkCombos,
     }
 
-    // Bulk endpoints size from the buffer; this only satisfies `Endpoint: MaxSize`.
+    // Firmware sizes its fixed buffer from these exact bounds; host builds leave
+    // the fields unbounded and never need `MaxSize`.
+    #[cfg(not(feature = "host"))]
     impl MaxSize for SetComboBulkRequest {
-        const POSTCARD_MAX_SIZE: usize = crate::constants::RYNK_BUFFER_SIZE;
+        // start_index, then the bounded configs vector.
+        const POSTCARD_MAX_SIZE: usize =
+            <u8 as MaxSize>::POSTCARD_MAX_SIZE + crate::heapless_vec_max_size::<Combo, BULK_SIZE>();
     }
 
     /// Bulk response for getting multiple combos at once.
@@ -63,8 +67,9 @@ mod bulk {
         pub configs: BulkCombos,
     }
 
+    #[cfg(not(feature = "host"))]
     impl MaxSize for GetComboBulkResponse {
-        const POSTCARD_MAX_SIZE: usize = crate::constants::RYNK_BUFFER_SIZE;
+        const POSTCARD_MAX_SIZE: usize = crate::heapless_vec_max_size::<Combo, BULK_SIZE>();
     }
 
     impl GetComboBulkResponse {

--- a/rmk-types/src/protocol/rynk/payload/keymap.rs
+++ b/rmk-types/src/protocol/rynk/payload/keymap.rs
@@ -24,8 +24,7 @@ pub struct SetKeyRequest {
     pub action: KeyAction,
 }
 
-// Keep the bulk cfg on this module; public payloads are re-exported below.
-#[cfg(feature = "bulk")]
+// Bulk payloads grouped here; re-exported flat below.
 mod bulk {
     use postcard::experimental::max_size::MaxSize;
     use serde::{Deserialize, Serialize};
@@ -100,7 +99,6 @@ mod bulk {
     }
 }
 
-#[cfg(feature = "bulk")]
 pub use bulk::*;
 
 #[cfg(test)]
@@ -130,7 +128,7 @@ mod tests {
     }
 
     // Firmware-only: exercises heapless keymap bulk capacity.
-    #[cfg(all(feature = "bulk", not(feature = "host")))]
+    #[cfg(not(feature = "host"))]
     mod bulk {
         use heapless::Vec;
 

--- a/rmk-types/src/protocol/rynk/payload/keymap.rs
+++ b/rmk-types/src/protocol/rynk/payload/keymap.rs
@@ -62,9 +62,11 @@ mod bulk {
         pub actions: BulkActions,
     }
 
-    // Bulk endpoints size from the buffer; this only satisfies `Endpoint: MaxSize`.
+    // Firmware sizes its fixed buffer from this exact bound; host builds leave
+    // the field unbounded and never need `MaxSize`.
+    #[cfg(not(feature = "host"))]
     impl MaxSize for GetKeymapBulkResponse {
-        const POSTCARD_MAX_SIZE: usize = crate::constants::RYNK_BUFFER_SIZE;
+        const POSTCARD_MAX_SIZE: usize = crate::heapless_vec_max_size::<KeyAction, BULK_KEYMAP_SIZE>();
     }
 
     impl GetKeymapBulkResponse {
@@ -93,8 +95,11 @@ mod bulk {
         pub actions: BulkActions,
     }
 
+    #[cfg(not(feature = "host"))]
     impl MaxSize for SetKeymapBulkRequest {
-        const POSTCARD_MAX_SIZE: usize = crate::constants::RYNK_BUFFER_SIZE;
+        // layer + start_row + start_col, then the bounded actions vector.
+        const POSTCARD_MAX_SIZE: usize =
+            3 * <u8 as MaxSize>::POSTCARD_MAX_SIZE + crate::heapless_vec_max_size::<KeyAction, BULK_KEYMAP_SIZE>();
     }
 }
 

--- a/rmk-types/src/protocol/rynk/payload/keymap.rs
+++ b/rmk-types/src/protocol/rynk/payload/keymap.rs
@@ -24,7 +24,6 @@ pub struct SetKeyRequest {
     pub action: KeyAction,
 }
 
-// Bulk payloads grouped here; re-exported flat below.
 mod bulk {
     use postcard::experimental::max_size::MaxSize;
     use serde::{Deserialize, Serialize};

--- a/rmk-types/src/protocol/rynk/payload/layout.rs
+++ b/rmk-types/src/protocol/rynk/payload/layout.rs
@@ -39,10 +39,7 @@ impl MaxSize for LayoutChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::rynk::command::GetLayout;
-    use crate::protocol::rynk::endpoint::Endpoint;
     use crate::protocol::rynk::tests::{assert_max_size_bound, round_trip};
-    use crate::protocol::rynk::{RYNK_HEADER_SIZE, RYNK_MIN_BUFFER_SIZE, RynkError};
 
     #[test]
     fn round_trip_layout_chunk() {
@@ -61,19 +58,5 @@ mod tests {
         };
         round_trip(&full);
         assert_max_size_bound(&full);
-    }
-
-    /// Layout is built-in, so a full `GetLayout` frame must always fit the
-    /// auto-sized rynk buffer floor. Verifies the blob page can't overrun it.
-    #[test]
-    fn layout_chunk_fits_the_buffer_floor() {
-        let wrapped = <Result<LayoutChunk, RynkError> as MaxSize>::POSTCARD_MAX_SIZE;
-        assert!(
-            RYNK_MIN_BUFFER_SIZE >= RYNK_HEADER_SIZE + wrapped,
-            "RYNK_MIN_BUFFER_SIZE ({RYNK_MIN_BUFFER_SIZE}) must hold a header + a full LayoutChunk response ({})",
-            RYNK_HEADER_SIZE + wrapped,
-        );
-        // GetLayout's own MAX_PAYLOAD is folded into the buffer floor.
-        assert!(RYNK_MIN_BUFFER_SIZE >= RYNK_HEADER_SIZE + <GetLayout as Endpoint>::MAX_PAYLOAD);
     }
 }

--- a/rmk-types/src/protocol/rynk/payload/morse.rs
+++ b/rmk-types/src/protocol/rynk/payload/morse.rs
@@ -14,7 +14,6 @@ pub struct SetMorseRequest {
     pub config: Morse,
 }
 
-// Bulk payloads grouped here; re-exported flat below.
 mod bulk {
     use postcard::experimental::max_size::MaxSize;
     use serde::{Deserialize, Serialize};

--- a/rmk-types/src/protocol/rynk/payload/morse.rs
+++ b/rmk-types/src/protocol/rynk/payload/morse.rs
@@ -49,9 +49,13 @@ mod bulk {
         pub configs: BulkMorses,
     }
 
-    // Bulk endpoints size from the buffer; this only satisfies `Endpoint: MaxSize`.
+    // Firmware sizes its fixed buffer from these exact bounds; host builds leave
+    // the fields unbounded and never need `MaxSize`.
+    #[cfg(not(feature = "host"))]
     impl MaxSize for SetMorseBulkRequest {
-        const POSTCARD_MAX_SIZE: usize = crate::constants::RYNK_BUFFER_SIZE;
+        // start_index, then the bounded configs vector.
+        const POSTCARD_MAX_SIZE: usize =
+            <u8 as MaxSize>::POSTCARD_MAX_SIZE + crate::heapless_vec_max_size::<Morse, BULK_SIZE>();
     }
 
     /// Bulk response for getting multiple morse configs at once.
@@ -63,8 +67,9 @@ mod bulk {
         pub configs: BulkMorses,
     }
 
+    #[cfg(not(feature = "host"))]
     impl MaxSize for GetMorseBulkResponse {
-        const POSTCARD_MAX_SIZE: usize = crate::constants::RYNK_BUFFER_SIZE;
+        const POSTCARD_MAX_SIZE: usize = crate::heapless_vec_max_size::<Morse, BULK_SIZE>();
     }
 
     impl GetMorseBulkResponse {

--- a/rmk-types/src/protocol/rynk/payload/morse.rs
+++ b/rmk-types/src/protocol/rynk/payload/morse.rs
@@ -14,8 +14,7 @@ pub struct SetMorseRequest {
     pub config: Morse,
 }
 
-// Keep the bulk cfg on this module; public payloads are re-exported below.
-#[cfg(feature = "bulk")]
+// Bulk payloads grouped here; re-exported flat below.
 mod bulk {
     use postcard::experimental::max_size::MaxSize;
     use serde::{Deserialize, Serialize};
@@ -81,7 +80,6 @@ mod bulk {
     }
 }
 
-#[cfg(feature = "bulk")]
 pub use bulk::*;
 
 #[cfg(test)]
@@ -144,7 +142,7 @@ mod tests {
     }
 
     // Firmware-only: exercises heapless bulk capacity.
-    #[cfg(all(feature = "bulk", not(feature = "host")))]
+    #[cfg(not(feature = "host"))]
     mod bulk {
         use heapless::Vec;
 

--- a/rmk-types/src/protocol/rynk/tests.rs
+++ b/rmk-types/src/protocol/rynk/tests.rs
@@ -1026,14 +1026,9 @@ mod protocol_reference {
                      request,
                      response,
                      attrs,
-                     bulk,
                  }| {
                     let (notes, feature) = parse_attrs(attrs);
-                    let feature = if *bulk {
-                        String::from("`bulk`")
-                    } else {
-                        feature.map(|f| format!("`{f}`")).unwrap_or_default()
-                    };
+                    let feature = feature.map(|f| format!("`{f}`")).unwrap_or_default();
                     alloc::vec![
                         format!("`0x{cmd:04X}`"),
                         format!("`{name}`"),
@@ -1086,7 +1081,7 @@ mod protocol_reference {
              ```\n\n\
              - **Requests** use CMD `0x0000..=0x7FFF`. The response echoes CMD and SEQ and wraps its payload in postcard `Result<T, RynkError>` (`T = ()` for `Set*`).\n\
              - **Topics** use CMD `0x8000..=0xFFFF` (server → host push, SEQ `0`, bare payload).\n\n\
-             Which commands a firmware answers depends on the RMK Cargo features it was built with: a row with no **Feature** is present once `rynk` is on, and the rest need their feature (`_ble`, `bulk`, `split`, …) compiled in. A command the firmware wasn't built with answers `UnknownCmd`.\n\n\
+             Which commands a firmware answers depends on the RMK Cargo features it was built with: a row with no **Feature** is present once `rynk` is on, and the rest need their feature (`_ble`, `split`, …) compiled in. A command the firmware wasn't built with answers `UnknownCmd`.\n\n\
              ## Endpoints\n\n\
              {endpoints}\n\
              ## Topics\n\n\

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -129,8 +129,6 @@ host_lock = []
 
 ## Enable Rynk protocol support (RMK-native protocol, mutually exclusive with vial).
 ## Includes `host_lock` so the lock gate always has matrix-state tracking.
-## Bulk transfer endpoints are always included: they stream over the session
-## buffer, so they add no RAM over the single-element endpoints.
 rynk = ["host", "host_lock", "rmk-types/rynk"]
 
 ## Enable the storage. The storage is optional to save memory

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -129,10 +129,9 @@ host_lock = []
 
 ## Enable Rynk protocol support (RMK-native protocol, mutually exclusive with vial).
 ## Includes `host_lock` so the lock gate always has matrix-state tracking.
+## Bulk transfer endpoints are always included: they stream over the session
+## buffer, so they add no RAM over the single-element endpoints.
 rynk = ["host", "host_lock", "rmk-types/rynk"]
-
-## Enable bulk transfer endpoints for the Rynk protocol on MCUs with sufficient RAM
-bulk = ["rynk", "rmk-types/bulk"]
 
 ## Enable the storage. The storage is optional to save memory
 storage = [

--- a/rmk/src/host/rynk/handlers/bulk.rs
+++ b/rmk/src/host/rynk/handlers/bulk.rs
@@ -1,10 +1,3 @@
-//! Shared logic for the bulk transfer handlers: flat-index arithmetic plus the
-//! streaming decode helpers that let a `Set*Bulk` handler walk its payload
-//! element by element instead of materializing the whole `Vec`.
-//!
-//! Per-resource addressing (combo/morse slot index, keymap `layer/row/col`) is
-//! translated to a flat index by each handler before calling the arithmetic.
-
 use rmk_types::protocol::rynk::RynkError;
 use serde::de::DeserializeOwned;
 
@@ -24,25 +17,19 @@ pub(super) fn bulk_write_start(start: usize, len: usize, total: usize) -> Result
     Ok(start)
 }
 
-/// Decode the postcard varint a bulk `Vec` payload begins with — the element
-/// count — returning it and the remaining element bytes. The count never exceeds
-/// the reported bulk budget (`u8::MAX`), so a `u16` decode covers every valid
-/// frame and rejects an overlong varint as malformed.
+/// Valid bulk counts fit in `u16`.
 pub(super) fn take_seq_len(bytes: &[u8]) -> Result<(usize, &[u8]), RynkError> {
     let (len, rest) = postcard::take_from_bytes::<u16>(bytes).map_err(|_| RynkError::Malformed)?;
     Ok((len as usize, rest))
 }
 
-/// Decode one bulk element and advance `cursor` past it.
 pub(super) fn take_element<T: DeserializeOwned>(cursor: &mut &[u8]) -> Result<T, RynkError> {
     let (value, rest) = postcard::take_from_bytes::<T>(cursor).map_err(|_| RynkError::Malformed)?;
     *cursor = rest;
     Ok(value)
 }
 
-/// Pass one of the two-pass bulk write: confirm all `count` elements decode
-/// cleanly, so a malformed tail aborts the whole write before any element lands
-/// (all-or-nothing). Pass two re-decodes the same bytes and applies each.
+/// Validates all elements first so malformed input cannot cause a partial write.
 pub(super) fn validate_bulk_elements<T: DeserializeOwned>(mut bytes: &[u8], count: usize) -> Result<(), RynkError> {
     for _ in 0..count {
         take_element::<T>(&mut bytes)?;

--- a/rmk/src/host/rynk/handlers/bulk.rs
+++ b/rmk/src/host/rynk/handlers/bulk.rs
@@ -33,13 +33,19 @@ pub(super) fn take_seq_len(bytes: &[u8]) -> Result<(usize, &[u8]), RynkError> {
     Ok((len as usize, rest))
 }
 
+/// Decode one bulk element and advance `cursor` past it.
+pub(super) fn take_element<T: DeserializeOwned>(cursor: &mut &[u8]) -> Result<T, RynkError> {
+    let (value, rest) = postcard::take_from_bytes::<T>(cursor).map_err(|_| RynkError::Malformed)?;
+    *cursor = rest;
+    Ok(value)
+}
+
 /// Pass one of the two-pass bulk write: confirm all `count` elements decode
 /// cleanly, so a malformed tail aborts the whole write before any element lands
 /// (all-or-nothing). Pass two re-decodes the same bytes and applies each.
 pub(super) fn validate_bulk_elements<T: DeserializeOwned>(mut bytes: &[u8], count: usize) -> Result<(), RynkError> {
     for _ in 0..count {
-        let (_, rest) = postcard::take_from_bytes::<T>(bytes).map_err(|_| RynkError::Malformed)?;
-        bytes = rest;
+        take_element::<T>(&mut bytes)?;
     }
     Ok(())
 }

--- a/rmk/src/host/rynk/handlers/bulk.rs
+++ b/rmk/src/host/rynk/handlers/bulk.rs
@@ -1,8 +1,12 @@
-//! Shared arithmetic for the bulk transfer handlers, over flat resource indices.
+//! Shared logic for the bulk transfer handlers: flat-index arithmetic plus the
+//! streaming decode helpers that let a `Set*Bulk` handler walk its payload
+//! element by element instead of materializing the whole `Vec`.
+//!
 //! Per-resource addressing (combo/morse slot index, keymap `layer/row/col`) is
-//! translated to a flat index by each handler before calling these.
+//! translated to a flat index by each handler before calling the arithmetic.
 
 use rmk_types::protocol::rynk::RynkError;
+use serde::de::DeserializeOwned;
 
 /// Clamp a bulk read to one page: at most `cap` items from flat index `start`,
 /// never past `total`. An out-of-range `start` yields an empty range — the empty
@@ -18,4 +22,24 @@ pub(super) fn bulk_write_start(start: usize, len: usize, total: usize) -> Result
         return Err(RynkError::Invalid);
     }
     Ok(start)
+}
+
+/// Decode the postcard varint a bulk `Vec` payload begins with — the element
+/// count — returning it and the remaining element bytes. The count never exceeds
+/// the reported bulk budget (`u8::MAX`), so a `u16` decode covers every valid
+/// frame and rejects an overlong varint as malformed.
+pub(super) fn take_seq_len(bytes: &[u8]) -> Result<(usize, &[u8]), RynkError> {
+    let (len, rest) = postcard::take_from_bytes::<u16>(bytes).map_err(|_| RynkError::Malformed)?;
+    Ok((len as usize, rest))
+}
+
+/// Pass one of the two-pass bulk write: confirm all `count` elements decode
+/// cleanly, so a malformed tail aborts the whole write before any element lands
+/// (all-or-nothing). Pass two re-decodes the same bytes and applies each.
+pub(super) fn validate_bulk_elements<T: DeserializeOwned>(mut bytes: &[u8], count: usize) -> Result<(), RynkError> {
+    for _ in 0..count {
+        let (_, rest) = postcard::take_from_bytes::<T>(bytes).map_err(|_| RynkError::Malformed)?;
+        bytes = rest;
+    }
+    Ok(())
 }

--- a/rmk/src/host/rynk/handlers/combo.rs
+++ b/rmk/src/host/rynk/handlers/combo.rs
@@ -6,8 +6,8 @@ use rmk_types::protocol::rynk::command::{GetCombo, GetComboBulk, SetCombo, SetCo
 use rmk_types::protocol::rynk::{GetComboBulkRequest, RynkError, RynkMessage, SetComboRequest};
 
 use super::super::RynkService;
-use super::Handle;
 use super::bulk::{bulk_page, bulk_write_start, take_element, take_seq_len, validate_bulk_elements};
+use super::{Handle, HandleBulk};
 
 impl Handle<GetCombo> for RynkService<'_> {
     async fn handle(&self, idx: u8) -> Result<ComboConfig, RynkError> {
@@ -34,8 +34,8 @@ impl Handle<SetCombo> for RynkService<'_> {
     }
 }
 
-impl Handle<GetComboBulk> for RynkService<'_> {
-    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+impl HandleBulk<GetComboBulk> for RynkService<'_> {
+    async fn handle_bulk(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
         let req = msg.decode_request::<GetComboBulkRequest>()?;
         // Empty slots read back as the empty config, same as the single Get; an
         // out-of-range `start_index` yields an empty page.
@@ -55,8 +55,8 @@ impl Handle<GetComboBulk> for RynkService<'_> {
     }
 }
 
-impl Handle<SetComboBulk> for RynkService<'_> {
-    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+impl HandleBulk<SetComboBulk> for RynkService<'_> {
+    async fn handle_bulk(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
         let (start_index, rest) = postcard::take_from_bytes::<u8>(msg.payload()).map_err(|_| RynkError::Malformed)?;
         let (count, elements) = take_seq_len(rest)?;
 

--- a/rmk/src/host/rynk/handlers/combo.rs
+++ b/rmk/src/host/rynk/handlers/combo.rs
@@ -7,7 +7,7 @@ use rmk_types::protocol::rynk::{GetComboBulkRequest, RynkError, RynkMessage, Set
 
 use super::super::RynkService;
 use super::Handle;
-use super::bulk::{bulk_page, bulk_write_start, take_seq_len, validate_bulk_elements};
+use super::bulk::{bulk_page, bulk_write_start, take_element, take_seq_len, validate_bulk_elements};
 
 impl Handle<GetCombo> for RynkService<'_> {
     async fn handle(&self, idx: u8) -> Result<ComboConfig, RynkError> {
@@ -63,18 +63,14 @@ impl Handle<SetComboBulk> for RynkService<'_> {
         let (start_index, rest) = postcard::take_from_bytes::<u8>(msg.payload()).map_err(|_| RynkError::Malformed)?;
         let (count, elements) = take_seq_len(rest)?;
 
-        // Validate the whole run first, so it applies whole or not at all: the
-        // range fits, and every element decodes (pass one).
+        // Validate the whole run first, so it applies whole or not at all.
         let num_combos = self.ctx.with_combos(|combos| combos.len());
         let start = bulk_write_start(start_index as usize, count, num_combos)?;
         validate_bulk_elements::<ComboConfig>(elements, count)?;
 
-        // Pass two: re-decode and apply. Range and decode are already checked,
-        // so `set_combo` succeeds for every slot.
         let mut cursor = elements;
         for idx in start..start + count {
-            let (config, next) = postcard::take_from_bytes::<ComboConfig>(cursor).map_err(|_| RynkError::Malformed)?;
-            cursor = next;
+            let config = take_element::<ComboConfig>(&mut cursor)?;
             self.ctx.set_combo(idx as u8, config).await;
         }
         msg.encode_response(&())

--- a/rmk/src/host/rynk/handlers/combo.rs
+++ b/rmk/src/host/rynk/handlers/combo.rs
@@ -35,7 +35,6 @@ impl Handle<SetCombo> for RynkService<'_> {
 }
 
 impl Handle<GetComboBulk> for RynkService<'_> {
-    // Streams the page straight into the response buffer — no `Vec` of `Combo`.
     async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
         let req = msg.decode_request::<GetComboBulkRequest>()?;
         // Empty slots read back as the empty config, same as the single Get; an
@@ -57,13 +56,10 @@ impl Handle<GetComboBulk> for RynkService<'_> {
 }
 
 impl Handle<SetComboBulk> for RynkService<'_> {
-    // Decodes the payload one `Combo` at a time instead of into a `Vec`.
     async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
-        // Payload: `start_index` (u8) then a postcard seq of `Combo`.
         let (start_index, rest) = postcard::take_from_bytes::<u8>(msg.payload()).map_err(|_| RynkError::Malformed)?;
         let (count, elements) = take_seq_len(rest)?;
 
-        // Validate the whole run first, so it applies whole or not at all.
         let num_combos = self.ctx.with_combos(|combos| combos.len());
         let start = bulk_write_start(start_index as usize, count, num_combos)?;
         validate_bulk_elements::<ComboConfig>(elements, count)?;

--- a/rmk/src/host/rynk/handlers/combo.rs
+++ b/rmk/src/host/rynk/handlers/combo.rs
@@ -1,19 +1,13 @@
 //! Combo handlers.
 
 use rmk_types::combo::Combo as ComboConfig;
-#[cfg(feature = "bulk")]
 use rmk_types::constants::BULK_SIZE;
-use rmk_types::protocol::rynk::command::{GetCombo, SetCombo};
-#[cfg(feature = "bulk")]
-use rmk_types::protocol::rynk::command::{GetComboBulk, SetComboBulk};
-#[cfg(feature = "bulk")]
-use rmk_types::protocol::rynk::{GetComboBulkRequest, GetComboBulkResponse, SetComboBulkRequest};
-use rmk_types::protocol::rynk::{RynkError, SetComboRequest};
+use rmk_types::protocol::rynk::command::{GetCombo, GetComboBulk, SetCombo, SetComboBulk};
+use rmk_types::protocol::rynk::{GetComboBulkRequest, RynkError, RynkMessage, SetComboRequest};
 
 use super::super::RynkService;
 use super::Handle;
-#[cfg(feature = "bulk")]
-use super::bulk::{bulk_page, bulk_write_start};
+use super::bulk::{bulk_page, bulk_write_start, take_seq_len, validate_bulk_elements};
 
 impl Handle<GetCombo> for RynkService<'_> {
     async fn handle(&self, idx: u8) -> Result<ComboConfig, RynkError> {
@@ -40,33 +34,49 @@ impl Handle<SetCombo> for RynkService<'_> {
     }
 }
 
-#[cfg(feature = "bulk")]
 impl Handle<GetComboBulk> for RynkService<'_> {
-    async fn handle(&self, req: GetComboBulkRequest) -> Result<GetComboBulkResponse, RynkError> {
+    // Streams the page straight into the response buffer — no `Vec` of `Combo`.
+    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+        let req = msg.decode_request::<GetComboBulkRequest>()?;
         // Empty slots read back as the empty config, same as the single Get; an
         // out-of-range `start_index` yields an empty page.
         self.ctx.with_combos(|combos| {
             let page = bulk_page(req.start_index as usize, BULK_SIZE, combos.len());
-            Ok(GetComboBulkResponse::from_iter_bounded(page.map(|i| {
-                combos[i]
-                    .as_ref()
-                    .map(|c| c.config.clone())
-                    .unwrap_or_else(ComboConfig::empty)
-            })))
+            let count = page.len();
+            msg.encode_bulk_ok(
+                count,
+                page.map(|i| {
+                    combos[i]
+                        .as_ref()
+                        .map(|c| c.config.clone())
+                        .unwrap_or_else(ComboConfig::empty)
+                }),
+            )
         })
     }
 }
 
-#[cfg(feature = "bulk")]
 impl Handle<SetComboBulk> for RynkService<'_> {
-    async fn handle(&self, req: SetComboBulkRequest) -> Result<(), RynkError> {
-        // Validate the whole run first, so it applies whole or not at all. The
-        // range then stays in bounds, so `set_combo`'s success is guaranteed.
+    // Decodes the payload one `Combo` at a time instead of into a `Vec`.
+    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+        // Payload: `start_index` (u8) then a postcard seq of `Combo`.
+        let (start_index, rest) = postcard::take_from_bytes::<u8>(msg.payload()).map_err(|_| RynkError::Malformed)?;
+        let (count, elements) = take_seq_len(rest)?;
+
+        // Validate the whole run first, so it applies whole or not at all: the
+        // range fits, and every element decodes (pass one).
         let num_combos = self.ctx.with_combos(|combos| combos.len());
-        let start = bulk_write_start(req.start_index as usize, req.configs.len(), num_combos)?;
-        for (idx, config) in (start..).zip(req.configs.iter()) {
-            self.ctx.set_combo(idx as u8, config.clone()).await;
+        let start = bulk_write_start(start_index as usize, count, num_combos)?;
+        validate_bulk_elements::<ComboConfig>(elements, count)?;
+
+        // Pass two: re-decode and apply. Range and decode are already checked,
+        // so `set_combo` succeeds for every slot.
+        let mut cursor = elements;
+        for idx in start..start + count {
+            let (config, next) = postcard::take_from_bytes::<ComboConfig>(cursor).map_err(|_| RynkError::Malformed)?;
+            cursor = next;
+            self.ctx.set_combo(idx as u8, config).await;
         }
-        Ok(())
+        msg.encode_response(&())
     }
 }

--- a/rmk/src/host/rynk/handlers/keymap.rs
+++ b/rmk/src/host/rynk/handlers/keymap.rs
@@ -1,21 +1,18 @@
 //! Keymap and encoder handlers (encoder is part of keymap's `0x01xx` Cmd group).
 
 use rmk_types::action::{EncoderAction, KeyAction};
-#[cfg(feature = "bulk")]
 use rmk_types::constants::BULK_KEYMAP_SIZE;
 use rmk_types::protocol::rynk::command::{
-    GetDefaultLayer, GetEncoderAction, GetKeyAction, SetDefaultLayer, SetEncoderAction, SetKeyAction,
+    GetDefaultLayer, GetEncoderAction, GetKeyAction, GetKeymapBulk, SetDefaultLayer, SetEncoderAction, SetKeyAction,
+    SetKeymapBulk,
 };
-#[cfg(feature = "bulk")]
-use rmk_types::protocol::rynk::command::{GetKeymapBulk, SetKeymapBulk};
-use rmk_types::protocol::rynk::{GetEncoderRequest, KeyPosition, RynkError, SetEncoderRequest, SetKeyRequest};
-#[cfg(feature = "bulk")]
-use rmk_types::protocol::rynk::{GetKeymapBulkRequest, GetKeymapBulkResponse, SetKeymapBulkRequest};
+use rmk_types::protocol::rynk::{
+    GetEncoderRequest, GetKeymapBulkRequest, KeyPosition, RynkError, RynkMessage, SetEncoderRequest, SetKeyRequest,
+};
 
 use super::super::RynkService;
 use super::Handle;
-#[cfg(feature = "bulk")]
-use super::bulk::{bulk_page, bulk_write_start};
+use super::bulk::{bulk_page, bulk_write_start, take_seq_len, validate_bulk_elements};
 
 impl Handle<GetKeyAction> for RynkService<'_> {
     async fn handle(&self, pos: KeyPosition) -> Result<KeyAction, RynkError> {
@@ -90,7 +87,6 @@ impl RynkService<'_> {
     }
 }
 
-#[cfg(feature = "bulk")]
 impl RynkService<'_> {
     /// Validate a bulk keymap start position against the live geometry and
     /// return its flat, row-major, layer-major key index.
@@ -105,33 +101,44 @@ impl RynkService<'_> {
     }
 }
 
-#[cfg(feature = "bulk")]
 impl Handle<GetKeymapBulk> for RynkService<'_> {
-    async fn handle(&self, req: GetKeymapBulkRequest) -> Result<GetKeymapBulkResponse, RynkError> {
+    // Streams the page straight into the response buffer — no `Vec` of `KeyAction`.
+    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+        let req = msg.decode_request::<GetKeymapBulkRequest>()?;
         // From the start key the page reads forward through the flat keymap,
         // crossing row and layer boundaries freely, and stops at the keymap's end.
         let start = self.keymap_flat_start(req.layer, req.start_row, req.start_col)?;
         let (rows, cols, num_layers) = self.ctx.keymap_dimensions();
         let page = bulk_page(start, BULK_KEYMAP_SIZE, num_layers * rows * cols);
-        Ok(GetKeymapBulkResponse::from_iter_bounded(
-            page.map(|offset| self.ctx.get_action_flat(offset)),
-        ))
+        let count = page.len();
+        msg.encode_bulk_ok(count, page.map(|offset| self.ctx.get_action_flat(offset)))
     }
 }
 
-#[cfg(feature = "bulk")]
 impl Handle<SetKeymapBulk> for RynkService<'_> {
-    async fn handle(&self, req: SetKeymapBulkRequest) -> Result<(), RynkError> {
+    // Decodes the payload one `KeyAction` at a time instead of into a `Vec`.
+    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+        // Payload: layer/start_row/start_col (3×u8) then a postcard seq of `KeyAction`.
+        let ([layer, start_row, start_col], rest) =
+            postcard::take_from_bytes::<[u8; 3]>(msg.payload()).map_err(|_| RynkError::Malformed)?;
+        let (count, elements) = take_seq_len(rest)?;
+
         // Validate the whole run first, so it applies whole or not at all.
-        let start = self.keymap_flat_start(req.layer, req.start_row, req.start_col)?;
+        let start = self.keymap_flat_start(layer, start_row, start_col)?;
         let (rows, cols, num_layers) = self.ctx.keymap_dimensions();
-        let start = bulk_write_start(start, req.actions.len(), num_layers * rows * cols)?;
-        for (offset, action) in (start..).zip(req.actions.iter()) {
+        let start = bulk_write_start(start, count, num_layers * rows * cols)?;
+        validate_bulk_elements::<KeyAction>(elements, count)?;
+
+        // Row-major, layer-major flat walk from the validated start.
+        let mut cursor = elements;
+        for offset in start..start + count {
+            let (action, next) = postcard::take_from_bytes::<KeyAction>(cursor).map_err(|_| RynkError::Malformed)?;
+            cursor = next;
             let layer = (offset / (rows * cols)) as u8;
             let row = (offset / cols % rows) as u8;
             let col = (offset % cols) as u8;
-            self.ctx.set_action(layer, row, col, *action).await;
+            self.ctx.set_action(layer, row, col, action).await;
         }
-        Ok(())
+        msg.encode_response(&())
     }
 }

--- a/rmk/src/host/rynk/handlers/keymap.rs
+++ b/rmk/src/host/rynk/handlers/keymap.rs
@@ -102,7 +102,6 @@ impl RynkService<'_> {
 }
 
 impl Handle<GetKeymapBulk> for RynkService<'_> {
-    // Streams the page straight into the response buffer — no `Vec` of `KeyAction`.
     async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
         let req = msg.decode_request::<GetKeymapBulkRequest>()?;
         // From the start key the page reads forward through the flat keymap,
@@ -116,20 +115,17 @@ impl Handle<GetKeymapBulk> for RynkService<'_> {
 }
 
 impl Handle<SetKeymapBulk> for RynkService<'_> {
-    // Decodes the payload one `KeyAction` at a time instead of into a `Vec`.
     async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
-        // Payload: layer/start_row/start_col (3×u8) then a postcard seq of `KeyAction`.
         let ([layer, start_row, start_col], rest) =
             postcard::take_from_bytes::<[u8; 3]>(msg.payload()).map_err(|_| RynkError::Malformed)?;
         let (count, elements) = take_seq_len(rest)?;
 
-        // Validate the whole run first, so it applies whole or not at all.
         let start = self.keymap_flat_start(layer, start_row, start_col)?;
         let (rows, cols, num_layers) = self.ctx.keymap_dimensions();
         let start = bulk_write_start(start, count, num_layers * rows * cols)?;
         validate_bulk_elements::<KeyAction>(elements, count)?;
 
-        // Row-major, layer-major flat walk from the validated start.
+        // Bulk order advances columns, then rows, then layers.
         let mut cursor = elements;
         for offset in start..start + count {
             let action = take_element::<KeyAction>(&mut cursor)?;

--- a/rmk/src/host/rynk/handlers/keymap.rs
+++ b/rmk/src/host/rynk/handlers/keymap.rs
@@ -12,7 +12,7 @@ use rmk_types::protocol::rynk::{
 
 use super::super::RynkService;
 use super::Handle;
-use super::bulk::{bulk_page, bulk_write_start, take_seq_len, validate_bulk_elements};
+use super::bulk::{bulk_page, bulk_write_start, take_element, take_seq_len, validate_bulk_elements};
 
 impl Handle<GetKeyAction> for RynkService<'_> {
     async fn handle(&self, pos: KeyPosition) -> Result<KeyAction, RynkError> {
@@ -132,8 +132,7 @@ impl Handle<SetKeymapBulk> for RynkService<'_> {
         // Row-major, layer-major flat walk from the validated start.
         let mut cursor = elements;
         for offset in start..start + count {
-            let (action, next) = postcard::take_from_bytes::<KeyAction>(cursor).map_err(|_| RynkError::Malformed)?;
-            cursor = next;
+            let action = take_element::<KeyAction>(&mut cursor)?;
             let layer = (offset / (rows * cols)) as u8;
             let row = (offset / cols % rows) as u8;
             let col = (offset % cols) as u8;

--- a/rmk/src/host/rynk/handlers/keymap.rs
+++ b/rmk/src/host/rynk/handlers/keymap.rs
@@ -11,8 +11,8 @@ use rmk_types::protocol::rynk::{
 };
 
 use super::super::RynkService;
-use super::Handle;
 use super::bulk::{bulk_page, bulk_write_start, take_element, take_seq_len, validate_bulk_elements};
+use super::{Handle, HandleBulk};
 
 impl Handle<GetKeyAction> for RynkService<'_> {
     async fn handle(&self, pos: KeyPosition) -> Result<KeyAction, RynkError> {
@@ -101,8 +101,8 @@ impl RynkService<'_> {
     }
 }
 
-impl Handle<GetKeymapBulk> for RynkService<'_> {
-    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+impl HandleBulk<GetKeymapBulk> for RynkService<'_> {
+    async fn handle_bulk(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
         let req = msg.decode_request::<GetKeymapBulkRequest>()?;
         // From the start key the page reads forward through the flat keymap,
         // crossing row and layer boundaries freely, and stops at the keymap's end.
@@ -114,8 +114,8 @@ impl Handle<GetKeymapBulk> for RynkService<'_> {
     }
 }
 
-impl Handle<SetKeymapBulk> for RynkService<'_> {
-    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+impl HandleBulk<SetKeymapBulk> for RynkService<'_> {
+    async fn handle_bulk(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
         let ([layer, start_row, start_col], rest) =
             postcard::take_from_bytes::<[u8; 3]>(msg.payload()).map_err(|_| RynkError::Malformed)?;
         let (count, elements) = take_seq_len(rest)?;

--- a/rmk/src/host/rynk/handlers/mod.rs
+++ b/rmk/src/host/rynk/handlers/mod.rs
@@ -15,17 +15,39 @@ pub(crate) mod morse;
 pub(crate) mod status;
 pub(crate) mod system;
 
-/// The dispatcher calls [`handle_message`](Self::handle_message) for every command.
+/// Fixed-size endpoints: a request → response function. The [`Serve`] blanket
+/// impl adds the decode → handle → encode wire glue.
 pub(super) trait Handle<E: Endpoint> {
-    /// Fixed-size handlers implement this method.
-    /// Bulk handlers override `handle_message` to stream through the session buffer.
-    async fn handle(&self, _req: E::Request) -> Result<E::Response, RynkError> {
-        Err(RynkError::Unimplemented)
-    }
+    async fn handle(&self, req: E::Request) -> Result<E::Response, RynkError>;
+}
 
-    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+/// Bulk endpoints stream a page straight through the session buffer, so no `Vec`
+/// is ever materialized. Implemented instead of [`Handle`].
+pub(super) trait HandleBulk<E: Endpoint> {
+    async fn handle_bulk(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError>;
+}
+
+/// Dispatch-mode markers so the two [`Serve`] blanket impls don't overlap; bounds
+/// alone can't disambiguate blanket impls. Inferred as `_`, never named.
+pub(super) struct Fixed;
+pub(super) struct Bulk;
+
+/// The uniform surface the dispatcher calls, blanket-derived from [`Handle`]
+/// (`Fixed`) or [`HandleBulk`] (`Bulk`). Handlers never implement it directly.
+pub(super) trait Serve<E: Endpoint, Mode> {
+    async fn serve(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError>;
+}
+
+impl<E: Endpoint, T: Handle<E>> Serve<E, Fixed> for T {
+    async fn serve(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
         let req = msg.decode_request::<E::Request>()?;
         let resp = self.handle(req).await?;
         msg.encode_response(&resp)
+    }
+}
+
+impl<E: Endpoint, T: HandleBulk<E>> Serve<E, Bulk> for T {
+    async fn serve(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+        self.handle_bulk(msg).await
     }
 }

--- a/rmk/src/host/rynk/handlers/mod.rs
+++ b/rmk/src/host/rynk/handlers/mod.rs
@@ -1,11 +1,4 @@
 //! Rynk command handlers.
-//!
-//! Each command row implements [`Handle`] on
-//! [`RynkService`](super::RynkService), split across this directory by
-//! domain. Most handlers are pure request → response functions; the trait's
-//! provided [`handle_message`](Handle::handle_message) carries the shared wire
-//! glue, so they never touch the wire view. The variable-length bulk endpoints
-//! override `handle_message` to stream over the buffer instead (see [`bulk`]).
 
 use rmk_types::protocol::rynk::endpoint::Endpoint;
 use rmk_types::protocol::rynk::{RynkError, RynkMessage};
@@ -22,24 +15,14 @@ pub(crate) mod morse;
 pub(crate) mod status;
 pub(crate) mod system;
 
-/// One typed handler per command row (the `Read::read` / `read_exact` naming
-/// convention): dispatch always calls [`handle_message`](Self::handle_message).
-///
-/// Fixed-size endpoints implement the bare [`handle`](Self::handle) primitive and
-/// inherit the default `handle_message`. The variable-length bulk endpoints
-/// instead override `handle_message` to stream over the buffer — decoding and
-/// encoding one element at a time rather than materializing the payload `Vec` —
-/// and leave `handle` at its default.
+/// The dispatcher calls [`handle_message`](Self::handle_message) for every command.
 pub(super) trait Handle<E: Endpoint> {
-    /// Compute the command's response — pure request → response logic, the wire
-    /// never appears here. Bulk endpoints stream in `handle_message` instead, so
-    /// this default stands unused for them.
+    /// Fixed-size handlers implement this method.
+    /// Bulk handlers override `handle_message` to stream through the session buffer.
     async fn handle(&self, _req: E::Request) -> Result<E::Response, RynkError> {
         Err(RynkError::Unimplemented)
     }
 
-    /// [`handle`](Self::handle) at the wire level, in place:
-    /// decode `E::Request`, await the handler, and encode the reply envelope.
     async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
         let req = msg.decode_request::<E::Request>()?;
         let resp = self.handle(req).await?;

--- a/rmk/src/host/rynk/handlers/mod.rs
+++ b/rmk/src/host/rynk/handlers/mod.rs
@@ -2,16 +2,15 @@
 //!
 //! Each command row implements [`Handle`] on
 //! [`RynkService`](super::RynkService), split across this directory by
-//! domain. A handler is a pure request → response function; the trait's
-//! provided [`handle_message`](Handle::handle_message) carries the shared
-//! wire glue, so implementations never touch the wire view and cannot decode
-//! or reply under the wrong `Cmd`.
+//! domain. Most handlers are pure request → response functions; the trait's
+//! provided [`handle_message`](Handle::handle_message) carries the shared wire
+//! glue, so they never touch the wire view. The variable-length bulk endpoints
+//! override `handle_message` to stream over the buffer instead (see [`bulk`]).
 
 use rmk_types::protocol::rynk::endpoint::Endpoint;
 use rmk_types::protocol::rynk::{RynkError, RynkMessage};
 
 pub(crate) mod behavior;
-#[cfg(feature = "bulk")]
 mod bulk;
 pub(crate) mod combo;
 pub(crate) mod connection;
@@ -23,17 +22,24 @@ pub(crate) mod morse;
 pub(crate) mod status;
 pub(crate) mod system;
 
-/// One typed handler per command row: implementors define the bare
-/// [`handle`](Self::handle) primitive; dispatch calls the provided
-/// [`handle_message`](Self::handle_message) wrapper (the `Read::read` /
-/// `read_exact` naming convention).
+/// One typed handler per command row (the `Read::read` / `read_exact` naming
+/// convention): dispatch always calls [`handle_message`](Self::handle_message).
+///
+/// Fixed-size endpoints implement the bare [`handle`](Self::handle) primitive and
+/// inherit the default `handle_message`. The variable-length bulk endpoints
+/// instead override `handle_message` to stream over the buffer — decoding and
+/// encoding one element at a time rather than materializing the payload `Vec` —
+/// and leave `handle` at its default.
 pub(super) trait Handle<E: Endpoint> {
-    /// Compute the command's response — pure request → response logic, the
-    /// wire never appears here.
-    async fn handle(&self, req: E::Request) -> Result<E::Response, RynkError>;
+    /// Compute the command's response — pure request → response logic, the wire
+    /// never appears here. Bulk endpoints stream in `handle_message` instead, so
+    /// this default stands unused for them.
+    async fn handle(&self, _req: E::Request) -> Result<E::Response, RynkError> {
+        Err(RynkError::Unimplemented)
+    }
 
     /// [`handle`](Self::handle) at the wire level, in place:
-    /// decode`E::Request`, await the handler, and encode the reply envelope.
+    /// decode `E::Request`, await the handler, and encode the reply envelope.
     async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
         let req = msg.decode_request::<E::Request>()?;
         let resp = self.handle(req).await?;

--- a/rmk/src/host/rynk/handlers/morse.rs
+++ b/rmk/src/host/rynk/handlers/morse.rs
@@ -30,11 +30,8 @@ impl Handle<SetMorse> for RynkService<'_> {
 }
 
 impl Handle<GetMorseBulk> for RynkService<'_> {
-    // Streams the page straight into the response buffer — no `Vec` of `Morse`.
     async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
         let req = msg.decode_request::<GetMorseBulkRequest>()?;
-        // `bulk_page` keeps every index in range, so `get_morse` is always
-        // `Some`; the `unwrap_or_default` fallback is unreachable.
         let page = bulk_page(req.start_index as usize, BULK_SIZE, self.ctx.morses_len());
         let count = page.len();
         msg.encode_bulk_ok(count, page.map(|idx| self.ctx.get_morse(idx as u8).unwrap_or_default()))
@@ -42,13 +39,10 @@ impl Handle<GetMorseBulk> for RynkService<'_> {
 }
 
 impl Handle<SetMorseBulk> for RynkService<'_> {
-    // Decodes the payload one `Morse` at a time instead of into a `Vec`.
     async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
-        // Payload: `start_index` (u8) then a postcard seq of `Morse`.
         let (start_index, rest) = postcard::take_from_bytes::<u8>(msg.payload()).map_err(|_| RynkError::Malformed)?;
         let (count, elements) = take_seq_len(rest)?;
 
-        // Validate the whole run first, so it applies whole or not at all.
         let start = bulk_write_start(start_index as usize, count, self.ctx.morses_len())?;
         validate_bulk_elements::<Morse>(elements, count)?;
 

--- a/rmk/src/host/rynk/handlers/morse.rs
+++ b/rmk/src/host/rynk/handlers/morse.rs
@@ -6,8 +6,8 @@ use rmk_types::protocol::rynk::command::{GetMorse, GetMorseBulk, SetMorse, SetMo
 use rmk_types::protocol::rynk::{GetMorseBulkRequest, RynkError, RynkMessage, SetMorseRequest};
 
 use super::super::RynkService;
-use super::Handle;
 use super::bulk::{bulk_page, bulk_write_start, take_element, take_seq_len, validate_bulk_elements};
+use super::{Handle, HandleBulk};
 
 impl Handle<GetMorse> for RynkService<'_> {
     async fn handle(&self, idx: u8) -> Result<Morse, RynkError> {
@@ -29,8 +29,8 @@ impl Handle<SetMorse> for RynkService<'_> {
     }
 }
 
-impl Handle<GetMorseBulk> for RynkService<'_> {
-    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+impl HandleBulk<GetMorseBulk> for RynkService<'_> {
+    async fn handle_bulk(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
         let req = msg.decode_request::<GetMorseBulkRequest>()?;
         let page = bulk_page(req.start_index as usize, BULK_SIZE, self.ctx.morses_len());
         let count = page.len();
@@ -38,8 +38,8 @@ impl Handle<GetMorseBulk> for RynkService<'_> {
     }
 }
 
-impl Handle<SetMorseBulk> for RynkService<'_> {
-    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+impl HandleBulk<SetMorseBulk> for RynkService<'_> {
+    async fn handle_bulk(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
         let (start_index, rest) = postcard::take_from_bytes::<u8>(msg.payload()).map_err(|_| RynkError::Malformed)?;
         let (count, elements) = take_seq_len(rest)?;
 

--- a/rmk/src/host/rynk/handlers/morse.rs
+++ b/rmk/src/host/rynk/handlers/morse.rs
@@ -7,7 +7,7 @@ use rmk_types::protocol::rynk::{GetMorseBulkRequest, RynkError, RynkMessage, Set
 
 use super::super::RynkService;
 use super::Handle;
-use super::bulk::{bulk_page, bulk_write_start, take_seq_len, validate_bulk_elements};
+use super::bulk::{bulk_page, bulk_write_start, take_element, take_seq_len, validate_bulk_elements};
 
 impl Handle<GetMorse> for RynkService<'_> {
     async fn handle(&self, idx: u8) -> Result<Morse, RynkError> {
@@ -54,8 +54,7 @@ impl Handle<SetMorseBulk> for RynkService<'_> {
 
         let mut cursor = elements;
         for idx in start..start + count {
-            let (config, next) = postcard::take_from_bytes::<Morse>(cursor).map_err(|_| RynkError::Malformed)?;
-            cursor = next;
+            let config = take_element::<Morse>(&mut cursor)?;
             self.ctx.update_morse(idx as u8, |m| *m = config).await;
         }
         msg.encode_response(&())

--- a/rmk/src/host/rynk/handlers/morse.rs
+++ b/rmk/src/host/rynk/handlers/morse.rs
@@ -1,19 +1,13 @@
 //! Morse handlers.
 
-#[cfg(feature = "bulk")]
 use rmk_types::constants::BULK_SIZE;
 use rmk_types::morse::Morse;
-use rmk_types::protocol::rynk::command::{GetMorse, SetMorse};
-#[cfg(feature = "bulk")]
-use rmk_types::protocol::rynk::command::{GetMorseBulk, SetMorseBulk};
-#[cfg(feature = "bulk")]
-use rmk_types::protocol::rynk::{GetMorseBulkRequest, GetMorseBulkResponse, SetMorseBulkRequest};
-use rmk_types::protocol::rynk::{RynkError, SetMorseRequest};
+use rmk_types::protocol::rynk::command::{GetMorse, GetMorseBulk, SetMorse, SetMorseBulk};
+use rmk_types::protocol::rynk::{GetMorseBulkRequest, RynkError, RynkMessage, SetMorseRequest};
 
 use super::super::RynkService;
 use super::Handle;
-#[cfg(feature = "bulk")]
-use super::bulk::{bulk_page, bulk_write_start};
+use super::bulk::{bulk_page, bulk_write_start, take_seq_len, validate_bulk_elements};
 
 impl Handle<GetMorse> for RynkService<'_> {
     async fn handle(&self, idx: u8) -> Result<Morse, RynkError> {
@@ -35,30 +29,35 @@ impl Handle<SetMorse> for RynkService<'_> {
     }
 }
 
-#[cfg(feature = "bulk")]
 impl Handle<GetMorseBulk> for RynkService<'_> {
-    async fn handle(&self, req: GetMorseBulkRequest) -> Result<GetMorseBulkResponse, RynkError> {
+    // Streams the page straight into the response buffer — no `Vec` of `Morse`.
+    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+        let req = msg.decode_request::<GetMorseBulkRequest>()?;
         // `bulk_page` keeps every index in range, so `get_morse` is always
-        // `Some`; `filter_map` unwraps without a fallback.
+        // `Some`; the `unwrap_or_default` fallback is unreachable.
         let page = bulk_page(req.start_index as usize, BULK_SIZE, self.ctx.morses_len());
-        Ok(GetMorseBulkResponse::from_iter_bounded(
-            page.filter_map(|idx| self.ctx.get_morse(idx as u8)),
-        ))
+        let count = page.len();
+        msg.encode_bulk_ok(count, page.map(|idx| self.ctx.get_morse(idx as u8).unwrap_or_default()))
     }
 }
 
-#[cfg(feature = "bulk")]
 impl Handle<SetMorseBulk> for RynkService<'_> {
-    async fn handle(&self, req: SetMorseBulkRequest) -> Result<(), RynkError> {
+    // Decodes the payload one `Morse` at a time instead of into a `Vec`.
+    async fn handle_message(&self, msg: &mut RynkMessage<'_>) -> Result<(), RynkError> {
+        // Payload: `start_index` (u8) then a postcard seq of `Morse`.
+        let (start_index, rest) = postcard::take_from_bytes::<u8>(msg.payload()).map_err(|_| RynkError::Malformed)?;
+        let (count, elements) = take_seq_len(rest)?;
+
         // Validate the whole run first, so it applies whole or not at all.
-        let start = bulk_write_start(req.start_index as usize, req.configs.len(), self.ctx.morses_len())?;
-        for (idx, config) in (start..).zip(req.configs.iter()) {
-            self.ctx
-                .update_morse(idx as u8, |m| {
-                    *m = config.clone();
-                })
-                .await;
+        let start = bulk_write_start(start_index as usize, count, self.ctx.morses_len())?;
+        validate_bulk_elements::<Morse>(elements, count)?;
+
+        let mut cursor = elements;
+        for idx in start..start + count {
+            let (config, next) = postcard::take_from_bytes::<Morse>(cursor).map_err(|_| RynkError::Malformed)?;
+            cursor = next;
+            self.ctx.update_morse(idx as u8, |m| *m = config).await;
         }
-        Ok(())
+        msg.encode_response(&())
     }
 }

--- a/rmk/src/host/rynk/handlers/system.rs
+++ b/rmk/src/host/rynk/handlers/system.rs
@@ -49,8 +49,6 @@ impl Handle<GetCapabilities> for RynkService<'_> {
             // Protocol limits
             max_payload_size: (constants::RYNK_BUFFER_SIZE - RYNK_HEADER_SIZE) as u16,
             macro_chunk_size: constants::MACRO_DATA_SIZE as u16,
-            // Bulk endpoints are always available under `rynk`; they stream over
-            // the session buffer, so the budgets come straight from its size.
             max_bulk_keys: constants::BULK_KEYMAP_SIZE as u8,
             max_bulk_configs: constants::BULK_SIZE as u8,
             bulk_transfer_supported: true,

--- a/rmk/src/host/rynk/handlers/system.rs
+++ b/rmk/src/host/rynk/handlers/system.rs
@@ -49,16 +49,11 @@ impl Handle<GetCapabilities> for RynkService<'_> {
             // Protocol limits
             max_payload_size: (constants::RYNK_BUFFER_SIZE - RYNK_HEADER_SIZE) as u16,
             macro_chunk_size: constants::MACRO_DATA_SIZE as u16,
-            // The BULK_* constants only exist under `bulk`, hence #[cfg] over cfg!().
-            #[cfg(feature = "bulk")]
+            // Bulk endpoints are always available under `rynk`; they stream over
+            // the session buffer, so the budgets come straight from its size.
             max_bulk_keys: constants::BULK_KEYMAP_SIZE as u8,
-            #[cfg(not(feature = "bulk"))]
-            max_bulk_keys: 0,
-            #[cfg(feature = "bulk")]
             max_bulk_configs: constants::BULK_SIZE as u8,
-            #[cfg(not(feature = "bulk"))]
-            max_bulk_configs: 0,
-            bulk_transfer_supported: cfg!(feature = "bulk"),
+            bulk_transfer_supported: true,
         })
     }
 }

--- a/rmk/src/host/rynk/mod.rs
+++ b/rmk/src/host/rynk/mod.rs
@@ -17,7 +17,7 @@ use rmk_types::protocol::rynk::{
 #[allow(unused_imports)] // re-exported at `crate::host` for downstream users
 pub use uart::run_rynk_uart;
 
-use self::handlers::Handle;
+use self::handlers::Serve;
 use super::context::KeyboardContext;
 use super::lock::HostLock;
 use crate::config::{DeviceConfig, RmkConfig};
@@ -129,64 +129,64 @@ impl<'a> RynkService<'a> {
         }
 
         if let Err(e) = match cmd {
-            Cmd::GetVersion => Handle::<command::GetVersion>::handle_message(self, msg).await,
-            Cmd::GetCapabilities => Handle::<command::GetCapabilities>::handle_message(self, msg).await,
-            Cmd::Reboot => Handle::<command::Reboot>::handle_message(self, msg).await,
-            Cmd::BootloaderJump => Handle::<command::BootloaderJump>::handle_message(self, msg).await,
-            Cmd::StorageReset => Handle::<command::StorageReset>::handle_message(self, msg).await,
-            Cmd::GetLockStatus => Handle::<command::GetLockStatus>::handle_message(self, msg).await,
-            Cmd::UnlockPoll => Handle::<command::UnlockPoll>::handle_message(self, msg).await,
-            Cmd::Lock => Handle::<command::Lock>::handle_message(self, msg).await,
-            Cmd::GetDeviceInfo => Handle::<command::GetDeviceInfo>::handle_message(self, msg).await,
+            Cmd::GetVersion => Serve::<command::GetVersion, _>::serve(self, msg).await,
+            Cmd::GetCapabilities => Serve::<command::GetCapabilities, _>::serve(self, msg).await,
+            Cmd::Reboot => Serve::<command::Reboot, _>::serve(self, msg).await,
+            Cmd::BootloaderJump => Serve::<command::BootloaderJump, _>::serve(self, msg).await,
+            Cmd::StorageReset => Serve::<command::StorageReset, _>::serve(self, msg).await,
+            Cmd::GetLockStatus => Serve::<command::GetLockStatus, _>::serve(self, msg).await,
+            Cmd::UnlockPoll => Serve::<command::UnlockPoll, _>::serve(self, msg).await,
+            Cmd::Lock => Serve::<command::Lock, _>::serve(self, msg).await,
+            Cmd::GetDeviceInfo => Serve::<command::GetDeviceInfo, _>::serve(self, msg).await,
 
-            Cmd::GetKeyAction => Handle::<command::GetKeyAction>::handle_message(self, msg).await,
-            Cmd::SetKeyAction => Handle::<command::SetKeyAction>::handle_message(self, msg).await,
-            Cmd::GetDefaultLayer => Handle::<command::GetDefaultLayer>::handle_message(self, msg).await,
-            Cmd::SetDefaultLayer => Handle::<command::SetDefaultLayer>::handle_message(self, msg).await,
-            Cmd::GetEncoderAction => Handle::<command::GetEncoderAction>::handle_message(self, msg).await,
-            Cmd::SetEncoderAction => Handle::<command::SetEncoderAction>::handle_message(self, msg).await,
-            Cmd::GetKeymapBulk => Handle::<command::GetKeymapBulk>::handle_message(self, msg).await,
-            Cmd::SetKeymapBulk => Handle::<command::SetKeymapBulk>::handle_message(self, msg).await,
+            Cmd::GetKeyAction => Serve::<command::GetKeyAction, _>::serve(self, msg).await,
+            Cmd::SetKeyAction => Serve::<command::SetKeyAction, _>::serve(self, msg).await,
+            Cmd::GetDefaultLayer => Serve::<command::GetDefaultLayer, _>::serve(self, msg).await,
+            Cmd::SetDefaultLayer => Serve::<command::SetDefaultLayer, _>::serve(self, msg).await,
+            Cmd::GetEncoderAction => Serve::<command::GetEncoderAction, _>::serve(self, msg).await,
+            Cmd::SetEncoderAction => Serve::<command::SetEncoderAction, _>::serve(self, msg).await,
+            Cmd::GetKeymapBulk => Serve::<command::GetKeymapBulk, _>::serve(self, msg).await,
+            Cmd::SetKeymapBulk => Serve::<command::SetKeymapBulk, _>::serve(self, msg).await,
 
-            Cmd::GetMacro => Handle::<command::GetMacro>::handle_message(self, msg).await,
-            Cmd::SetMacro => Handle::<command::SetMacro>::handle_message(self, msg).await,
+            Cmd::GetMacro => Serve::<command::GetMacro, _>::serve(self, msg).await,
+            Cmd::SetMacro => Serve::<command::SetMacro, _>::serve(self, msg).await,
 
-            Cmd::GetCombo => Handle::<command::GetCombo>::handle_message(self, msg).await,
-            Cmd::SetCombo => Handle::<command::SetCombo>::handle_message(self, msg).await,
-            Cmd::GetComboBulk => Handle::<command::GetComboBulk>::handle_message(self, msg).await,
-            Cmd::SetComboBulk => Handle::<command::SetComboBulk>::handle_message(self, msg).await,
+            Cmd::GetCombo => Serve::<command::GetCombo, _>::serve(self, msg).await,
+            Cmd::SetCombo => Serve::<command::SetCombo, _>::serve(self, msg).await,
+            Cmd::GetComboBulk => Serve::<command::GetComboBulk, _>::serve(self, msg).await,
+            Cmd::SetComboBulk => Serve::<command::SetComboBulk, _>::serve(self, msg).await,
 
-            Cmd::GetMorse => Handle::<command::GetMorse>::handle_message(self, msg).await,
-            Cmd::SetMorse => Handle::<command::SetMorse>::handle_message(self, msg).await,
-            Cmd::GetMorseBulk => Handle::<command::GetMorseBulk>::handle_message(self, msg).await,
-            Cmd::SetMorseBulk => Handle::<command::SetMorseBulk>::handle_message(self, msg).await,
+            Cmd::GetMorse => Serve::<command::GetMorse, _>::serve(self, msg).await,
+            Cmd::SetMorse => Serve::<command::SetMorse, _>::serve(self, msg).await,
+            Cmd::GetMorseBulk => Serve::<command::GetMorseBulk, _>::serve(self, msg).await,
+            Cmd::SetMorseBulk => Serve::<command::SetMorseBulk, _>::serve(self, msg).await,
 
-            Cmd::GetFork => Handle::<command::GetFork>::handle_message(self, msg).await,
-            Cmd::SetFork => Handle::<command::SetFork>::handle_message(self, msg).await,
+            Cmd::GetFork => Serve::<command::GetFork, _>::serve(self, msg).await,
+            Cmd::SetFork => Serve::<command::SetFork, _>::serve(self, msg).await,
 
-            Cmd::GetBehaviorConfig => Handle::<command::GetBehaviorConfig>::handle_message(self, msg).await,
-            Cmd::SetBehaviorConfig => Handle::<command::SetBehaviorConfig>::handle_message(self, msg).await,
+            Cmd::GetBehaviorConfig => Serve::<command::GetBehaviorConfig, _>::serve(self, msg).await,
+            Cmd::SetBehaviorConfig => Serve::<command::SetBehaviorConfig, _>::serve(self, msg).await,
 
-            Cmd::GetConnectionType => Handle::<command::GetConnectionType>::handle_message(self, msg).await,
-            Cmd::GetConnectionStatus => Handle::<command::GetConnectionStatus>::handle_message(self, msg).await,
+            Cmd::GetConnectionType => Serve::<command::GetConnectionType, _>::serve(self, msg).await,
+            Cmd::GetConnectionStatus => Serve::<command::GetConnectionStatus, _>::serve(self, msg).await,
             #[cfg(feature = "_ble")]
-            Cmd::GetBleStatus => Handle::<command::GetBleStatus>::handle_message(self, msg).await,
+            Cmd::GetBleStatus => Serve::<command::GetBleStatus, _>::serve(self, msg).await,
             #[cfg(feature = "_ble")]
-            Cmd::SwitchBleProfile => Handle::<command::SwitchBleProfile>::handle_message(self, msg).await,
+            Cmd::SwitchBleProfile => Serve::<command::SwitchBleProfile, _>::serve(self, msg).await,
             #[cfg(feature = "_ble")]
-            Cmd::ClearBleProfile => Handle::<command::ClearBleProfile>::handle_message(self, msg).await,
+            Cmd::ClearBleProfile => Serve::<command::ClearBleProfile, _>::serve(self, msg).await,
 
-            Cmd::GetCurrentLayer => Handle::<command::GetCurrentLayer>::handle_message(self, msg).await,
-            Cmd::GetMatrixState => Handle::<command::GetMatrixState>::handle_message(self, msg).await,
+            Cmd::GetCurrentLayer => Serve::<command::GetCurrentLayer, _>::serve(self, msg).await,
+            Cmd::GetMatrixState => Serve::<command::GetMatrixState, _>::serve(self, msg).await,
             #[cfg(feature = "_ble")]
-            Cmd::GetBatteryStatus => Handle::<command::GetBatteryStatus>::handle_message(self, msg).await,
+            Cmd::GetBatteryStatus => Serve::<command::GetBatteryStatus, _>::serve(self, msg).await,
             #[cfg(feature = "split")]
-            Cmd::GetPeripheralStatus => Handle::<command::GetPeripheralStatus>::handle_message(self, msg).await,
-            Cmd::GetWpm => Handle::<command::GetWpm>::handle_message(self, msg).await,
-            Cmd::GetSleepState => Handle::<command::GetSleepState>::handle_message(self, msg).await,
-            Cmd::GetLedIndicator => Handle::<command::GetLedIndicator>::handle_message(self, msg).await,
+            Cmd::GetPeripheralStatus => Serve::<command::GetPeripheralStatus, _>::serve(self, msg).await,
+            Cmd::GetWpm => Serve::<command::GetWpm, _>::serve(self, msg).await,
+            Cmd::GetSleepState => Serve::<command::GetSleepState, _>::serve(self, msg).await,
+            Cmd::GetLedIndicator => Serve::<command::GetLedIndicator, _>::serve(self, msg).await,
 
-            Cmd::GetLayout => Handle::<command::GetLayout>::handle_message(self, msg).await,
+            Cmd::GetLayout => Serve::<command::GetLayout, _>::serve(self, msg).await,
 
             // Direct `dispatch` callers should not turn topics into replies.
             cmd if cmd.is_topic() => Err(RynkError::Invalid),

--- a/rmk/src/host/rynk/mod.rs
+++ b/rmk/src/host/rynk/mod.rs
@@ -108,9 +108,10 @@ impl<'a> RynkService<'a> {
             | Cmd::SetCombo
             | Cmd::SetMorse
             | Cmd::SetFork
-            | Cmd::SetBehaviorConfig => self.write_requires_unlock,
-            #[cfg(feature = "bulk")]
-            Cmd::SetKeymapBulk | Cmd::SetComboBulk | Cmd::SetMorseBulk => self.write_requires_unlock,
+            | Cmd::SetBehaviorConfig
+            | Cmd::SetKeymapBulk
+            | Cmd::SetComboBulk
+            | Cmd::SetMorseBulk => self.write_requires_unlock,
             _ => false,
         }
     }
@@ -144,9 +145,7 @@ impl<'a> RynkService<'a> {
             Cmd::SetDefaultLayer => Handle::<command::SetDefaultLayer>::handle_message(self, msg).await,
             Cmd::GetEncoderAction => Handle::<command::GetEncoderAction>::handle_message(self, msg).await,
             Cmd::SetEncoderAction => Handle::<command::SetEncoderAction>::handle_message(self, msg).await,
-            #[cfg(feature = "bulk")]
             Cmd::GetKeymapBulk => Handle::<command::GetKeymapBulk>::handle_message(self, msg).await,
-            #[cfg(feature = "bulk")]
             Cmd::SetKeymapBulk => Handle::<command::SetKeymapBulk>::handle_message(self, msg).await,
 
             Cmd::GetMacro => Handle::<command::GetMacro>::handle_message(self, msg).await,
@@ -154,16 +153,12 @@ impl<'a> RynkService<'a> {
 
             Cmd::GetCombo => Handle::<command::GetCombo>::handle_message(self, msg).await,
             Cmd::SetCombo => Handle::<command::SetCombo>::handle_message(self, msg).await,
-            #[cfg(feature = "bulk")]
             Cmd::GetComboBulk => Handle::<command::GetComboBulk>::handle_message(self, msg).await,
-            #[cfg(feature = "bulk")]
             Cmd::SetComboBulk => Handle::<command::SetComboBulk>::handle_message(self, msg).await,
 
             Cmd::GetMorse => Handle::<command::GetMorse>::handle_message(self, msg).await,
             Cmd::SetMorse => Handle::<command::SetMorse>::handle_message(self, msg).await,
-            #[cfg(feature = "bulk")]
             Cmd::GetMorseBulk => Handle::<command::GetMorseBulk>::handle_message(self, msg).await,
-            #[cfg(feature = "bulk")]
             Cmd::SetMorseBulk => Handle::<command::SetMorseBulk>::handle_message(self, msg).await,
 
             Cmd::GetFork => Handle::<command::GetFork>::handle_message(self, msg).await,

--- a/rmk/src/host/rynk/mod.rs
+++ b/rmk/src/host/rynk/mod.rs
@@ -12,7 +12,7 @@ use embassy_futures::select::{Either, select};
 use embedded_io_async::{Read, Write};
 use rmk_types::constants::RYNK_BUFFER_SIZE;
 use rmk_types::protocol::rynk::{
-    Cmd, FirmwareVersion, RYNK_HEADER_SIZE, RYNK_MIN_BUFFER_SIZE, RynkError, RynkHeader, RynkMessage, command,
+    Cmd, FirmwareVersion, RYNK_HEADER_SIZE, RynkError, RynkHeader, RynkMessage, command,
 };
 #[allow(unused_imports)] // re-exported at `crate::host` for downstream users
 pub use uart::run_rynk_uart;
@@ -34,15 +34,6 @@ impl Drop for RelockGuard<'_, '_> {
         self.0.lock();
     }
 }
-
-// Use `core::assert!` explicitly: in a `defmt` build the crate-level `assert!`
-// expands to `defmt::assert!`, whose panic path is not `const`-callable.
-const _: () = core::assert!(
-    rmk_types::constants::RYNK_BUFFER_SIZE >= RYNK_MIN_BUFFER_SIZE,
-    "rynk_buffer_size is smaller than RYNK_MIN_BUFFER_SIZE — set [rmk] \
-     rynk_buffer_size in keyboard.toml, or disable features to shrink the \
-     floor",
-);
 
 const RMK_VERSION: FirmwareVersion = {
     const fn component(s: &str) -> u8 {

--- a/rmk/tests/rynk_loopback.rs
+++ b/rmk/tests/rynk_loopback.rs
@@ -130,7 +130,6 @@ fn get_capabilities() {
         assert_eq!(caps.storage_enabled, cfg!(feature = "storage"));
         assert_eq!(caps.ble_enabled, cfg!(feature = "_ble"));
         assert_eq!(caps.is_split, cfg!(feature = "split"));
-        // Bulk is always supported; budgets derive from the session buffer.
         assert!(caps.bulk_transfer_supported);
         assert_eq!(caps.max_bulk_keys as usize, rmk_types::constants::BULK_KEYMAP_SIZE);
         assert_eq!(caps.max_bulk_configs as usize, rmk_types::constants::BULK_SIZE);
@@ -667,17 +666,13 @@ fn keymap_bulk_get_caps_page_at_budget() {
 
 #[test]
 fn keymap_bulk_set_malformed_element_aborts_whole_write() {
-    // A run whose range is valid but whose second element is undecodable must
-    // leave every slot untouched: the streaming write validates all elements
-    // decode (pass one) before applying any (pass two) — all-or-nothing.
     let service = service_3x4x4();
     link_session(&service, async |client| {
         let good = KeyAction::Single(Action::Key(KeyCode::Hid(HidKeyCode::A)));
         let mut scratch = [0u8; 16];
         let good_bytes = postcard::to_slice(&good, &mut scratch).unwrap();
 
-        // Payload: layer/row/col = 0/0/0, count = 2, one good action, then a byte
-        // that is not a valid `KeyAction` discriminant.
+        // 0x7F is not a valid `KeyAction` discriminant.
         let mut payload = vec![0u8, 0, 0, 2];
         payload.extend_from_slice(good_bytes);
         payload.push(0x7F);
@@ -696,7 +691,6 @@ fn keymap_bulk_set_malformed_element_aborts_whole_write() {
             "a malformed element rejects the whole write"
         );
 
-        // The first, valid element must not have landed.
         let first = client
             .request::<_, KeyAction>(
                 Cmd::GetKeyAction,

--- a/rmk/tests/rynk_loopback.rs
+++ b/rmk/tests/rynk_loopback.rs
@@ -74,7 +74,6 @@ fn service_with_encoders() -> RynkService<'static> {
 }
 
 /// 3x4 service for bulk edge and row-wrap cases.
-#[cfg(feature = "bulk")]
 fn service_3x4() -> RynkService<'static> {
     let behavior: &'static mut BehaviorConfig = Box::leak(Box::new(BehaviorConfig::default()));
     let per_key: &'static PositionalConfig<3, 4> = Box::leak(Box::new(PositionalConfig::default()));
@@ -85,7 +84,6 @@ fn service_3x4() -> RynkService<'static> {
 }
 
 /// 48-key service for full and over-budget bulk runs.
-#[cfg(feature = "bulk")]
 fn service_3x4x4() -> RynkService<'static> {
     let behavior: &'static mut BehaviorConfig = Box::leak(Box::new(BehaviorConfig::default()));
     let per_key: &'static PositionalConfig<3, 4> = Box::leak(Box::new(PositionalConfig::default()));
@@ -96,7 +94,6 @@ fn service_3x4x4() -> RynkService<'static> {
 }
 
 /// Distinct action per bulk slot catches wrong-position writes.
-#[cfg(feature = "bulk")]
 fn bulk_action(i: usize) -> KeyAction {
     KeyAction::Single(Action::Key(KeyCode::Hid(HidKeyCode::from(4 + i as u8))))
 }
@@ -133,18 +130,10 @@ fn get_capabilities() {
         assert_eq!(caps.storage_enabled, cfg!(feature = "storage"));
         assert_eq!(caps.ble_enabled, cfg!(feature = "_ble"));
         assert_eq!(caps.is_split, cfg!(feature = "split"));
-        // Bulk flag and budgets must move together.
-        assert_eq!(caps.bulk_transfer_supported, cfg!(feature = "bulk"));
-        #[cfg(feature = "bulk")]
-        {
-            assert_eq!(caps.max_bulk_keys as usize, rmk_types::constants::BULK_KEYMAP_SIZE);
-            assert_eq!(caps.max_bulk_configs as usize, rmk_types::constants::BULK_SIZE);
-        }
-        #[cfg(not(feature = "bulk"))]
-        {
-            assert_eq!(caps.max_bulk_keys, 0);
-            assert_eq!(caps.max_bulk_configs, 0);
-        }
+        // Bulk is always supported; budgets derive from the session buffer.
+        assert!(caps.bulk_transfer_supported);
+        assert_eq!(caps.max_bulk_keys as usize, rmk_types::constants::BULK_KEYMAP_SIZE);
+        assert_eq!(caps.max_bulk_configs as usize, rmk_types::constants::BULK_SIZE);
     });
 }
 
@@ -427,7 +416,6 @@ fn get_set_encoder_round_trip() {
     });
 }
 
-#[cfg(feature = "bulk")]
 #[test]
 fn keymap_bulk_round_trip_wraps_row_boundary() {
     use rmk_types::constants::BULK_KEYMAP_SIZE;
@@ -478,7 +466,6 @@ fn keymap_bulk_round_trip_wraps_row_boundary() {
     });
 }
 
-#[cfg(feature = "bulk")]
 #[test]
 fn keymap_bulk_round_trip_wraps_layer_boundary() {
     use rmk_types::constants::BULK_KEYMAP_SIZE;
@@ -542,7 +529,6 @@ fn keymap_bulk_round_trip_wraps_layer_boundary() {
     });
 }
 
-#[cfg(feature = "bulk")]
 #[test]
 fn keymap_bulk_max_capacity_round_trip() {
     use rmk_types::constants::BULK_KEYMAP_SIZE;
@@ -579,7 +565,6 @@ fn keymap_bulk_max_capacity_round_trip() {
     });
 }
 
-#[cfg(feature = "bulk")]
 #[test]
 fn keymap_bulk_clamps_and_rejects() {
     use rmk_types::constants::BULK_KEYMAP_SIZE;
@@ -652,7 +637,6 @@ fn keymap_bulk_clamps_and_rejects() {
     });
 }
 
-#[cfg(feature = "bulk")]
 #[test]
 fn keymap_bulk_get_caps_page_at_budget() {
     use rmk_types::constants::BULK_KEYMAP_SIZE;
@@ -677,6 +661,57 @@ fn keymap_bulk_get_caps_page_at_budget() {
             got.actions.len(),
             BULK_KEYMAP_SIZE,
             "page capped at the per-message budget even though 48 keys remain"
+        );
+    });
+}
+
+#[test]
+fn keymap_bulk_set_malformed_element_aborts_whole_write() {
+    // A run whose range is valid but whose second element is undecodable must
+    // leave every slot untouched: the streaming write validates all elements
+    // decode (pass one) before applying any (pass two) — all-or-nothing.
+    let service = service_3x4x4();
+    link_session(&service, async |client| {
+        let good = KeyAction::Single(Action::Key(KeyCode::Hid(HidKeyCode::A)));
+        let mut scratch = [0u8; 16];
+        let good_bytes = postcard::to_slice(&good, &mut scratch).unwrap();
+
+        // Payload: layer/row/col = 0/0/0, count = 2, one good action, then a byte
+        // that is not a valid `KeyAction` discriminant.
+        let mut payload = vec![0u8, 0, 0, 2];
+        payload.extend_from_slice(good_bytes);
+        payload.push(0x7F);
+
+        let mut frame = vec![0u8; RYNK_HEADER_SIZE];
+        frame[0..2].copy_from_slice(&Cmd::SetKeymapBulk.to_le_bytes());
+        frame[2] = 0x40;
+        frame[3..5].copy_from_slice(&(payload.len() as u16).to_le_bytes());
+        frame.extend_from_slice(&payload);
+        client.send_raw(&frame).await;
+
+        let reply = client.recv_response(0x40).await;
+        assert_eq!(
+            reply.envelope::<()>(),
+            Err(RynkError::Malformed),
+            "a malformed element rejects the whole write"
+        );
+
+        // The first, valid element must not have landed.
+        let first = client
+            .request::<_, KeyAction>(
+                Cmd::GetKeyAction,
+                0x41,
+                &KeyPosition {
+                    layer: 0,
+                    row: 0,
+                    col: 0,
+                },
+            )
+            .await;
+        assert_eq!(
+            first,
+            Ok(KeyAction::No),
+            "all-or-nothing: no element is written when a later one is malformed"
         );
     });
 }
@@ -752,7 +787,6 @@ fn combo_rejects_out_of_range() {
     });
 }
 
-#[cfg(feature = "bulk")]
 #[test]
 fn combo_bulk_round_trip_with_empty_slots() {
     use rmk_types::constants::BULK_SIZE;
@@ -792,7 +826,6 @@ fn combo_bulk_round_trip_with_empty_slots() {
     });
 }
 
-#[cfg(feature = "bulk")]
 #[test]
 fn combo_bulk_clamps_and_rejects() {
     use rmk_types::constants::BULK_SIZE;
@@ -891,7 +924,6 @@ fn morse_rejects_out_of_range() {
     });
 }
 
-#[cfg(feature = "bulk")]
 #[test]
 fn morse_bulk_round_trip() {
     use rmk_types::constants::BULK_SIZE;
@@ -932,7 +964,6 @@ fn morse_bulk_round_trip() {
     });
 }
 
-#[cfg(feature = "bulk")]
 #[test]
 fn morse_bulk_clamps_and_rejects() {
     use rmk_types::constants::BULK_SIZE;

--- a/rynk/Cargo.toml
+++ b/rynk/Cargo.toml
@@ -32,7 +32,6 @@ rmk = { path = "../rmk", default-features = false, features = [
     "log",
     "rynk",
     "storage",
-    "bulk",
     "_ble",
     "split",
     "steno",

--- a/rynk/rynk-serial/src/lib.rs
+++ b/rynk/rynk-serial/src/lib.rs
@@ -138,8 +138,7 @@ mod tests {
     use std::time::Duration;
 
     use rmk_types::protocol::rynk::{
-        Cmd, DeviceCapabilities, ProtocolVersion, RYNK_HEADER_SIZE, RYNK_MIN_BUFFER_SIZE, RynkError, RynkHeader,
-        RynkMessage,
+        Cmd, DeviceCapabilities, ProtocolVersion, RYNK_HEADER_SIZE, RynkError, RynkHeader, RynkMessage,
     };
     use rynk::Client;
     use serde::Serialize;
@@ -170,7 +169,8 @@ mod tests {
 
     /// Header + postcard payload, framed as the firmware sends it.
     fn frame<T: Serialize>(cmd: Cmd, seq: u8, value: &T) -> Vec<u8> {
-        let mut buf = vec![0u8; RYNK_MIN_BUFFER_SIZE];
+        // Scratch large enough for any test frame.
+        let mut buf = vec![0u8; 4096];
         let msg = RynkMessage::build(&mut buf, cmd, seq, value).unwrap();
         msg.frame().to_vec()
     }

--- a/rynk/src/driver.rs
+++ b/rynk/src/driver.rs
@@ -30,8 +30,7 @@ use std::collections::VecDeque;
 use embedded_io_async::{Read, Write};
 use rmk_types::protocol::rynk::endpoint::Endpoint;
 use rmk_types::protocol::rynk::{
-    Cmd, DeviceCapabilities, ProtocolVersion, RYNK_HEADER_SIZE, RYNK_MIN_BUFFER_SIZE, RynkError, RynkHeader,
-    RynkMessage,
+    Cmd, DeviceCapabilities, ProtocolVersion, RYNK_HEADER_SIZE, RynkError, RynkHeader, RynkMessage,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -77,12 +76,10 @@ pub enum RynkHostError {
     /// Firmware accepted the request but answered with an error.
     #[error("device rejected {0:?}")]
     Rejected(RynkError),
-    #[error("request encode failed for {0:?} (request exceeds tx buffer?)")]
+    /// The request did not fit the device's advertised buffer, or failed to
+    /// encode. The send scratch is sized to the device's `max_payload_size`.
+    #[error("request {0:?} does not fit the device buffer (or failed to encode)")]
     Encode(Cmd),
-    /// Encoded frame exceeds the device's advertised
-    /// [`max_payload_size`](DeviceCapabilities::max_payload_size).
-    #[error("request {cmd:?} frame is {frame_len} bytes; device accepts at most {max}")]
-    TooLarge { cmd: Cmd, frame_len: usize, max: usize },
     #[error("response decode failed for {cmd:?}: {source}")]
     Deserialize { cmd: Cmd, source: postcard::Error },
     /// `GetLayout` blob inflate or decode failed.
@@ -92,8 +89,6 @@ pub enum RynkHostError {
     TrailingBytes { cmd: Cmd },
     #[error("response cmd mismatch: sent {sent:?}, got {got:?}")]
     CmdMismatch { sent: Cmd, got: Cmd },
-    #[error("inbound frame is {frame_len} bytes; negotiated maximum is {max}")]
-    InboundTooLarge { frame_len: usize, max: usize },
     /// A topic-range `Cmd` was passed to a request method.
     #[error("{0:?} is a topic, not a request")]
     TopicCmd(Cmd),
@@ -114,12 +109,10 @@ impl From<RynkHostError> for wasm_bindgen::JsValue {
             RynkHostError::Unsupported(..) => "Unsupported",
             RynkHostError::VersionMismatch { .. } => "VersionMismatch",
             RynkHostError::Encode(_) => "RequestEncodeError",
-            RynkHostError::TooLarge { .. } => "RequestTooLarge",
             RynkHostError::Deserialize { .. } => "ResponseDecodeError",
             RynkHostError::Layout(_) => "LayoutDecodeError",
             RynkHostError::TrailingBytes { .. } => "ResponseTrailingBytes",
             RynkHostError::CmdMismatch { .. } => "ResponseCommandMismatch",
-            RynkHostError::InboundTooLarge { .. } => "ResponseTooLarge",
             RynkHostError::TopicCmd(_) => "InvalidRequestCommand",
         };
         let err = js_sys::Error::new(&e.to_string());
@@ -154,7 +147,9 @@ pub struct Client<T: Read + Write> {
     events_dropped: u64,
     /// Reusable TX scratch.
     tx_buf: Vec<u8>,
-    /// Handshake capability snapshot, initialized to the protocol floor.
+    /// Device capabilities from the handshake. `Default` (all-zero) until
+    /// `connect` fills it; only `max_payload_size` is read before then, and only
+    /// to bound outbound frames — the host reads inbound frames unbounded.
     capabilities: DeviceCapabilities,
 }
 
@@ -171,16 +166,15 @@ impl<T: Read + Write> Client<T> {
             receive_in_flight: false,
             events: VecDeque::new(),
             events_dropped: 0,
-            tx_buf: vec![0u8; RYNK_MIN_BUFFER_SIZE],
-            capabilities: DeviceCapabilities {
-                max_payload_size: (RYNK_MIN_BUFFER_SIZE - RYNK_HEADER_SIZE) as u16,
-                ..Default::default()
-            },
+            // Handshake requests carry no payload; grow after `GetCapabilities`.
+            tx_buf: vec![0u8; RYNK_HEADER_SIZE],
+            capabilities: DeviceCapabilities::default(),
         }
     }
 
-    /// Largest frame either side may send: header + the device's advertised
-    /// `max_payload_size` (the protocol floor until the handshake fills it).
+    /// Largest frame the host may send: header + the device's advertised
+    /// `max_payload_size`. Zero until the handshake fills it, which still admits
+    /// the empty-payload handshake requests.
     fn max_frame_size(&self) -> usize {
         RYNK_HEADER_SIZE + self.capabilities.max_payload_size as usize
     }
@@ -330,12 +324,10 @@ impl<T: Read + Write> Client<T> {
         }
         let seq = self.next_seq;
         self.next_seq = self.next_seq.checked_add(1).unwrap_or(1);
-        let max = self.max_frame_size();
+        // The scratch is sized to the device's advertised buffer, so a request
+        // too large for the device fails to encode here — a local reject that
+        // leaves the link intact.
         let msg = RynkMessage::build(&mut self.tx_buf, cmd, seq, req).map_err(|_| RynkHostError::Encode(cmd))?;
-        let frame_len = msg.frame_len();
-        if frame_len > max {
-            return Err(RynkHostError::TooLarge { cmd, frame_len, max });
-        }
         // If dropped mid-write, the next wire op marks the link dead.
         self.send_in_flight = true;
         let result = self.transport.write_all(msg.frame()).await;
@@ -364,14 +356,11 @@ impl<T: Read + Write> Client<T> {
         loop {
             let header = self.rx_buf.first_chunk::<RYNK_HEADER_SIZE>().map(RynkHeader::parse);
             if let Some(header) = header {
+                // Frames are read by their declared length and routed; the host
+                // never rejects one by size. Replies are correlated by SEQ and
+                // decoded; topics are best-effort (decode-or-Unknown). The u16
+                // LEN already caps a single frame at ~64 KB.
                 let frame_len = header.frame_len();
-
-                let max = self.max_frame_size();
-                if frame_len > max {
-                    self.dead = true;
-                    return Err(RynkHostError::InboundTooLarge { frame_len, max });
-                }
-
                 if self.rx_buf.len() >= frame_len {
                     let payload = self.rx_buf[RYNK_HEADER_SIZE..frame_len].to_vec();
                     self.rx_buf.drain(..frame_len);
@@ -478,12 +467,18 @@ mod tests {
     }
 
     fn raw_client(steps: Vec<Step>) -> Client<MockTransport> {
-        Client::new(MockTransport::new(steps))
+        // Skip the handshake but give the client a generous send budget and a
+        // scratch sized to it, so request-sending tests work without a `connect`.
+        // Other capabilities stay at their defaults, as before.
+        let mut c = Client::new(MockTransport::new(steps));
+        c.capabilities.max_payload_size = 4096;
+        c.tx_buf.resize(c.max_frame_size(), 0);
+        c
     }
 
     /// A bare frame: header + postcard(value). Used for raw headers and topics.
     fn frame<T: Serialize>(cmd: Cmd, seq: u8, value: &T) -> Vec<u8> {
-        let mut buf = vec![0u8; RYNK_MIN_BUFFER_SIZE];
+        let mut buf = vec![0u8; READ_SCRATCH_SIZE];
         let msg = RynkMessage::build(&mut buf, cmd, seq, value).unwrap();
         msg.frame().to_vec()
     }
@@ -608,19 +603,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn oversized_inbound_frame_is_fatal() {
-        let mut oversized_then_valid = header(Cmd::GetWpm.raw(), 3, u16::MAX);
-        oversized_then_valid.extend_from_slice(&reply(Cmd::GetWpm, 3, 42u16));
+    async fn oversized_inbound_topic_is_read_not_fatal() {
+        // A topic larger than the negotiated max_payload_size (256) is no longer
+        // rejected by size: the host reads it by length and surfaces it, link intact.
+        let mut big = header(0x80ff, 0, 300);
+        big.extend_from_slice(&vec![0xAB; 300]);
         let t = MockTransport::new(vec![
             Step::Chunk(reply(Cmd::GetVersion, 1, ProtocolVersion::CURRENT)),
             Step::Chunk(reply(Cmd::GetCapabilities, 2, caps())),
-            Step::Chunk(oversized_then_valid),
+            Step::Chunk(big),
+            Step::Chunk(reply(Cmd::GetWpm, 3, 7u16)),
         ]);
         let mut client = Client::connect(t).await.unwrap();
-        let result = client.get_wpm().await;
-        assert!(matches!(result, Err(RynkHostError::InboundTooLarge { .. })));
-        assert!(!client.is_alive());
-        assert!(matches!(client.get_wpm().await, Err(RynkHostError::Disconnected)));
+        let ev = client.next_event().await.unwrap();
+        assert!(
+            matches!(ev, IncomingTopic::Unknown(ref f) if f.cmd == Cmd::from_raw(0x80ff) && f.payload.len() == 300)
+        );
+        assert!(client.is_alive());
+        assert_eq!(client.get_wpm().await.unwrap(), 7);
     }
 
     #[tokio::test]
@@ -794,13 +794,7 @@ mod tests {
         ]);
         let mut client = Client::connect(t).await.unwrap();
         let r = client.set_key(0, 0, 0, KeyAction::Morse(3)).await;
-        assert!(matches!(
-            r,
-            Err(RynkHostError::TooLarge {
-                cmd: Cmd::SetKeyAction,
-                ..
-            })
-        ));
+        assert!(matches!(r, Err(RynkHostError::Encode(Cmd::SetKeyAction))));
         assert!(
             client.is_alive(),
             "a locally-rejected oversized request must not kill the link"

--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -16,7 +16,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../.github/ci/_lib.sh"
 nx=(nextest run --config-file "$repo_root/.config/nextest.toml")
 
 # rmk-types: default-features run + host-feature run (the latter enables
-# rynk/bulk/_ble/split/steno, which is required to compile the wire-format
+# rynk/_ble/split/steno, which is required to compile the wire-format
 # snapshot tests under src/protocol/rynk/snapshots/) + steno-only run.
 cargo "${nx[@]}" --manifest-path rmk-types/Cargo.toml
 cargo "${nx[@]}" --manifest-path rmk-types/Cargo.toml --features host


### PR DESCRIPTION
## What

Bulk transfer endpoints now stream over the session buffer instead of decoding/encoding a whole `heapless::Vec<_, BULK_SIZE>`. With the RAM cost gone, the `bulk` cargo feature is removed — bulk is always available under `rynk`.

## Why

The `Set*Bulk`/`Get*Bulk` handlers materialized a `heapless::Vec<Item, BULK_SIZE>` on the stack, held across `.await` in the session future — a second copy of the payload sized `BULK_SIZE * size_of::<Item>()`. Because the in-memory item size exceeds its postcard-encoded size (padding, enum tags, the `Vec` len field), that copy could be *larger* than `RYNK_BUFFER_SIZE` itself (keymap: ~40 × 16 B ≈ 650 B against a 512 B buffer). That RAM was the sole reason bulk was an opt-in, RAM-gated feature.

## How

- **Get**: decode the small request, then stream the page straight into the response buffer via `RynkMessage::encode_bulk_ok` — no `Vec`.
- **Set**: parse the fixed prefix, then walk the payload one element at a time. A **two-pass** write (validate every element decodes, then apply) preserves the all-or-nothing guarantee a malformed tail would otherwise break.
- Peak extra RAM drops from `BULK_SIZE * size_of::<Item>()` to a single element.

### Design notes

- **`Handle<E>` is preserved.** Dispatch is unchanged (`Handle::<X>::handle_message`). The six bulk endpoints override the provided `handle_message` to stream; `handle` becomes a default (`Err(Unimplemented)`) so the ~30 fixed endpoints are untouched.
- **Wire format is identical.** postcard is sequential — `Vec<T>` = `varint(len) ++ elements`, `Ok(x)` = `0x00 ++ x` — so streamed bytes match the owned-`Vec` encoding exactly. The host (owned `alloc::Vec`) interoperates unchanged.
- The **`@bulk`** marker now only exempts a row from the buffer-floor fold (no longer gates compilation); the buffer still drives `BULK_SIZE`, not the reverse.
- Per-item flash persistence still `.await`s (durability over throughput): a bulk write blocks briefly under flash backpressure rather than dropping persists.

## Testing

- Full `rynk_loopback` suite passes unchanged (round-trips, row/layer wrap, max capacity, clamps, rejects across keymap/combo/morse) — the byte-for-byte interop proof.
- New test: a valid-range bulk Set with a malformed mid-stream element writes nothing (all-or-nothing).
- rmk-types wire snapshots unchanged; clippy + nightly rustfmt clean; `rynk` and `rynk,storage` featuresets green.