### PR TITLE
fix: default split peripheral serial number

### DIFF
--- a/rmk-macro/src/codegen/split/peripheral.rs
+++ b/rmk-macro/src/codegen/split/peripheral.rs
@@ -55,14 +55,17 @@ pub(crate) fn parse_split_peripheral_mod(
         let pid = identity.product_id;
         let manufacturer = &identity.manufacturer;
         let product_name = &identity.product_name;
-        let serial_number = &identity.serial_number;
+        let serial_number_tokens = match &identity.serial_number {
+            Some(s) => quote! { #s },
+            None => quote! { ::rmk::config::RMK_BUILD_INFO },
+        };
         quote! {
             const KEYBOARD_DEVICE_CONFIG: ::rmk::config::DeviceConfig = ::rmk::config::DeviceConfig {
                 vid: #vid,
                 pid: #pid,
                 manufacturer: #manufacturer,
                 product_name: #product_name,
-                serial_number: #serial_number,
+                serial_number: #serial_number_tokens,
             };
         }
     } else {


### PR DESCRIPTION
## Summary

- default an omitted DFU split-peripheral serial number to `RMK_BUILD_INFO`
- preserve explicitly configured serial numbers

## Root cause

`Identity.serial_number` became optional, but split-peripheral code generation still interpolated the `Option` directly. When `keyboard.toml` omitted the value, `quote!` emitted no expression and generated `serial_number: ,`, breaking the `rp2040_dfu_split` build on main.

## Validation

- `RUSTFLAGS="-D warnings" cargo build --release` in `examples/use_config/rp2040_dfu_split`
- `cargo fmt --all -- --check` in `rmk-macro`
- `git diff --check`

Main CI failure: https://github.com/HaoboGu/rmk/actions/runs/29435153000/job/87419856738