### PR TITLE
Use portable Bash shebangs

### DIFF
--- a/.github/ci/bloat-report.sh
+++ b/.github/ci/bloat-report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Assemble a bloat report from size-data artifact files.
 # Input directory structure per example:
 #   <safe_name>/size-data.txt       — dir|bin_label|base_total|head_total|text_diff|data_diff|bss_diff

--- a/.github/ci/check.sh
+++ b/.github/ci/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 # shellcheck source=_lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"

--- a/.github/ci/discover.sh
+++ b/.github/ci/discover.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Discover buildable examples and emit GitHub Actions matrix JSON.
 # Outputs:
 #   stable  — JSON array of {dir, target, bloat, bloat_bins} for stable-toolchain examples

--- a/.github/ci/format.sh
+++ b/.github/ci/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 # shellcheck source=_lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"

--- a/.github/ci/test.sh
+++ b/.github/ci/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 # shellcheck source=_lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"

--- a/scripts/fetch_all.sh
+++ b/scripts/fetch_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run `cargo fetch` in every directory with a Cargo.toml.
 #


### PR DESCRIPTION
Changes the executable Bash scripts in `.github/ci` and `scripts/fetch_all.sh` to use `#!/usr/bin/env bash`.

NixOS does not provide `/bin/bash`, so invoking these scripts directly currently fails even when Bash is available on `PATH`.

Validation:
- `bash -n` on all changed scripts
- `git diff --check`
- Direct `.github/ci/discover.sh` run (48 stable, 2 ESP, 16 bloat examples)