### PR TITLE
fix(wasm): show macro storage capacity

### DIFF
--- a/rynk/rynk-wasm/index.html
+++ b/rynk/rynk-wasm/index.html
@@ -288,7 +288,7 @@
           connected = true;
           log(`✓ connected via ${label} (${client.label()}) — ${caps.num_layers}×${caps.num_rows}×${caps.num_cols} keymap, `
             + `${caps.max_combos} combos, ${caps.max_forks} forks, ${caps.max_morse} morse, `
-            + `${caps.max_macros} macros, ble=${caps.ble_enabled}\n`);
+            + `${caps.macro_space_size} bytes macro storage, ble=${caps.ble_enabled}\n`);
 
           // Exercise the typed client surface.
           await show("version",         () => client.get_version());


### PR DESCRIPTION
## What

Display `macro_space_size` as bytes of macro storage in the Wasm demo's capability summary.

## Why

Every successful demo connection currently prints `undefined macros` because `DeviceCapabilities` has no `max_macros` field.

## Root cause

The demo referenced a capability name that is not present in the generated Wasm type.

## Impact

Demo output now reports the capability the firmware actually sends. No protocol or firmware behavior changes.

## Checks

- Confirmed the generated capability field is `macro_space_size` and no `max_macros` field exists.
- Extracted module passes `node --input-type=module --check`.

Built on #848.
