### PR TITLE
fix(rynk): report locked bootloader jumps

### DIFF
--- a/rynk/src/api.rs
+++ b/rynk/src/api.rs
@@ -13,7 +13,7 @@ use rmk_types::morse::Morse;
 use rmk_types::protocol::rynk::{
     BehaviorConfig, Cmd, DeviceCapabilities, GetComboBulkRequest, GetComboBulkResponse, GetEncoderRequest,
     GetKeymapBulkRequest, GetKeymapBulkResponse, GetMacroRequest, GetMorseBulkRequest, GetMorseBulkResponse,
-    KeyPosition, LockStatus, MacroData, MatrixState, PeripheralStatus, ProtocolVersion, SetComboBulkRequest,
+    KeyPosition, LockStatus, MacroData, MatrixState, PeripheralStatus, ProtocolVersion, RynkError, SetComboBulkRequest,
     SetComboRequest, SetEncoderRequest, SetForkRequest, SetKeyRequest, SetKeymapBulkRequest, SetMacroRequest,
     SetMorseBulkRequest, SetMorseRequest, StorageResetMode, TopicEvent, command,
 };
@@ -87,9 +87,13 @@ impl<T: Read + Write> Client<T> {
         self.send_no_reply::<command::Reboot>(&()).await
     }
 
-    /// Jump to the bootloader (DFU mode) — fire-and-forget, same contract as
-    /// [`reboot`](Self::reboot).
+    /// Jump to the bootloader (DFU mode). The lock state is checked first so a
+    /// locked device is reported to the caller; once unlocked, the jump itself
+    /// is fire-and-forget because the firmware resets before it can reply.
     pub async fn bootloader_jump(&mut self) -> Result<(), RynkHostError> {
+        if self.get_lock_status().await?.locked {
+            return Err(RynkHostError::Rejected(RynkError::Locked));
+        }
         self.send_no_reply::<command::BootloaderJump>(&()).await
     }
 

--- a/rynk/src/driver.rs
+++ b/rynk/src/driver.rs
@@ -405,8 +405,8 @@ mod tests {
     use rmk_types::battery::BatteryStatus;
     use rmk_types::connection::{ConnectionStatus, ConnectionType};
     use rmk_types::protocol::rynk::{
-        GetComboBulkResponse, GetKeymapBulkResponse, GetMorseBulkResponse, PeripheralStatus, SetComboBulkRequest,
-        SetKeymapBulkRequest, SetMorseBulkRequest, TopicEvent,
+        GetComboBulkResponse, GetKeymapBulkResponse, GetMorseBulkResponse, LockStatus, PeripheralStatus,
+        SetComboBulkRequest, SetKeymapBulkRequest, SetMorseBulkRequest, TopicEvent,
     };
     use tokio::time::timeout;
 
@@ -749,6 +749,47 @@ mod tests {
         let mut client = Client::connect(t).await.unwrap();
         assert_eq!(client.capabilities().num_cols, 14);
         assert_eq!(client.get_wpm().await.unwrap(), 37);
+    }
+
+    #[tokio::test]
+    async fn bootloader_jump_reports_locked_device_before_fire_and_forget_send() {
+        let status = LockStatus {
+            locked: true,
+            unlocking: false,
+            remaining_keys: 0,
+            key_positions: Default::default(),
+        };
+        let t = MockTransport::new(vec![
+            Step::Chunk(reply(Cmd::GetVersion, 1, ProtocolVersion::CURRENT)),
+            Step::Chunk(reply(Cmd::GetCapabilities, 2, caps())),
+            Step::Chunk(reply(Cmd::GetLockStatus, 3, status)),
+        ]);
+        let mut client = Client::connect(t).await.unwrap();
+
+        assert!(matches!(
+            client.bootloader_jump().await,
+            Err(RynkHostError::Rejected(RynkError::Locked))
+        ));
+        assert_eq!(client.next_seq, 4, "locked preflight must not send BootloaderJump");
+    }
+
+    #[tokio::test]
+    async fn bootloader_jump_sends_after_unlocked_preflight() {
+        let status = LockStatus {
+            locked: false,
+            unlocking: false,
+            remaining_keys: 0,
+            key_positions: Default::default(),
+        };
+        let t = MockTransport::new(vec![
+            Step::Chunk(reply(Cmd::GetVersion, 1, ProtocolVersion::CURRENT)),
+            Step::Chunk(reply(Cmd::GetCapabilities, 2, caps())),
+            Step::Chunk(reply(Cmd::GetLockStatus, 3, status)),
+        ]);
+        let mut client = Client::connect(t).await.unwrap();
+
+        client.bootloader_jump().await.unwrap();
+        assert_eq!(client.next_seq, 5, "unlocked client sends BootloaderJump");
     }
 
     #[tokio::test]

--- a/rynk/tests/loopback.rs
+++ b/rynk/tests/loopback.rs
@@ -247,6 +247,12 @@ async fn lock_gate_rejects_and_reports() {
         assert!(!status.unlocking);
         assert_eq!(status.key_positions.as_slice(), &[(0, 0)]);
 
+        let jump = client.bootloader_jump().await;
+        assert!(
+            matches!(jump, Err(RynkHostError::Rejected(RynkError::Locked))),
+            "locked bootloader jump must be reported, got {jump:?}"
+        );
+
         // A hard-locked command flattens `RynkError::Locked` to `Rejected` end to end.
         let gated = client.get_matrix_state().await;
         assert!(


### PR DESCRIPTION
## What

Check the device lock state before sending the fire-and-forget bootloader jump, and return `Rejected(Locked)` when the device is locked.

## Why

Locked devices reject bootloader jumps in firmware, but the host API previously returned `Ok(())` because it deliberately did not wait for a reply. Default locked configurations therefore reported success without entering the bootloader.

## Root cause

A fire-and-forget command cannot distinguish a successful reset from a lock-gate rejection.

## Impact

Unlocked jumps gain one lock-status request. The actual jump remains fire-and-forget because a successful device resets before replying.

## Checks

- `cargo test bootloader_jump`
- `cargo test lock_gate_rejects_and_reports`
- `wasm-pack build --target web --dev`

Built on #848.
