### PR TITLE
fix(wasm): release Web Serial locks on close

### DIFF
--- a/rynk/rynk-wasm/index.html
+++ b/rynk/rynk-wasm/index.html
@@ -165,7 +165,9 @@
           // Release locks so a failed attempt can be retried.
           async close() {
             try { await reader.cancel(); } catch {}
+            reader.releaseLock();
             try { await writer.abort(); } catch {}
+            writer.releaseLock();
             try { await port.close(); } catch {}
           },
         };


### PR DESCRIPTION
## What

Release the Web Serial reader and writer locks before closing the port.

## Why

Normal demo disconnect and reconnect attempts can reach `port.close()` while both streams are still locked. The [Web Serial specification](https://wicg.github.io/serial/) requires those locks to be released before the port can close.

## Root cause

`cancel()` and `abort()` settle the streams but do not release their reader/writer locks.

## Impact

The demo can close and reconnect a serial device cleanly. Transport protocol behavior is unchanged.

## Checks

- Exercised the actual `link()` implementation with standard Web Streams and a port that rejects close while locked.
- Extracted module passes `node --input-type=module --check`.

Built on #848.
