### PR TITLE
Merge all BLE HID reports into a single HID service

### DIFF
--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: `CompositeReportType` discriminants are renumbered (`Keyboard=1`, `Mouse=2`, `Media=3`, `System=4`): the BLE report map carries the keyboard report as id 1, and the mouse/media/system report ids shift to 2/3/4 on both BLE and USB. USB hosts re-read report ids on every enumeration so nothing changes for them; BLE hosts bonded to an older firmware must forget and re-pair the keyboard
 - **BREAKING**: `PollingController::INTERVAL` constant is now `PollingController::interval()` method, allowing dynamic interval configuration at runtime
 - **BREAKING**: PointingDevice and PointingProcessor replace Pmw3610Device and Pmw3610Processor. For the Pmw3610 the calls of ::new() for these stay the same, only the name changes. If using Rust to configure the keyboard change the calls, if using Toml nothing needs to be done.
 - **BREAKING**: `MouseKeyConfig` fields renamed: `time_to_max` → `ticks_to_max`, `wheel_time_to_max` → `wheel_ticks_to_max`, `wheel_max_speed_multiplier` → `wheel_max_speed`
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix mouse keys (`KC_MS_*`), media keys and system control keys doing nothing on Android over BLE: Android's HID host only attaches to the first HID service instance (AOSP `bta_hh_le.cc`, b/286413526), so reports served from the separate composite HID service were never subscribed. All HID reports now live in a single HID service, distinguished by report id via the Report Reference descriptor
 - Fix `ClearEeprom` keycode being defined but not functional: pressing the key now resets the storage on release (same operation as `ViaCommand::EepromReset`, requires the `storage` feature), and the keycode round-trips through Vial as `0x7C03` (QMK's `QK_CLEAR_EEPROM`) instead of being rendered as a raw hex literal ([#929](https://github.com/HaoboGu/rmk/issues/929))
 - Fix Vial keycode conversion truncating user keycodes to 4 bits: `User16`–`User31` silently aliased to `User0`–`User15` on the Vial side (assign, view, and save-back). Widen the mask and accepted range to 5 bits (`0x7E00..=0x7E1F`, matching QMK's `QK_KB_0..QK_KB_31`) ([#918](https://github.com/HaoboGu/rmk/issues/918))
 - Fix BLE output stopping while the keyboard is on charge-only USB power (charge-only cable, wall charger, power bank). A never-enumerated device's bus-idle suspend was published as `Suspended`, which `usb_ready()` treats as routable, so reports were routed to USB endpoints that were never configured and silently dropped ([#910](https://github.com/HaoboGu/rmk/issues/910))

--- a/rmk/src/ble/ble_server.rs
+++ b/rmk/src/ble/ble_server.rs
@@ -5,7 +5,7 @@ use super::battery_service::BatteryService;
 use super::device_info::DeviceConfigurationService;
 #[cfg(feature = "host")]
 use crate::hid::ViaReport;
-use crate::hid::{CompositeReport, CompositeReportType, HidError, HidWriterTrait, KeyboardReport, Report};
+use crate::hid::{BleCompositeReport, CompositeReportType, HidError, HidWriterTrait, Report};
 
 // Used for saving the client attribute (CCCD) table. Tracks the trouble-host
 // per-connection client-specific attribute buffer size.
@@ -20,7 +20,6 @@ pub(crate) struct Server {
     pub(crate) battery_service: BatteryService,
     pub(crate) hid_service: HidService,
     pub(crate) host_service: VialService,
-    pub(crate) composite_service: CompositeService,
     pub(crate) device_config_service: DeviceConfigurationService,
 }
 
@@ -52,38 +51,29 @@ pub(crate) struct VialService {
 pub(crate) struct Server {
     pub(crate) battery_service: BatteryService,
     pub(crate) hid_service: HidService,
-    pub(crate) composite_service: CompositeService,
     pub(crate) device_config_service: DeviceConfigurationService,
 }
 
+/// The single HID service carrying all reports, distinguished by report id via
+/// each characteristic's Report Reference descriptor. Android's HID host only
+/// attaches to the first HID service instance, so the reports must not be
+/// spread over multiple service instances.
 #[gatt_service(uuid = service::HUMAN_INTERFACE_DEVICE)]
 pub(crate) struct HidService {
     #[characteristic(uuid = "2a4a", read, value = [0x01, 0x01, 0x00, 0x03])]
     pub(crate) hid_info: [u8; 4],
-    #[characteristic(uuid = "2a4b", read, value = KeyboardReport::desc().try_into().expect("Failed to convert KeyboardReport to [u8; 67]"))]
-    pub(crate) report_map: [u8; 67],
+    #[characteristic(uuid = "2a4b", read, value = BleCompositeReport::desc().try_into().expect("Failed to convert BleCompositeReport to [u8; 178]"))]
+    pub(crate) report_map: [u8; 178],
     #[characteristic(uuid = "2a4c", write_without_response)]
     pub(crate) hid_control_point: u8,
     #[characteristic(uuid = "2a4e", read, write_without_response, value = 1)]
     pub(crate) protocol_mode: u8,
-    #[descriptor(uuid = "2908", read, value = [0u8, 1u8])]
+    #[descriptor(uuid = "2908", read, value = [CompositeReportType::Keyboard as u8, 1u8])]
     #[characteristic(uuid = "2a4d", read, notify)]
     pub(crate) input_keyboard: [u8; 8],
-    #[descriptor(uuid = "2908", read, value = [0u8, 2u8])]
+    #[descriptor(uuid = "2908", read, value = [CompositeReportType::Keyboard as u8, 2u8])]
     #[characteristic(uuid = "2a4d", read, write, write_without_response)]
     pub(crate) output_keyboard: [u8; 1],
-}
-
-#[gatt_service(uuid = service::HUMAN_INTERFACE_DEVICE)]
-pub(crate) struct CompositeService {
-    #[characteristic(uuid = "2a4a", read, value = [0x01, 0x01, 0x00, 0x03])]
-    pub(crate) hid_info: [u8; 4],
-    #[characteristic(uuid = "2a4b", read, value = CompositeReport::desc().try_into().expect("Failed to convert CompositeReport to [u8; 111]"))]
-    pub(crate) report_map: [u8; 111],
-    #[characteristic(uuid = "2a4c", write_without_response)]
-    pub(crate) hid_control_point: u8,
-    #[characteristic(uuid = "2a4e", read, write_without_response, value = 1)]
-    pub(crate) protocol_mode: u8,
     #[descriptor(uuid = "2908", read, value = [CompositeReportType::Mouse as u8, 1u8])]
     #[characteristic(uuid = "2a4d", read, notify)]
     pub(crate) mouse_report: [u8; 5],
@@ -107,9 +97,9 @@ impl<'stack, 'server, 'conn, P: PacketPool> BleHidServer<'stack, 'server, 'conn,
     pub(crate) fn new(server: &Server, conn: &'conn GattConnection<'stack, 'server, P>) -> Self {
         Self {
             input_keyboard: server.hid_service.input_keyboard,
-            mouse_report: server.composite_service.mouse_report,
-            media_report: server.composite_service.media_report,
-            system_report: server.composite_service.system_report,
+            mouse_report: server.hid_service.mouse_report,
+            media_report: server.hid_service.media_report,
+            system_report: server.hid_service.system_report,
             conn,
         }
     }

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -272,10 +272,9 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
         server.host_service.input_data,
         server.host_service.hid_control_point,
     );
-    let mouse = server.composite_service.mouse_report;
-    let media = server.composite_service.media_report;
-    let media_control_point = server.composite_service.hid_control_point;
-    let system_control = server.composite_service.system_report;
+    let mouse = server.hid_service.mouse_report;
+    let media = server.hid_service.media_report;
+    let system_control = server.hid_service.system_report;
 
     #[cfg(feature = "passkey_entry")]
     let mut passkey_state = PasskeyInputState::new();
@@ -371,10 +370,7 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
                             || event.handle() == level.cccd_handle.expect("No CCCD for battery level")
                         {
                             cccd_updated = true;
-                        } else if event.handle() == hid_control_point.handle
-                            || event.handle() == media_control_point.handle
-                            || host_control_point_match
-                        {
+                        } else if event.handle() == hid_control_point.handle || host_control_point_match {
                             info!("Write GATT Event to Control Point: {:?}", event.handle());
                             #[cfg(feature = "split")]
                             {

--- a/rmk/src/hid.rs
+++ b/rmk/src/hid.rs
@@ -59,7 +59,7 @@ pub struct ViaReport {
 }
 
 /// Predefined report ids for composite hid report.
-/// Should be same with `#[gen_hid_descriptor]`
+/// Should be same with `#[gen_hid_descriptor]` of `CompositeReport` and `BleCompositeReport`
 /// DO NOT EDIT
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize)]
@@ -67,9 +67,12 @@ pub struct ViaReport {
 pub enum CompositeReportType {
     #[default]
     None = 0x00,
-    Mouse = 0x01,
-    Media = 0x02,
-    System = 0x03,
+    /// Used only in the BLE report map; the USB keyboard interface stays a
+    /// report-ID-less boot keyboard.
+    Keyboard = 0x01,
+    Mouse = 0x02,
+    Media = 0x03,
+    System = 0x04,
 }
 
 /// Plover HID stenography report.
@@ -146,7 +149,7 @@ mod steno_tests {
 #[gen_hid_descriptor(
     (collection = APPLICATION, usage_page = GENERIC_DESKTOP, usage = MOUSE) = {
         (collection = PHYSICAL, usage = POINTER) = {
-            (report_id = 0x01,) = {
+            (report_id = 0x02,) = {
                 (usage_page = BUTTON, usage_min = BUTTON_1, usage_max = BUTTON_8) = {
                     #[packed_bits = 8] #[item_settings(data,variable,absolute)] buttons=input;
                 };
@@ -170,14 +173,14 @@ mod steno_tests {
         };
     },
     (collection = APPLICATION, usage_page = CONSUMER, usage = CONSUMER_CONTROL) = {
-        (report_id = 0x02,) = {
+        (report_id = 0x03,) = {
             (usage_page = CONSUMER, usage_min = 0x00, usage_max = 0x514) = {
             #[item_settings(data,array,absolute,not_null)] media_usage_id=input;
             }
         };
     },
     (collection = APPLICATION, usage_page = GENERIC_DESKTOP, usage = SYSTEM_CONTROL) = {
-        (report_id = 0x03,) = {
+        (report_id = 0x04,) = {
             (usage_min = 0x01, usage_max = 0xB7, logical_min = 1) = {
                 #[item_settings(data,array,absolute,not_null)] system_usage_id=input;
             };
@@ -193,6 +196,113 @@ pub struct CompositeReport {
     pub(crate) pan: i8,   // Scroll left (negative) or right (positive) this many units
     pub(crate) media_usage_id: u16,
     pub(crate) system_usage_id: u8,
+}
+
+/// The BLE report map: everything in one HID service, distinguished by report id.
+///
+/// Android's HID host only attaches to the first HID service instance (AOSP
+/// `bta_hh_le.cc`, b/286413526), so unlike USB the keyboard/mouse/media/system
+/// reports must share a single service. Only `desc()` is used; the actual
+/// payloads are still serialized from `KeyboardReport`, `MouseReport`, etc.,
+/// as HID-over-GATT carries the report id in the Report Reference descriptor
+/// instead of the payload.
+#[cfg(feature = "_ble")]
+#[gen_hid_descriptor(
+    (collection = APPLICATION, usage_page = GENERIC_DESKTOP, usage = KEYBOARD) = {
+        (report_id = 0x01,) = {
+            (usage_page = KEYBOARD, usage_min = 0xE0, usage_max = 0xE7) = {
+                #[packed_bits = 8] #[item_settings(data,variable,absolute)] modifier=input;
+            };
+            (logical_min = 0,) = {
+                #[item_settings(constant,variable,absolute)] reserved=input;
+            };
+            (usage_page = LEDS, usage_min = 0x01, usage_max = 0x05) = {
+                #[packed_bits = 5] #[item_settings(data,variable,absolute)] leds=output;
+            };
+            (usage_page = KEYBOARD, usage_min = 0x00, usage_max = 0xDD) = {
+                #[item_settings(data,array,absolute)] keycodes=input;
+            };
+        };
+    },
+    (collection = APPLICATION, usage_page = GENERIC_DESKTOP, usage = MOUSE) = {
+        (collection = PHYSICAL, usage = POINTER) = {
+            (report_id = 0x02,) = {
+                (usage_page = BUTTON, usage_min = BUTTON_1, usage_max = BUTTON_8) = {
+                    #[packed_bits = 8] #[item_settings(data,variable,absolute)] buttons=input;
+                };
+                (usage_page = GENERIC_DESKTOP,) = {
+                    (usage = X,) = {
+                        #[item_settings(data,variable,relative)] x=input;
+                    };
+                    (usage = Y,) = {
+                        #[item_settings(data,variable,relative)] y=input;
+                    };
+                    (usage = WHEEL,) = {
+                        #[item_settings(data,variable,relative)] wheel=input;
+                    };
+                };
+                (usage_page = CONSUMER,) = {
+                    (usage = AC_PAN,) = {
+                        #[item_settings(data,variable,relative)] pan=input;
+                    };
+                };
+            };
+        };
+    },
+    (collection = APPLICATION, usage_page = CONSUMER, usage = CONSUMER_CONTROL) = {
+        (report_id = 0x03,) = {
+            (usage_page = CONSUMER, usage_min = 0x00, usage_max = 0x514) = {
+            #[item_settings(data,array,absolute,not_null)] media_usage_id=input;
+            }
+        };
+    },
+    (collection = APPLICATION, usage_page = GENERIC_DESKTOP, usage = SYSTEM_CONTROL) = {
+        (report_id = 0x04,) = {
+            (usage_min = 0x01, usage_max = 0xB7, logical_min = 1) = {
+                #[item_settings(data,array,absolute,not_null)] system_usage_id=input;
+            };
+        };
+    }
+)]
+#[allow(dead_code)]
+#[derive(Default)]
+pub struct BleCompositeReport {
+    pub(crate) modifier: u8,
+    pub(crate) reserved: u8,
+    pub(crate) leds: u8,
+    pub(crate) keycodes: [u8; 6],
+    pub(crate) buttons: u8,
+    pub(crate) x: i8,
+    pub(crate) y: i8,
+    pub(crate) wheel: i8,
+    pub(crate) pan: i8,
+    pub(crate) media_usage_id: u16,
+    pub(crate) system_usage_id: u8,
+}
+
+#[cfg(all(test, feature = "_ble"))]
+mod ble_report_map_tests {
+    use usbd_hid::descriptor::SerializedDescriptor;
+
+    use super::BleCompositeReport;
+
+    /// Pins the report map: `ble_server::HidService` hardcodes its length, and
+    /// the report ids must match `CompositeReportType`.
+    #[test]
+    fn ble_report_map_matches_service_definition() {
+        let desc = BleCompositeReport::desc();
+        fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+            haystack.windows(needle.len()).position(|w| w == needle)
+        }
+        assert_eq!(desc.len(), 178, "update HidService's report_map size on change");
+        let keyboard = find(desc, &[0x09, 0x06]).expect("missing Usage Keyboard");
+        for report_id in 1u8..=4 {
+            let id = find(desc, &[0x85, report_id]).unwrap_or_else(|| panic!("missing ReportID {report_id}"));
+            if report_id == 0x01 {
+                assert!(keyboard < id, "keyboard collection must own ReportID 1");
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Merge keyboard/mouse/media/system reports into one HID service with a single report map, distinguished by report id via each characteristic's Report Reference descriptor.

Background: Android's HID host only attaches to the first HID service instance (AOSP bta_hh_le.cc, b/286413526), so mouse/media/system reports served from a second HID service instance are never subscribed.