### PR TITLE
Add Nix flake development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,100 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1784361593,
+        "narHash": "sha256-K1ym8vyrGxSZ8/SgQVyXWlBysVuJyEC5L25jPaq6PwQ=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "480c95c3c9ca478e857f7153639010fb54ec73e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784364478,
+        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784275547,
+        "narHash": "sha256-VFi+Fy9hYOcA75NayRMOjkWfg1bxIQRZ/N/4Kv9Z7sc=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "1649637a9c68a8f371d2e1326bbd15d36a8a74a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,183 @@
+{
+  description = "RMK Rust development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    fenix,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        lib = pkgs.lib;
+        fenixPkgs = fenix.packages.${system};
+
+        embeddedTargets = [
+          "thumbv6m-none-eabi"
+          "thumbv7m-none-eabi"
+          "thumbv7em-none-eabi"
+          "thumbv7em-none-eabihf"
+          "thumbv8m.main-none-eabihf"
+          "riscv32imc-unknown-none-elf"
+          "riscv32imac-unknown-none-elf"
+        ];
+
+        stableToolchain = fenixPkgs.combine (
+          [
+            fenixPkgs.stable.cargo
+            fenixPkgs.stable.clippy
+            fenixPkgs.stable.llvm-tools
+            fenixPkgs.stable.rust-src
+            fenixPkgs.stable.rustc
+            fenixPkgs.stable.rustfmt
+            fenixPkgs.stable.rust-analyzer
+          ]
+          ++ map (target: fenixPkgs.targets.${target}.stable.rust-std) embeddedTargets
+        );
+
+        # RMK uses nightly for formatting and for a small smoke-check matrix.
+        nightlyToolchain = fenixPkgs.combine [
+          fenixPkgs.latest.cargo
+          fenixPkgs.latest.rustc
+          fenixPkgs.latest.rustfmt
+        ];
+
+        # The repository's scripts intentionally use rustup-style invocations
+        # such as `cargo +stable` and `rustfmt +nightly`. Keep that interface
+        # while sourcing those toolchains from Fenix. The Xtensa-only `+esp`
+        # toolchain remains managed by espup and is delegated to rustup.
+        mkToolchainDispatcher = command:
+          pkgs.writeShellScriptBin command ''
+            toolchain=${lib.escapeShellArg (toString stableToolchain)}
+            case "''${1:-}" in
+              +stable)
+                shift
+                ;;
+              +nightly)
+                toolchain=${lib.escapeShellArg (toString nightlyToolchain)}
+                shift
+                ;;
+              +esp)
+                shift
+                exec ${pkgs.rustup}/bin/rustup run esp ${command} "$@"
+                ;;
+              +*)
+                echo "unsupported Rust toolchain: $1" >&2
+                exit 2
+                ;;
+            esac
+
+            export PATH="$toolchain/bin:$PATH"
+            export RUSTC="$toolchain/bin/rustc"
+            export RUSTDOC="$toolchain/bin/rustdoc"
+            exec "$toolchain/bin/${command}" "$@"
+          '';
+
+        toolchainDispatchers = pkgs.symlinkJoin {
+          name = "rmk-rust-toolchain-dispatchers";
+          paths = map mkToolchainDispatcher [
+            "cargo"
+            "clippy-driver"
+            "rustc"
+            "rustdoc"
+            "rustfmt"
+          ];
+        };
+
+        # cargo-batch is not packaged in nixpkgs. This implements the subset
+        # used by .github/ci/check.sh, preserving its shared target directory
+        # while running each `---`-delimited Cargo command in order.
+        cargoBatch = pkgs.writeShellScriptBin "cargo-batch" ''
+          set -euo pipefail
+
+          if [[ "''${1:-}" == batch ]]; then
+            shift
+          fi
+
+          common_args=()
+          while (( $# > 0 )) && [[ "$1" != --- ]]; do
+            common_args+=("$1")
+            shift
+          done
+
+          while (( $# > 0 )); do
+            [[ "$1" == --- ]] || {
+              echo "cargo-batch: expected ---, got $1" >&2
+              exit 2
+            }
+            shift
+            (( $# > 0 )) || {
+              echo "cargo-batch: missing Cargo command after ---" >&2
+              exit 2
+            }
+
+            cargo_command="$1"
+            shift
+            command_args=()
+            while (( $# > 0 )) && [[ "$1" != --- ]]; do
+              command_args+=("$1")
+              shift
+            done
+
+            ${toolchainDispatchers}/bin/cargo \
+              "$cargo_command" \
+              "''${common_args[@]}" \
+              "''${command_args[@]}"
+          done
+        '';
+
+        shellPackages = [
+          toolchainDispatchers
+          stableToolchain
+          cargoBatch
+          pkgs.cargo-binutils
+          pkgs.cargo-expand
+          pkgs.cargo-make
+          pkgs.cargo-nextest
+          pkgs.espflash
+          pkgs.espup
+          pkgs.flip-link
+          pkgs.just
+          pkgs.probe-rs-tools
+        ];
+      in {
+        formatter = pkgs.alejandra;
+
+        checks.toolchains =
+          pkgs.runCommand "rmk-toolchains-check" {
+            nativeBuildInputs = shellPackages;
+          } ''
+            ${toolchainDispatchers}/bin/cargo +stable --version
+            ${toolchainDispatchers}/bin/cargo +nightly --version
+            ${toolchainDispatchers}/bin/rustfmt +nightly --version
+            cargo-nextest --version
+            cargo-expand --version
+            touch "$out"
+          '';
+
+        devShells.default = pkgs.mkShell {
+          packages = shellPackages;
+
+          env = {
+            CARGO_NET_GIT_FETCH_WITH_CLI = "true";
+            RUST_MIN_STACK = "67108864";
+            RUST_SRC_PATH = "${stableToolchain}/lib/rustlib/src/rust/library";
+          };
+
+          shellHook = ''
+            export PATH="${toolchainDispatchers}/bin:$PATH"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

- add a pinned Nix flake and direnv entry point for RMK development
- provide Fenix-managed stable and nightly Rust toolchains with every ARM and RISC-V target from `rust-toolchain.toml`
- preserve the repository's `cargo +stable`, `cargo +nightly`, `rustfmt +nightly`, and `cargo +esp` workflows
- include the tools used by RMK development and CI, including nextest, cargo-expand, cargo-binutils, cargo-make, espflash, espup, flip-link, probe-rs, and a compatible cargo-batch runner

## Why

RMK currently relies on rustup and separately installed Cargo utilities. This gives contributors a reproducible `nix develop` / direnv environment while retaining the command-line conventions used by the existing scripts.

## Validation

- `nix flake update --flake path:$PWD` (already on the newest input revisions)
- `nix flake check path:$PWD`
- verified stable and nightly Cargo/rustfmt dispatch inside `nix develop`
- verified all configured embedded Rust targets are available
- `nix develop path:$PWD -c bash .github/ci/check.sh`