### PR TITLE
fix(wasm): unlock before listening for topics

### DIFF
--- a/rynk/rynk-wasm/index.html
+++ b/rynk/rynk-wasm/index.html
@@ -53,10 +53,12 @@
           const v = await fn();
           const isObj = v !== null && typeof v === "object";
           logLine(`✓ ${pad} ${isObj ? JSON.stringify(v) : v}`, isObj);
+          return v;
         } catch (e) {
           const kind = (e && e.name) || "Error";
           const glyph = kind === "Unsupported" ? "·" : kind === "Rejected" ? "⚠" : "✗";
           log(`${glyph} ${pad} ${kind}: ${e && e.message}`);
+          return null;
         }
       }
 
@@ -253,13 +255,20 @@
       }
 
       // One live session across both transports.
-      let port = null, device = null, l = null, core = null, client = null, connected = false;
+      let port = null, device = null, l = null, core = null, client = null, connected = false, topicsStarted = false;
+
+      function startTopicPump() {
+        if (!client || topicsStarted) return;
+        topicsStarted = true;
+        log("\n— listening for topics (type on the keyboard); click to disconnect —");
+        pumpTopics(client);
+      }
 
       async function teardown() {
         // Closing the link EOFs the transport, ending any parked next_event() pump.
         if (l) await l.close();
         else if (port) { try { await port.close(); } catch {} }
-        port = null; device = null; l = null; core = null; client = null; connected = false;
+        port = null; device = null; l = null; core = null; client = null; connected = false; topicsStarted = false;
         serialBtn.textContent = "Connect via Serial (USB)";
         bleBtn.textContent = "Connect via BLE (WebHID)";
         serialBtn.disabled = false; bleBtn.disabled = false;
@@ -292,7 +301,7 @@
 
           // Exercise the typed client surface.
           await show("version",         () => client.get_version());
-          await show("lock status",     () => client.get_lock_status());
+          const lockStatus = await show("lock status", () => client.get_lock_status());
           await show("default layer",   () => client.get_default_layer());
           await show("current layer",   () => client.get_current_layer());
           await show("key L0(0,0)",     () => client.get_key(0, 0, 0));
@@ -310,12 +319,16 @@
           // Gated behind the lock: shows "⚠ Rejected: Locked" until unlocked.
           await show("matrix state",    () => client.get_matrix_state());
 
-          unlockBtn.hidden = false;      // offer the unlock ceremony while connected
-          log("\n— listening for topics (type on the keyboard); click to disconnect —");
           thisBtn.textContent = "Disconnect";
           thisBtn.disabled = false;       // re-enable so it can disconnect
           otherBtn.disabled = true;       // one transport at a time
-          pumpTopics(client);             // pull topics until the link closes
+          if (lockStatus?.locked && lockStatus.key_positions.length > 0) {
+            unlockBtn.hidden = false;
+            log("\n— unlock before starting the topic listener —");
+          } else {
+            unlockBtn.hidden = true;
+            startTopicPump();
+          }
         } catch (e) {
           log("ERROR: " + e);
           console.error(e);
@@ -345,7 +358,12 @@
         unlockBtn.disabled = true;
         try {
           const start = await client.get_lock_status();
-          if (!start.locked) { log("· already unlocked"); return; }
+          if (!start.locked) {
+            log("· already unlocked");
+            unlockBtn.hidden = true;
+            startTopicPump();
+            return;
+          }
           if (start.key_positions.length === 0) {
             log("⚠ permanently locked — set [host].unlock_keys in keyboard.toml");
             return;
@@ -354,7 +372,12 @@
           const deadline = Date.now() + 30000;
           for (;;) {
             const s = await client.unlock_poll();
-            if (!s.locked) { log("✓ unlocked — retry the gated action"); break; }
+            if (!s.locked) {
+              log("✓ unlocked — retry the gated action");
+              unlockBtn.hidden = true;
+              startTopicPump();
+              break;
+            }
             log(`  holding… ${s.remaining_keys} key(s) left`);
             if (Date.now() > deadline) { log("✗ unlock timed out"); break; }
             await new Promise((r) => setTimeout(r, 150));


### PR DESCRIPTION
## What

Delay the demo's topic listener until the unlock ceremony has completed. Already-unlocked and permanently locked devices still start the listener immediately.

## Why

On a normally locked device, the demo started `next_event()` and then exposed the unlock button. The pending wasm-bindgen call keeps a mutable borrow of the Rust client, so clicking Unlock re-enters the same object and traps with `recursive use of an object detected`.

## Root cause

The same `WasmClient` was used concurrently by the indefinitely pending topic pump and the unlock request sequence.

## Impact

This only changes demo sequencing. Protocol and firmware behavior are unchanged.

## Checks

- Reproduced the pre-fix trap with the generated wasm-bindgen package and a locked-device transport.
- Extracted module passes `node --input-type=module --check`.

Built on #848.
