### PR TITLE
fix(macro): make invalid `#[Overwritten(...)]` attributes a compile error

### DIFF
--- a/examples/use_config/stm32h7/src/main.rs
+++ b/examples/use_config/stm32h7/src/main.rs
@@ -16,11 +16,15 @@ mod my_keyboard {
     use rmk::usb::UsbTransport;
     use static_cell::StaticCell;
 
-    // If you want customize interrupte binding , use `#[Override(bind_interrupt)]` to override default interrupt binding
+    // If you want customize interrupte binding , use `#[Override(bind_interrupt)]` to override default interrupt binding.
+    // The override replaces the whole generated `bind_interrupts!` block, so it has to bind
+    // everything this configuration needs (here: USB, plus the EXTI lines used by `async_matrix`).
     #[Override(bind_interrupt)]
     fn bind_interrupt() {
-        bind_interrupts!(struct Irqs {
-            OTG_HS => InterruptHandler<USB_OTG_HS>;
+        embassy_stm32::bind_interrupts!(struct Irqs {
+            OTG_HS => embassy_stm32::usb::InterruptHandler<embassy_stm32::peripherals::USB_OTG_HS>;
+            EXTI9_5 => embassy_stm32::exti::InterruptHandler<embassy_stm32::interrupt::typelevel::EXTI9_5>;
+            EXTI15_10 => embassy_stm32::exti::InterruptHandler<embassy_stm32::interrupt::typelevel::EXTI15_10>;
         });
     }
 

--- a/rmk-macro/src/codegen/chip/bind_interrupt.rs
+++ b/rmk-macro/src/codegen/chip/bind_interrupt.rs
@@ -7,23 +7,44 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use rmk_config::resolved::Hardware;
 use rmk_config::resolved::hardware::{BoardConfig, InputDeviceConfig, UniBodyConfig};
-use syn::ItemMod;
+use syn::{ItemFn, ItemMod};
 
 use crate::codegen::display::expand_display_interrupt;
 use crate::codegen::feature::{get_rmk_features, is_feature_enabled};
 use crate::codegen::input_device::iqs5xx::expand_iqs5xx_interrupts;
+use crate::codegen::override_helper::{Overwritten, find_overwritten};
+
+/// Does this function override the generated `bind_interrupts!` boilerplate?
+///
+/// Two markers are accepted:
+/// - `#[Override(bind_interrupt)]` / `#[Overwritten(bind_interrupt)]` (the form the stm32h7
+///   example documents), selected through the shared override matcher so inert attributes and
+///   `cfg` gating behave like every other override;
+/// - the legacy bare `#[bind_interrupt]` attribute (the original syntax), matched exactly as
+///   before for backward compatibility: it must be the function's only attribute.
+fn is_bind_interrupt_override(item_fn: &ItemFn) -> bool {
+    let current = matches!(
+        find_overwritten(item_fn),
+        Some(Ok(Overwritten::BindInterrupt))
+    );
+    let legacy = item_fn.attrs.len() == 1
+        && item_fn.attrs[0]
+            .meta
+            .path()
+            .get_ident()
+            .is_some_and(|i| i == "bind_interrupt");
+    current || legacy
+}
 
 /// Expand `bind_interrupt!` stuffs, and other code before `main` function
 pub(crate) fn expand_bind_interrupt(hardware: &Hardware, item_mod: &ItemMod) -> TokenStream2 {
-    // If there is a function with `#[Overwritten(bind_interrupt)]`, override it
+    // If there is a function marked as the bind_interrupt override, use its body
     if let Some((_, items)) = &item_mod.content {
         items
             .iter()
             .find_map(|item| {
                 if let syn::Item::Fn(item_fn) = &item
-                    && item_fn.attrs.len() == 1
-                    && let Some(i) = item_fn.attrs[0].meta.path().get_ident()
-                    && i == "bind_interrupt"
+                    && is_bind_interrupt_override(item_fn)
                 {
                     let content = &item_fn.block.stmts;
                     return Some(quote! {
@@ -375,5 +396,64 @@ fn get_pin_num_stm32(gpio_name: &str) -> Option<String> {
         None
     } else {
         Some(gpio_name[2..].to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_fn(src: &str) -> ItemFn {
+        syn::parse_str(src).expect("test fn should parse")
+    }
+
+    // Selection regression tests (#967 review): validation accepting a marker
+    // is meaningless if selection doesn't recognize the same marker.
+
+    #[test]
+    fn documented_override_form_is_selected() {
+        // The form the stm32h7 example documents. It used to pass validation
+        // but never get selected, silently dropping the custom binding.
+        assert!(is_bind_interrupt_override(&parse_fn(
+            "#[Override(bind_interrupt)]\nfn bind_interrupt() {}"
+        )));
+    }
+
+    #[test]
+    fn overwritten_spelling_is_selected() {
+        assert!(is_bind_interrupt_override(&parse_fn(
+            "#[Overwritten(bind_interrupt)]\nfn bind_interrupt() {}"
+        )));
+    }
+
+    #[test]
+    fn legacy_bare_marker_is_still_selected() {
+        // The original syntax; kept working for existing user code.
+        assert!(is_bind_interrupt_override(&parse_fn(
+            "#[bind_interrupt]\nfn bind_interrupt() {}"
+        )));
+    }
+
+    #[test]
+    fn doc_comment_does_not_disable_documented_form() {
+        assert!(is_bind_interrupt_override(&parse_fn(
+            "/// custom irq binding\n#[Override(bind_interrupt)]\nfn bind_interrupt() {}"
+        )));
+    }
+
+    #[test]
+    fn cfg_gated_override_is_not_selected() {
+        // Same `cfg` semantics as every other override: the macro cannot
+        // evaluate `cfg`, so the function is left unselected.
+        assert!(!is_bind_interrupt_override(&parse_fn(
+            "#[cfg(feature = \"x\")]\n#[Override(bind_interrupt)]\nfn bind_interrupt() {}"
+        )));
+    }
+
+    #[test]
+    fn other_override_marker_is_not_selected() {
+        assert!(!is_bind_interrupt_override(&parse_fn(
+            "#[Override(entry)]\nfn run() {}"
+        )));
     }
 }

--- a/rmk-macro/src/codegen/chip/chip_init.rs
+++ b/rmk-macro/src/codegen/chip/chip_init.rs
@@ -1,11 +1,10 @@
-use darling::FromMeta;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{ToTokens, quote};
 use rmk_config::resolved::Hardware;
 use rmk_config::resolved::hardware::{BoardConfig, ChipModel, ChipSeries, CommunicationConfig};
 use syn::{ItemFn, ItemMod};
 
-use crate::codegen::override_helper::Overwritten;
+use crate::codegen::override_helper::{Overwritten, find_overwritten};
 
 /// Expand chip initialization code
 ///
@@ -22,13 +21,13 @@ pub(crate) fn expand_chip_init(
             .iter()
             .find_map(|item| {
                 if let syn::Item::Fn(item_fn) = &item
-                    && item_fn.attrs.len() == 1
+                    && let Some(Ok(overwritten)) = find_overwritten(item_fn)
                 {
-                    match Overwritten::from_meta(&item_fn.attrs[0].meta) {
-                        Ok(Overwritten::ChipConfig) => {
+                    match overwritten {
+                        Overwritten::ChipConfig => {
                             return Some(override_chip_config(&hardware.chip, item_fn));
                         }
-                        Ok(Overwritten::ChipInit) => {
+                        Overwritten::ChipInit => {
                             // Override the whole chip initialization
                             let stmts = &item_fn.block.stmts;
                             return Some(quote! { #(#stmts)* });

--- a/rmk-macro/src/codegen/chip/comm.rs
+++ b/rmk-macro/src/codegen/chip/comm.rs
@@ -1,14 +1,13 @@
 //! Initialize communication boilerplate of RMK, including USB or BLE
 //!
 
-use darling::FromMeta;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{ToTokens, format_ident, quote};
 use rmk_config::resolved::Hardware;
 use rmk_config::resolved::hardware::ChipSeries;
 use syn::{ItemFn, ItemMod};
 
-use crate::codegen::override_helper::Overwritten;
+use crate::codegen::override_helper::{Overwritten, find_overwritten};
 
 pub(crate) fn expand_usb_init(hardware: &Hardware, item_mod: &ItemMod) -> TokenStream2 {
     // If there is a function with `#[Overwritten(usb)]`, override the chip initialization
@@ -17,8 +16,7 @@ pub(crate) fn expand_usb_init(hardware: &Hardware, item_mod: &ItemMod) -> TokenS
             .iter()
             .find_map(|item| {
                 if let syn::Item::Fn(item_fn) = &item
-                    && item_fn.attrs.len() == 1
-                    && let Ok(Overwritten::Usb) = Overwritten::from_meta(&item_fn.attrs[0].meta)
+                    && let Some(Ok(Overwritten::Usb)) = find_overwritten(item_fn)
                 {
                     return Some(override_usb_init(item_fn));
                 }

--- a/rmk-macro/src/codegen/entry.rs
+++ b/rmk-macro/src/codegen/entry.rs
@@ -1,4 +1,3 @@
-use darling::FromMeta;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use rmk_config::resolved::hardware::{BoardConfig, CommunicationConfig};
@@ -25,8 +24,8 @@ pub(crate) fn expand_rmk_entry(
             .iter()
             .find_map(|item| {
                 if let syn::Item::Fn(item_fn) = &item
-                    && item_fn.attrs.len() == 1
-                    && let Ok(Overwritten::Entry) = Overwritten::from_meta(&item_fn.attrs[0].meta)
+                    && let Some(Ok(Overwritten::Entry)) =
+                        super::override_helper::find_overwritten(item_fn)
                 {
                     return Some(override_rmk_entry(item_fn));
                 }

--- a/rmk-macro/src/codegen/orchestrator.rs
+++ b/rmk-macro/src/codegen/orchestrator.rs
@@ -26,6 +26,12 @@ use super::watchdog::expand_watchdog_init;
 
 /// Parse keyboard mod and generate a valid RMK main function with all needed code
 pub(crate) fn parse_keyboard_mod(item_mod: syn::ItemMod) -> TokenStream2 {
+    // Reject invalid `#[Overwritten(...)]` attributes up front instead of
+    // silently falling back to the generated defaults (#966)
+    if let Some(errors) = crate::codegen::override_helper::validate_overwritten_attrs(&item_mod) {
+        return errors;
+    }
+
     let rmk_features = get_rmk_features();
 
     let keyboard_config = read_keyboard_toml_config();

--- a/rmk-macro/src/codegen/override_helper.rs
+++ b/rmk-macro/src/codegen/override_helper.rs
@@ -9,9 +9,9 @@ pub enum Overwritten {
     ChipConfig,
     ChipInit,
     Entry,
-    /// Accepted so `#[Override(bind_interrupt)]` (used in existing examples)
-    /// passes validation; the bind_interrupt override itself is matched
-    /// separately in `bind_interrupt.rs`.
+    /// `#[Override(bind_interrupt)]` — the form the stm32h7 example documents. Selected by
+    /// `bind_interrupt.rs` through this shared matcher; the legacy bare `#[bind_interrupt]`
+    /// marker is also still accepted there for backward compatibility.
     BindInterrupt,
 }
 
@@ -104,7 +104,8 @@ mod tests {
 
     #[test]
     fn bind_interrupt_passes_validation() {
-        // Used by existing examples; consumed separately in bind_interrupt.rs.
+        // The form the stm32h7 example documents; selection lives in
+        // bind_interrupt.rs and is covered by that module's tests.
         let res = find_overwritten(&parse_fn("#[Override(bind_interrupt)]\nfn f() {}"));
         assert!(matches!(res, Some(Ok(Overwritten::BindInterrupt))));
     }

--- a/rmk-macro/src/codegen/override_helper.rs
+++ b/rmk-macro/src/codegen/override_helper.rs
@@ -1,4 +1,6 @@
 use darling::FromMeta;
+use proc_macro2::TokenStream as TokenStream2;
+use syn::{ItemFn, ItemMod};
 
 /// List of functions that can be overwritten
 #[derive(Debug, Clone, Copy, FromMeta)]
@@ -7,4 +9,125 @@ pub enum Overwritten {
     ChipConfig,
     ChipInit,
     Entry,
+    /// Accepted so `#[Override(bind_interrupt)]` (used in existing examples)
+    /// passes validation; the bind_interrupt override itself is matched
+    /// separately in `bind_interrupt.rs`.
+    BindInterrupt,
+}
+
+/// Find the override attribute on a function and parse it. Both documented
+/// spellings are accepted: `#[Override(...)]` (docs, examples) and
+/// `#[Overwritten(...)]` (this enum's name; the previous matching ignored the
+/// attribute path entirely, so both were in use).
+///
+/// Returns:
+/// - `None`: the function carries no override attribute
+/// - `Some(Ok(_))`: a valid override marker (other attributes, doc comments
+///   included, are allowed alongside it)
+/// - `Some(Err(_))`: an override attribute that failed to parse
+///   (unknown or miscased variant, missing argument, ...)
+pub(crate) fn find_overwritten(item_fn: &ItemFn) -> Option<darling::Result<Overwritten>> {
+    item_fn
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("Override") || attr.path().is_ident("Overwritten"))
+        .map(|attr| Overwritten::from_meta(&attr.meta))
+}
+
+/// Validate every `#[Overwritten(...)]` attribute in the module.
+///
+/// Returns darling's diagnostics rendered as `compile_error!` tokens, or
+/// `None` if all attributes are valid. This turns a typo like
+/// `#[Overwritten(Entry)]` into a compile error instead of a silent fallback
+/// to the generated default (#966).
+pub(crate) fn validate_overwritten_attrs(item_mod: &ItemMod) -> Option<TokenStream2> {
+    let mut errors: Vec<darling::Error> = Vec::new();
+    if let Some((_, items)) = &item_mod.content {
+        for item in items {
+            if let syn::Item::Fn(item_fn) = item
+                && let Some(Err(e)) = find_overwritten(item_fn)
+            {
+                errors.push(e);
+            }
+        }
+    }
+    if errors.is_empty() {
+        None
+    } else {
+        Some(darling::Error::multiple(errors).write_errors())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_fn(src: &str) -> ItemFn {
+        syn::parse_str(src).expect("test fn should parse")
+    }
+
+    #[test]
+    fn no_overwritten_attribute_is_none() {
+        assert!(find_overwritten(&parse_fn("fn f() {}")).is_none());
+        assert!(find_overwritten(&parse_fn("#[inline]\nfn f() {}")).is_none());
+    }
+
+    #[test]
+    fn valid_variant_parses() {
+        let res = find_overwritten(&parse_fn("#[Overwritten(entry)]\nfn f() {}"));
+        assert!(matches!(res, Some(Ok(Overwritten::Entry))));
+    }
+
+    #[test]
+    fn override_spelling_is_accepted() {
+        // The documented spelling (docs/examples) is `#[Override(...)]`.
+        let res = find_overwritten(&parse_fn("#[Override(chip_config)]\nfn f() {}"));
+        assert!(matches!(res, Some(Ok(Overwritten::ChipConfig))));
+    }
+
+    #[test]
+    fn bind_interrupt_passes_validation() {
+        // Used by existing examples; consumed separately in bind_interrupt.rs.
+        let res = find_overwritten(&parse_fn("#[Override(bind_interrupt)]\nfn f() {}"));
+        assert!(matches!(res, Some(Ok(Overwritten::BindInterrupt))));
+    }
+
+    #[test]
+    fn doc_comment_does_not_disable_override() {
+        // Doc comments are attributes; they used to make the override
+        // silently ineligible via the old `attrs.len() == 1` check.
+        let res = find_overwritten(&parse_fn("/// my entry\n#[Overwritten(entry)]\nfn f() {}"));
+        assert!(matches!(res, Some(Ok(Overwritten::Entry))));
+    }
+
+    #[test]
+    fn miscased_variant_is_an_error() {
+        let res = find_overwritten(&parse_fn("#[Overwritten(Entry)]\nfn f() {}"));
+        assert!(matches!(res, Some(Err(_))));
+        let res = find_overwritten(&parse_fn("#[Override(Entry)]\nfn f() {}"));
+        let err = match res {
+            Some(Err(e)) => e,
+            other => panic!("expected Some(Err(_)), got {other:?}"),
+        };
+        // darling's diagnostic suggests the snake_case spelling
+        assert!(
+            err.to_string().contains("entry"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn invalid_attr_in_module_becomes_compile_error() {
+        let item_mod: ItemMod =
+            syn::parse_str("mod kb { #[Overwritten(Entry)] fn run() {} }").unwrap();
+        let tokens = validate_overwritten_attrs(&item_mod).expect("should produce errors");
+        assert!(tokens.to_string().contains("compile_error"));
+    }
+
+    #[test]
+    fn valid_module_produces_no_errors() {
+        let item_mod: ItemMod =
+            syn::parse_str("mod kb { #[Overwritten(entry)] fn run() {} fn helper() {} }").unwrap();
+        assert!(validate_overwritten_attrs(&item_mod).is_none());
+    }
 }

--- a/rmk-macro/src/codegen/override_helper.rs
+++ b/rmk-macro/src/codegen/override_helper.rs
@@ -20,18 +20,35 @@ pub enum Overwritten {
 /// `#[Overwritten(...)]` (this enum's name; the previous matching ignored the
 /// attribute path entirely, so both were in use).
 ///
+/// A `#[cfg(...)]` / `#[cfg_attr(...)]` on the function makes it ineligible: an
+/// attribute macro receives its module's items *before* `cfg` stripping, so a
+/// disabled item still reaches us with its `cfg` intact and we cannot tell here
+/// whether it is compiled. Such a function is skipped entirely — neither
+/// selected nor validated — so a disabled override can't replace the generated
+/// default and a disabled typo can't emit an error (#967 review). Inert
+/// attributes (doc comments, `#[allow(...)]`, ...) don't gate compilation and
+/// may sit alongside the marker.
+///
 /// Returns:
-/// - `None`: the function carries no override attribute
-/// - `Some(Ok(_))`: a valid override marker (other attributes, doc comments
-///   included, are allowed alongside it)
+/// - `None`: no override marker, or the marker is `cfg`/`cfg_attr`-gated
+/// - `Some(Ok(_))`: a valid override marker (inert attributes may accompany it)
 /// - `Some(Err(_))`: an override attribute that failed to parse
 ///   (unknown or miscased variant, missing argument, ...)
 pub(crate) fn find_overwritten(item_fn: &ItemFn) -> Option<darling::Result<Overwritten>> {
-    item_fn
+    let marker = item_fn
         .attrs
         .iter()
-        .find(|attr| attr.path().is_ident("Override") || attr.path().is_ident("Overwritten"))
-        .map(|attr| Overwritten::from_meta(&attr.meta))
+        .find(|attr| attr.path().is_ident("Override") || attr.path().is_ident("Overwritten"))?;
+    // `cfg`/`cfg_attr` gate whether the item is compiled; we can't evaluate
+    // that here, so leave the function untouched rather than mis-select it.
+    if item_fn
+        .attrs
+        .iter()
+        .any(|attr| attr.path().is_ident("cfg") || attr.path().is_ident("cfg_attr"))
+    {
+        return None;
+    }
+    Some(Overwritten::from_meta(&marker.meta))
 }
 
 /// Validate every `#[Overwritten(...)]` attribute in the module.
@@ -98,6 +115,58 @@ mod tests {
         // silently ineligible via the old `attrs.len() == 1` check.
         let res = find_overwritten(&parse_fn("/// my entry\n#[Overwritten(entry)]\nfn f() {}"));
         assert!(matches!(res, Some(Ok(Overwritten::Entry))));
+    }
+
+    #[test]
+    fn cfg_gated_override_is_ignored() {
+        // A `cfg`-gated override must not be selected: the attribute macro sees
+        // the item before `cfg` stripping and cannot tell whether it is active,
+        // so it is left untouched (the generated default is used). Both a valid
+        // variant and a typo behind `cfg` resolve to `None` — no selection and
+        // no spurious compile error for a disabled function (#967 review).
+        assert!(
+            find_overwritten(&parse_fn(
+                "#[cfg(feature = \"x\")]\n#[Override(chip_config)]\nfn f() {}"
+            ))
+            .is_none()
+        );
+        assert!(
+            find_overwritten(&parse_fn(
+                "#[cfg(feature = \"x\")]\n#[Override(Entry)]\nfn f() {}"
+            ))
+            .is_none()
+        );
+        // `cfg_attr` is gated the same way.
+        assert!(
+            find_overwritten(&parse_fn(
+                "#[cfg_attr(test, inline)]\n#[Override(entry)]\nfn f() {}"
+            ))
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn inert_attribute_does_not_disable_override() {
+        // `#[allow(...)]` (like doc comments) does not gate compilation, so it
+        // must not make the override ineligible — only `cfg`/`cfg_attr` do.
+        let res = find_overwritten(&parse_fn(
+            "#[allow(dead_code)]\n#[Override(entry)]\nfn f() {}",
+        ));
+        assert!(matches!(res, Some(Ok(Overwritten::Entry))));
+        // A typo alongside an inert attribute is still caught (no cfg present).
+        let res = find_overwritten(&parse_fn(
+            "#[allow(dead_code)]\n#[Override(Entry)]\nfn f() {}",
+        ));
+        assert!(matches!(res, Some(Err(_))));
+    }
+
+    #[test]
+    fn cfg_gated_override_produces_no_module_error() {
+        // The disabled typo above must not turn into a compile error.
+        let item_mod: ItemMod =
+            syn::parse_str("mod kb { #[cfg(feature = \"x\")] #[Overwritten(Entry)] fn run() {} }")
+                .unwrap();
+        assert!(validate_overwritten_attrs(&item_mod).is_none());
     }
 
     #[test]

--- a/rmk-macro/src/codegen/split/peripheral.rs
+++ b/rmk-macro/src/codegen/split/peripheral.rs
@@ -35,6 +35,12 @@ pub(crate) fn parse_split_peripheral_mod(
     _attr: proc_macro::TokenStream,
     item_mod: ItemMod,
 ) -> TokenStream2 {
+    // Reject invalid `#[Overwritten(...)]` attributes up front instead of
+    // silently falling back to the generated defaults (#966)
+    if let Some(errors) = crate::codegen::override_helper::validate_overwritten_attrs(&item_mod) {
+        return errors;
+    }
+
     let rmk_features = get_rmk_features();
     if !is_feature_enabled(&rmk_features, "split") {
         panic!("\"split\" feature of RMK should be enabled");

--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `unregister_keycode` choosing the wrong HID slot when a combo output and another pressed key share a position. Slot lookup now prefers a `(pos, keycode)` match and falls back to keycode-only.
 - Fix spurious "Timer buffer full" warns after 16 distinct key positions are pressed. The per-position timer `LinearMap` is gone; press time is now threaded as a parameter through the morse-press dispatch.
 - Fix override attributes (`#[Override(...)]` / `#[Overwritten(...)]`) silently falling back to the generated default: an unknown or miscased variant (e.g. `Entry` instead of `entry`) is now a compile error carrying darling's diagnostic, and an extra attribute on the function (doc comments included) no longer disables a valid override ([#966](https://github.com/HaoboGu/rmk/issues/966))
+- Fix `#[Override(bind_interrupt)]` (the form the stm32h7 example documents) never taking effect: the custom interrupt binding is now selected through the shared override matcher instead of being silently dropped in favor of the generated default. The legacy bare `#[bind_interrupt]` marker keeps working unchanged
 
 ## [0.8.2] - 2025-12-18
 

--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix stuck combo output when overlapping triggered combos share a key (e.g. `M+,` and `,+.` both containing Comma). Releasing the shared key now dispatches the release of every fully-unwound combo output, not just the first.
 - Fix `unregister_keycode` choosing the wrong HID slot when a combo output and another pressed key share a position. Slot lookup now prefers a `(pos, keycode)` match and falls back to keycode-only.
 - Fix spurious "Timer buffer full" warns after 16 distinct key positions are pressed. The per-position timer `LinearMap` is gone; press time is now threaded as a parameter through the morse-press dispatch.
+- Fix override attributes (`#[Override(...)]` / `#[Overwritten(...)]`) silently falling back to the generated default: an unknown or miscased variant (e.g. `Entry` instead of `entry`) is now a compile error carrying darling's diagnostic, and an extra attribute on the function (doc comments included) no longer disables a valid override ([#966](https://github.com/HaoboGu/rmk/issues/966))
 
 ## [0.8.2] - 2025-12-18
 


### PR DESCRIPTION
Fixes #966

### Description

An `#[Overwritten(...)]` attribute that failed to parse — an unknown or miscased variant like `#[Overwritten(Entry)]` instead of `entry` — was silently skipped: the `if let Ok(...)` matchers discarded darling's error and fell back to the generated default, and the function itself was dropped from the expansion, so neither the macro nor rustc reported anything. The matchers also required `attrs.len() == 1`, so any extra attribute (doc comments included) silently disabled a correctly spelled override.

- Validate all `Overwritten` attributes up front in `parse_keyboard_mod` / `parse_split_peripheral_mod`; parse failures now surface darling's own diagnostic (``Unknown field: `Entry`. Did you mean `entry`?``) as a compile error via `write_errors()` — the idiom `lib.rs` already uses for other attribute parsing.
- Replace the per-site `attrs.len() == 1` + `from_meta` matching with a shared `find_overwritten()` helper that finds the attribute by path, so an extra attribute (doc comments included) no longer disables a correctly spelled override.
- Functions without an `Overwritten` attribute, and valid single-attribute overrides, expand exactly as before. `CHANGELOG` entry added.

### Testing

- `cargo test` in `rmk-macro`: unit tests (incl. 6 new covering the typo, extra-attribute/doc-comment, valid, and no-attribute cases), trybuild `compile_fail`, and macrotest `expand` — all passing (with `cargo expand` installed).
- `cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble` in `rmk`: 548/548 passed on current `main` (rmk consumes the path `rmk-macro`, so this compiles with the change).
- `scripts/format_all.sh` clean (nightly rustfmt).
- Macro-expansion-time change only; no hardware behavior change expected for valid configurations. Not tested on hardware.