### PR TITLE
Add event-driven lighting core abstractions

### DIFF
--- a/.github/ci/_lib.sh
+++ b/.github/ci/_lib.sh
@@ -39,6 +39,7 @@ log_section() {
 RMK_FEATURESETS=(
     ""
     "log,std"
+    "lighting"
     "storage"
     "async_matrix,storage"
     "split,vial,storage"

--- a/docs/docs/main/docs/configuration/event.md
+++ b/docs/docs/main/docs/configuration/event.md
@@ -58,6 +58,8 @@ peripheral_battery.subs = 4
 | `wpm_update`               | `WpmUpdateEvent`              |                        |
 | `led_indicator`            | `LedIndicatorEvent`           |                        |
 | `sleep_state`              | `SleepStateEvent`             |                        |
+| **Control Events**         |                               |                        |
+| `lighting_command`         | `LightingCommandEvent`        | lighting feature       |
 | **Battery Events**         |                               |                        |
 | `battery_adc`              | `BatteryAdcEvent`             | channel_size=2         |
 | `charging_state`           | `ChargingStateEvent`          | channel_size=2         |

--- a/docs/docs/main/docs/features/_meta.json
+++ b/docs/docs/main/docs/features/_meta.json
@@ -12,6 +12,7 @@
   "processor",
   "input_device",
   "display",
+  "lighting",
   "steno",
   "binary_size_optimization",
   "watchdog"

--- a/docs/docs/main/docs/features/lighting.md
+++ b/docs/docs/main/docs/features/lighting.md
@@ -1,0 +1,80 @@
+# Lighting
+
+RMK's optional `lighting` feature provides an event-driven integration boundary
+for custom lighting hardware. It deliberately establishes hardware and state
+ownership before prescribing topology, effects, or composition.
+
+Enable it in a Rust-configured keyboard:
+
+```toml
+[dependencies]
+rmk = { version = "0.8", features = ["lighting"] }
+```
+
+## Components
+
+- `LightingContext` contains current event-derived keyboard state.
+- `LightingRenderer` turns state and transient events into a logical frame.
+- `LightingDriver` initializes and writes board-specific hardware.
+- `LightingProcessor` owns all three plus frame storage and is the only hardware
+  writer.
+
+The structure follows RMK's display support. A renderer can be a simple layer
+color function today and a topology-aware compositor later without changing
+the event or driver ownership model.
+
+```rust
+use rmk::lighting::{
+    LightingContext, LightingDriver, LightingProcessor, LightingRenderer,
+};
+
+#[derive(Clone, Copy, Default, Eq, PartialEq)]
+struct Rgb8(u8, u8, u8);
+
+struct LayerColor;
+
+impl LightingRenderer<Rgb8> for LayerColor {
+    fn render(
+        &mut self,
+        context: &LightingContext,
+        frame: &mut [Rgb8],
+    ) -> rmk::lighting::LightingRenderResult {
+        let next = Rgb8(context.effective_layer * 16, 0, 16);
+        let changed = frame.iter().any(|pixel| *pixel != next);
+        frame.fill(next);
+        changed.into()
+    }
+}
+
+// Implement LightingDriver<Rgb8> for a board-specific strip driver, then:
+let mut lighting = LightingProcessor::new(driver, LayerColor, [Rgb8::default(); 16]);
+run_all!(matrix, lighting, keyboard, host_service).await;
+```
+
+The renderer receives key events and `LightAction` commands through `on_event`,
+and authoritative state through `LightingContext`. The context currently
+exposes the effective layer, host LED indicators, and sleep state. Future state
+additions should come from RMK's authoritative state rather than reconstructed
+event history.
+
+The generic pixel type lets a single indicator use `bool`, an addressable strip
+use an RGB type, and a composite driver route a logical frame to multiple
+physical outputs. Drivers retain electrical ordering, encoding, timing, power
+sequencing, and safety limits.
+
+See [`examples/use_rust/custom_lighting`](https://github.com/HaoboGu/rmk/tree/main/examples/use_rust/custom_lighting)
+for one-bit and RGB driver examples.
+
+## Current scope
+
+This first abstraction does not define:
+
+- LED topology or key association;
+- source priorities or composition;
+- built-in effects or animation scheduling;
+- `keyboard.toml` lighting configuration;
+- Rynk, Vial, or persistence integration; or
+- split-lighting synchronization.
+
+Those features can be added after the event, renderer, processor, and driver
+boundaries settle.

--- a/examples/use_rust/custom_lighting/Cargo.toml
+++ b/examples/use_rust/custom_lighting/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "custom_lighting"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+rmk = { path = "../../../rmk", features = ["lighting"], default-features = false }

--- a/examples/use_rust/custom_lighting/src/lib.rs
+++ b/examples/use_rust/custom_lighting/src/lib.rs
@@ -1,0 +1,143 @@
+#![no_std]
+
+//! Minimal custom lighting implementations.
+//!
+//! The same [`LightingProcessor`] works with a one-bit indicator and an RGB
+//! strip. Real keyboard crates implement the small hardware traits below for
+//! their selected HAL or device driver.
+
+use rmk::event::LightingCommand;
+use rmk::lighting::{
+    LightingContext, LightingDriver, LightingEvent, LightingProcessor, LightingRenderResult, LightingRenderer,
+};
+use rmk::types::action::LightAction;
+
+/// The smallest possible lighting hardware: one on/off indicator.
+pub trait IndicatorPin {
+    type Error;
+
+    fn set(&mut self, on: bool) -> Result<(), Self::Error>;
+}
+
+pub struct IndicatorDriver<P>(pub P);
+
+impl<P: IndicatorPin> LightingDriver<bool> for IndicatorDriver<P> {
+    type Error = P::Error;
+
+    async fn init(&mut self) -> Result<(), Self::Error> {
+        self.0.set(false)
+    }
+
+    async fn write(&mut self, frame: &[bool]) -> Result<(), Self::Error> {
+        self.0.set(frame.first().copied().unwrap_or(false))
+    }
+}
+
+/// Illuminate the indicator when Caps Lock is enabled.
+pub struct CapsLockRenderer;
+
+impl LightingRenderer<bool> for CapsLockRenderer {
+    fn render(&mut self, context: &LightingContext, frame: &mut [bool]) -> LightingRenderResult {
+        let next = context.indicators.caps_lock() && !context.sleeping;
+        let changed = frame.first().is_none_or(|current| *current != next);
+        if let Some(pixel) = frame.first_mut() {
+            *pixel = next;
+        }
+        changed.into()
+    }
+}
+
+pub fn caps_lock_indicator<P: IndicatorPin>(
+    pin: P,
+) -> LightingProcessor<IndicatorDriver<P>, CapsLockRenderer, bool, 1> {
+    LightingProcessor::new(IndicatorDriver(pin), CapsLockRenderer, [false])
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Rgb8 {
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
+}
+
+/// Hardware-specific RGB transport supplied by a keyboard crate.
+pub trait RgbStrip {
+    type Error;
+
+    fn init(&mut self) -> impl core::future::Future<Output = Result<(), Self::Error>>;
+    fn write(&mut self, pixels: &[Rgb8]) -> impl core::future::Future<Output = Result<(), Self::Error>>;
+}
+
+pub struct RgbStripDriver<S>(pub S);
+
+impl<S: RgbStrip> LightingDriver<Rgb8> for RgbStripDriver<S> {
+    type Error = S::Error;
+
+    async fn init(&mut self) -> Result<(), Self::Error> {
+        self.0.init().await
+    }
+
+    async fn write(&mut self, frame: &[Rgb8]) -> Result<(), Self::Error> {
+        self.0.write(frame).await
+    }
+}
+
+/// A deliberately simple renderer; a compositor can replace it later without
+/// changing [`RgbStripDriver`] or processor ownership.
+pub struct LayerRenderer {
+    key_pressed: bool,
+    enabled: bool,
+}
+
+impl Default for LayerRenderer {
+    fn default() -> Self {
+        Self {
+            key_pressed: false,
+            enabled: true,
+        }
+    }
+}
+
+impl LightingRenderer<Rgb8> for LayerRenderer {
+    fn on_event(&mut self, event: LightingEvent, _context: &LightingContext) {
+        if let LightingEvent::Keyboard(event) = event {
+            self.key_pressed = event.pressed;
+        }
+        if let LightingEvent::Command(event) = event
+            && let LightingCommand::Action {
+                action: LightAction::RgbTog,
+                pressed: true,
+            } = event.0
+        {
+            self.enabled = !self.enabled;
+        }
+    }
+
+    fn render(&mut self, context: &LightingContext, frame: &mut [Rgb8]) -> LightingRenderResult {
+        let next = if context.sleeping || !self.enabled {
+            Rgb8::default()
+        } else if self.key_pressed {
+            Rgb8 {
+                red: 0x20,
+                green: 0x20,
+                blue: 0x20,
+            }
+        } else {
+            Rgb8 {
+                red: context.effective_layer.saturating_mul(0x10),
+                green: 0,
+                blue: 0x10,
+            }
+        };
+
+        let changed = frame.iter().any(|pixel| *pixel != next);
+        frame.fill(next);
+        changed.into()
+    }
+}
+
+pub fn rgb_strip<S: RgbStrip, const N: usize>(
+    strip: S,
+) -> LightingProcessor<RgbStripDriver<S>, LayerRenderer, Rgb8, N> {
+    LightingProcessor::new(RgbStripDriver(strip), LayerRenderer::default(), [Rgb8::default(); N])
+}

--- a/rmk-config/src/default_config/event_default.toml
+++ b/rmk-config/src/default_config/event_default.toml
@@ -87,6 +87,11 @@ channel_size = 16
 pubs = 1
 subs = 0
 
+[event.lighting_command]
+channel_size = 4
+pubs = 1
+subs = 0
+
 # DFU events
 [event.dfu_status]
 channel_size = 2

--- a/rmk-config/src/default_config/subscriber_default.toml
+++ b/rmk-config/src/default_config/subscriber_default.toml
@@ -40,6 +40,19 @@ events = [
     { name = "sleep_state" },
 ]
 
+# --- Lighting-gated internal subscribers ---
+
+[[subscriber]]
+features = ["lighting"]
+events = [
+    # lighting/mod.rs: LightingProcessor subscribes to these events
+    { name = "keyboard" },
+    { name = "layer_change" },
+    { name = "led_indicator" },
+    { name = "sleep_state" },
+    { name = "lighting_command" },
+]
+
 # --- BLE-gated internal subscribers ---
 
 [[subscriber]]

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -411,6 +411,8 @@ define_event_config!(
     dfu_status,
     // Action events
     action,
+    // Lighting control events
+    lighting_command,
 );
 
 /// Configurations for keyboard layout

--- a/rmk-config/src/resolved/build_constants.rs
+++ b/rmk-config/src/resolved/build_constants.rs
@@ -112,6 +112,7 @@ impl crate::KeyboardTomlConfig {
             clear_peer,
             dfu_status,
             action,
+            lighting_command,
         );
 
         // Auto-bump subscriber counts based on enabled feature flags.
@@ -219,7 +220,24 @@ fn resolve_passkey_enabled(ble: &crate::BleConfig) -> Result<Passkey, String> {
 #[cfg(test)]
 mod tests {
     use super::resolve_passkey_enabled;
-    use crate::{BleConfig, DEFAULT_PASSKEY_ENTRY_TIMEOUT_SECS, MIN_PASSKEY_ENTRY_TIMEOUT_SECS};
+    use crate::{BleConfig, DEFAULT_PASSKEY_ENTRY_TIMEOUT_SECS, KeyboardTomlConfig, MIN_PASSKEY_ENTRY_TIMEOUT_SECS};
+
+    #[test]
+    fn lighting_feature_reserves_processor_subscribers() {
+        let config: KeyboardTomlConfig = toml::from_str("").unwrap();
+        let constants = config.build_constants(&["lighting"]).unwrap();
+
+        for (name, expected) in [
+            ("keyboard", 4),
+            ("layer_change", 2),
+            ("led_indicator", 4),
+            ("sleep_state", 2),
+            ("lighting_command", 1),
+        ] {
+            let event = constants.events.iter().find(|event| event.name == name).unwrap();
+            assert_eq!(event.subs, expected, "subscriber count for {name}");
+        }
+    }
 
     #[test]
     fn validates_passkey_timeout() {

--- a/rmk-types/Cargo.toml
+++ b/rmk-types/Cargo.toml
@@ -47,6 +47,7 @@ host = ["rmk_protocol", "bulk", "_ble", "split"]
 _ble = []
 split = []
 display = []
+lighting = []
 passkey_entry = []
 # DFU firmware update support
 dfu = []

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -178,6 +178,8 @@ std = [
 
 ## Enable display support (traits + processor)
 display = ["dep:embedded-graphics", "rmk-types/display"]
+## Enable event-driven lighting support (traits + processor)
+lighting = ["rmk-types/lighting"]
 ## Enable SSD1306 OLED driver
 ssd1306 = ["display", "dep:ssd1306", "dep:display-interface", "dep:display-interface-i2c"]
 ## Enable OLED drivers via oled_async (SH1106, SH1107, SH1108, SSD1309)

--- a/rmk/src/event/lighting.rs
+++ b/rmk/src/event/lighting.rs
@@ -1,0 +1,36 @@
+//! Lighting control events.
+
+use rmk_macro::event;
+use rmk_types::action::LightAction;
+
+/// A command for the active lighting controller.
+///
+/// Key actions are the first producer. Future RMK versions can add commands for
+/// host protocol adapters without making those adapters part of rendering or
+/// hardware implementations.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum LightingCommand {
+    /// A resolved RMK light action and its key edge.
+    Action { action: LightAction, pressed: bool },
+}
+
+/// A serialized mutation request for the active lighting controller.
+#[event(
+    channel_size = crate::LIGHTING_COMMAND_EVENT_CHANNEL_SIZE,
+    pubs = crate::LIGHTING_COMMAND_EVENT_PUB_SIZE,
+    subs = crate::LIGHTING_COMMAND_EVENT_SUB_SIZE
+)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct LightingCommandEvent(pub LightingCommand);
+
+impl LightingCommandEvent {
+    /// Create a command from a resolved keymap light action.
+    pub fn from_action(action: LightAction, pressed: bool) -> Self {
+        Self(LightingCommand::Action { action, pressed })
+    }
+}
+
+impl_payload_wrapper!(LightingCommandEvent, LightingCommand);

--- a/rmk/src/event/mod.rs
+++ b/rmk/src/event/mod.rs
@@ -50,6 +50,8 @@ mod connection;
 #[cfg(feature = "dfu")]
 mod dfu;
 mod input;
+#[cfg(feature = "lighting")]
+mod lighting;
 #[cfg(feature = "split")]
 mod split;
 mod state;
@@ -63,6 +65,8 @@ pub use input::{
     Axis, AxisEvent, AxisValType, KeyPos, KeyboardEvent, KeyboardEventPos, ModifierEvent, PointingEvent,
     PointingProcessorEvent, PointingSetCpiEvent, RotaryEncoderPos,
 };
+#[cfg(feature = "lighting")]
+pub use lighting::{LightingCommand, LightingCommandEvent};
 #[cfg(feature = "split")]
 pub use split::{CentralConnectedEvent, PeripheralConnectedEvent};
 #[cfg(all(feature = "split", feature = "_ble"))]

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1324,7 +1324,16 @@ impl<'a> Keyboard<'a> {
                 self.update_osl(event);
             }
             Action::OneShotKey(_k) => warn!("One-shot key is not supported: {:?}", action),
-            Action::Light(_light_action) => warn!("Light controll is not supported"),
+            Action::Light(light_action) => {
+                #[cfg(feature = "lighting")]
+                publish_event_async(crate::event::LightingCommandEvent::from_action(
+                    light_action,
+                    event.pressed,
+                ))
+                .await;
+                #[cfg(not(feature = "lighting"))]
+                warn!("Light control is not supported: {:?}", light_action);
+            }
             Action::KeyboardControl(c) => self.process_action_keyboard_control(c, event).await,
             Action::Special(special_key) => self.process_action_special(special_key, event).await,
             Action::User(id) => self.process_user(id, event).await,

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -82,6 +82,8 @@ pub mod keyboard_macros;
 pub mod keymap;
 pub mod layout_macro;
 pub mod light;
+#[cfg(feature = "lighting")]
+pub mod lighting;
 pub mod matrix;
 pub mod processor;
 #[cfg(feature = "split")]

--- a/rmk/src/lighting/mod.rs
+++ b/rmk/src/lighting/mod.rs
@@ -1,0 +1,474 @@
+//! Event-driven lighting support.
+//!
+//! This module provides the integration boundary between RMK state and
+//! board-specific lighting hardware. [`LightingProcessor`] owns the current
+//! [`LightingContext`], a replaceable [`LightingRenderer`], a caller-sized
+//! frame, and a [`LightingDriver`]. It is the only component that writes the
+//! driver.
+//!
+//! Topology, source composition, effect catalogs, and animation scheduling are
+//! intentionally outside this initial abstraction. They can be implemented by
+//! a renderer without changing event or hardware ownership.
+
+use rmk_macro::processor;
+use rmk_types::led_indicator::LedIndicator;
+
+use crate::core_traits::Runnable;
+use crate::event::{KeyboardEvent, LayerChangeEvent, LedIndicatorEvent, LightingCommandEvent, SleepStateEvent};
+use crate::processor::Processor;
+
+/// Current RMK state made available to lighting renderers.
+///
+/// This context contains state with an authoritative value. Transient input is
+/// delivered separately through [`LightingRenderer::on_event`]. A richer layer
+/// snapshot can extend this type once RMK exposes the default and complete
+/// active-layer state to processors.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct LightingContext {
+    /// Current effective (topmost) layer.
+    pub effective_layer: u8,
+    /// Host keyboard LED indicators such as Caps Lock and Num Lock.
+    pub indicators: LedIndicator,
+    /// Whether RMK has entered its sleep state.
+    pub sleeping: bool,
+}
+
+impl Default for LightingContext {
+    fn default() -> Self {
+        Self {
+            effective_layer: 0,
+            indicators: LedIndicator::new(),
+            sleeping: false,
+        }
+    }
+}
+
+/// An RMK event delivered to a lighting renderer.
+///
+/// State fields in [`LightingContext`] are updated before this event is
+/// delivered. The enum is non-exhaustive so RMK can expose additional relevant
+/// events without forcing renderers to handle them immediately.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum LightingEvent {
+    /// A key or encoder input event.
+    Keyboard(KeyboardEvent),
+    /// The effective layer changed.
+    LayerChanged(LayerChangeEvent),
+    /// Host keyboard LED indicators changed.
+    IndicatorsChanged(LedIndicatorEvent),
+    /// RMK entered or left sleep.
+    SleepChanged(SleepStateEvent),
+    /// A keymap or host control command.
+    Command(LightingCommandEvent),
+}
+
+/// Outcome of one renderer pass.
+///
+/// This type intentionally hides its representation so future versions can
+/// add a next-render deadline without changing [`LightingRenderer`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct LightingRenderResult {
+    changed: bool,
+}
+
+impl LightingRenderResult {
+    /// The rendered frame may differ from the previously completed frame.
+    pub const CHANGED: Self = Self { changed: true };
+
+    /// The rendered frame is known to be unchanged.
+    pub const UNCHANGED: Self = Self { changed: false };
+
+    /// Whether the rendered frame may have changed.
+    pub const fn may_have_changed(self) -> bool {
+        self.changed
+    }
+}
+
+impl From<bool> for LightingRenderResult {
+    fn from(changed: bool) -> Self {
+        Self { changed }
+    }
+}
+
+/// Board- or application-provided lighting behavior.
+///
+/// A renderer writes logical pixels into the provided frame and reports
+/// whether the completed frame may have changed. Reporting a possible change
+/// conservatively is always correct; reporting no change allows the processor
+/// to skip a hardware write.
+///
+/// Renderers may later contain topology, compositors, or effect engines. They
+/// do not initialize hardware or write a driver directly.
+pub trait LightingRenderer<P> {
+    /// Observe an event before the resulting frame is rendered.
+    ///
+    /// The default implementation is suitable for renderers that depend only
+    /// on current state in [`LightingContext`].
+    fn on_event(&mut self, _event: LightingEvent, _context: &LightingContext) {}
+
+    /// Update `frame` from the current context.
+    ///
+    /// Report whether the frame may have changed since the previous call.
+    fn render(&mut self, context: &LightingContext, frame: &mut [P]) -> LightingRenderResult;
+}
+
+/// Async output boundary for board-specific lighting hardware.
+///
+/// `P` is deliberately generic: a single GPIO-controlled LED may use `bool`,
+/// while an addressable strip may use a board- or ecosystem-specific RGB type.
+/// A driver can route one logical frame to multiple physical outputs.
+pub trait LightingDriver<P> {
+    /// Hardware initialization or write error.
+    type Error;
+
+    /// Initialize the lighting hardware.
+    async fn init(&mut self) -> Result<(), Self::Error>;
+
+    /// Apply a completed logical frame to the hardware.
+    async fn write(&mut self, frame: &[P]) -> Result<(), Self::Error>;
+}
+
+/// Owns event-derived state, rendering, frame storage, and hardware writes.
+///
+/// The frame capacity is selected by the board at compile time. The processor
+/// performs an initial write when it starts, then writes only when the renderer
+/// reports a possible change or a previous driver write remains pending.
+#[processor(subscribe = [KeyboardEvent, LayerChangeEvent, LedIndicatorEvent, SleepStateEvent, LightingCommandEvent])]
+#[::rmk::macros::runnable_generated]
+pub struct LightingProcessor<D, R, P, const N: usize>
+where
+    D: LightingDriver<P>,
+    R: LightingRenderer<P>,
+    P: Copy,
+{
+    driver: D,
+    renderer: R,
+    context: LightingContext,
+    frame: [P; N],
+    initialized: bool,
+    pending_write: bool,
+}
+
+impl<D, R, P, const N: usize> LightingProcessor<D, R, P, N>
+where
+    D: LightingDriver<P>,
+    R: LightingRenderer<P>,
+    P: Copy,
+{
+    /// Create a processor with caller-provided initial frame storage.
+    ///
+    /// Passing the frame as an array lets Rust infer the processor's capacity
+    /// while keeping storage explicit at the board construction site.
+    pub fn new(driver: D, renderer: R, frame: [P; N]) -> Self {
+        Self {
+            driver,
+            renderer,
+            context: LightingContext::default(),
+            frame,
+            initialized: false,
+            // Hardware state is unknown until the first successful write.
+            pending_write: true,
+        }
+    }
+
+    /// Current event-derived lighting state.
+    pub fn context(&self) -> &LightingContext {
+        &self.context
+    }
+
+    /// Last logical frame produced by the renderer.
+    pub fn frame(&self) -> &[P; N] {
+        &self.frame
+    }
+
+    /// Mutably access application rendering state.
+    ///
+    /// Call [`refresh`](Self::refresh) after making a change that should become
+    /// visible. The processor retains sole ownership of hardware writes.
+    pub fn renderer_mut(&mut self) -> &mut R {
+        &mut self.renderer
+    }
+
+    /// Render current state and flush pending output.
+    ///
+    /// Returns `Ok(true)` when the driver was written. Initialization and write
+    /// failures remain pending and are retried on the next refresh or event.
+    pub async fn refresh(&mut self) -> Result<bool, D::Error> {
+        if !self.initialized {
+            self.driver.init().await?;
+            self.initialized = true;
+        }
+
+        if self.renderer.render(&self.context, &mut self.frame).may_have_changed() {
+            self.pending_write = true;
+        }
+
+        if !self.pending_write {
+            return Ok(false);
+        }
+
+        self.driver.write(&self.frame).await?;
+        self.pending_write = false;
+        Ok(true)
+    }
+
+    async fn handle_event(&mut self, event: LightingEvent) {
+        match event {
+            LightingEvent::Keyboard(_) => {}
+            LightingEvent::LayerChanged(event) => {
+                self.context.effective_layer = event.0;
+            }
+            LightingEvent::IndicatorsChanged(event) => {
+                self.context.indicators = event.0;
+            }
+            LightingEvent::SleepChanged(event) => {
+                self.context.sleeping = event.0;
+            }
+            LightingEvent::Command(_) => {}
+        }
+
+        self.renderer.on_event(event, &self.context);
+        // A failed write remains pending. The next event or explicit refresh
+        // retries it without requiring a polling loop.
+        if self.refresh().await.is_err() {
+            error!("Lighting driver update failed");
+        }
+    }
+
+    async fn on_keyboard_event(&mut self, event: KeyboardEvent) {
+        self.handle_event(LightingEvent::Keyboard(event)).await;
+    }
+
+    async fn on_layer_change_event(&mut self, event: LayerChangeEvent) {
+        self.handle_event(LightingEvent::LayerChanged(event)).await;
+    }
+
+    async fn on_led_indicator_event(&mut self, event: LedIndicatorEvent) {
+        self.handle_event(LightingEvent::IndicatorsChanged(event)).await;
+    }
+
+    async fn on_sleep_state_event(&mut self, event: SleepStateEvent) {
+        self.handle_event(LightingEvent::SleepChanged(event)).await;
+    }
+
+    async fn on_lighting_command_event(&mut self, event: LightingCommandEvent) {
+        self.handle_event(LightingEvent::Command(event)).await;
+    }
+}
+
+impl<D, R, P, const N: usize> Runnable for LightingProcessor<D, R, P, N>
+where
+    D: LightingDriver<P>,
+    R: LightingRenderer<P>,
+    P: Copy,
+{
+    async fn run(&mut self) -> ! {
+        if self.refresh().await.is_err() {
+            error!("Initial lighting driver update failed");
+        }
+        self.process_loop().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rmk_types::action::LightAction;
+
+    use super::*;
+    use crate::event::{KeyPos, KeyboardEvent, LightingCommand, LightingCommandEvent};
+    use crate::test_support::test_block_on as block_on;
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum FakeError {
+        Init,
+        Write,
+    }
+
+    struct FakeDriver<P: Copy, const N: usize> {
+        init_calls: usize,
+        write_calls: usize,
+        fail_init_once: bool,
+        fail_write_once: bool,
+        last_frame: [P; N],
+    }
+
+    impl<P: Copy, const N: usize> FakeDriver<P, N> {
+        fn new(initial: P) -> Self {
+            Self {
+                init_calls: 0,
+                write_calls: 0,
+                fail_init_once: false,
+                fail_write_once: false,
+                last_frame: [initial; N],
+            }
+        }
+    }
+
+    impl<P: Copy, const N: usize> LightingDriver<P> for FakeDriver<P, N> {
+        type Error = FakeError;
+
+        async fn init(&mut self) -> Result<(), Self::Error> {
+            self.init_calls += 1;
+            if core::mem::take(&mut self.fail_init_once) {
+                Err(FakeError::Init)
+            } else {
+                Ok(())
+            }
+        }
+
+        async fn write(&mut self, frame: &[P]) -> Result<(), Self::Error> {
+            self.write_calls += 1;
+            if core::mem::take(&mut self.fail_write_once) {
+                return Err(FakeError::Write);
+            }
+            self.last_frame.copy_from_slice(frame);
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct StateRenderer {
+        events: usize,
+        last_event: Option<LightingEvent>,
+    }
+
+    impl LightingRenderer<u8> for StateRenderer {
+        fn on_event(&mut self, event: LightingEvent, _context: &LightingContext) {
+            self.events += 1;
+            self.last_event = Some(event);
+        }
+
+        fn render(&mut self, context: &LightingContext, frame: &mut [u8]) -> LightingRenderResult {
+            let next = if context.sleeping {
+                0
+            } else if context.indicators.caps_lock() {
+                0x80
+            } else {
+                context.effective_layer
+            };
+            let changed = frame.iter().any(|pixel| *pixel != next);
+            frame.fill(next);
+            changed.into()
+        }
+    }
+
+    #[test]
+    fn initializes_and_writes_the_first_frame_once() {
+        let driver = FakeDriver::<u8, 3>::new(0xff);
+        let mut processor = LightingProcessor::new(driver, StateRenderer::default(), [0; 3]);
+
+        assert_eq!(block_on(processor.refresh()), Ok(true));
+        assert_eq!(processor.driver.init_calls, 1);
+        assert_eq!(processor.driver.write_calls, 1);
+        assert_eq!(processor.driver.last_frame, [0; 3]);
+
+        assert_eq!(block_on(processor.refresh()), Ok(false));
+        assert_eq!(processor.driver.init_calls, 1);
+        assert_eq!(processor.driver.write_calls, 1);
+    }
+
+    #[test]
+    fn updates_context_before_notifying_and_rendering() {
+        let driver = FakeDriver::<u8, 2>::new(0);
+        let mut processor = LightingProcessor::new(driver, StateRenderer::default(), [0; 2]);
+        block_on(processor.refresh()).unwrap();
+
+        block_on(processor.on_layer_change_event(LayerChangeEvent::new(3)));
+        assert_eq!(processor.context.effective_layer, 3);
+        assert_eq!(processor.frame, [3; 2]);
+
+        block_on(processor.on_led_indicator_event(LedIndicatorEvent::new(LedIndicator::CAPS_LOCK)));
+        assert_eq!(processor.context.indicators, LedIndicator::CAPS_LOCK);
+        assert_eq!(processor.frame, [0x80; 2]);
+
+        block_on(processor.on_sleep_state_event(SleepStateEvent::new(true)));
+        assert!(processor.context.sleeping);
+        assert_eq!(processor.frame, [0; 2]);
+        assert_eq!(processor.renderer.events, 3);
+        assert_eq!(processor.driver.write_calls, 4);
+    }
+
+    #[test]
+    fn delivers_transient_keyboard_events_without_polling() {
+        struct ReactiveRenderer {
+            pressed: bool,
+        }
+
+        impl LightingRenderer<bool> for ReactiveRenderer {
+            fn on_event(&mut self, event: LightingEvent, _context: &LightingContext) {
+                if let LightingEvent::Keyboard(event) = event {
+                    self.pressed = event.pressed;
+                }
+            }
+
+            fn render(&mut self, _context: &LightingContext, frame: &mut [bool]) -> LightingRenderResult {
+                let changed = frame[0] != self.pressed;
+                frame[0] = self.pressed;
+                changed.into()
+            }
+        }
+
+        let driver = FakeDriver::<bool, 1>::new(false);
+        let renderer = ReactiveRenderer { pressed: false };
+        let mut processor = LightingProcessor::new(driver, renderer, [false; 1]);
+        block_on(processor.refresh()).unwrap();
+
+        block_on(processor.on_keyboard_event(KeyboardEvent::key(1, 2, true)));
+        assert_eq!(processor.frame, [true]);
+        block_on(processor.on_keyboard_event(KeyboardEvent::key(1, 2, false)));
+        assert_eq!(processor.frame, [false]);
+        assert_eq!(processor.driver.write_calls, 3);
+    }
+
+    #[test]
+    fn retries_initialization_and_failed_writes() {
+        let mut driver = FakeDriver::<u8, 1>::new(0);
+        driver.fail_init_once = true;
+        let mut processor = LightingProcessor::new(driver, StateRenderer::default(), [0; 1]);
+
+        assert_eq!(block_on(processor.refresh()), Err(FakeError::Init));
+        assert_eq!(block_on(processor.refresh()), Ok(true));
+        assert_eq!(processor.driver.init_calls, 2);
+
+        processor.driver.fail_write_once = true;
+        block_on(processor.on_layer_change_event(LayerChangeEvent::new(2)));
+        assert_eq!(processor.driver.write_calls, 2);
+        assert_eq!(processor.driver.last_frame, [0]);
+
+        assert_eq!(block_on(processor.refresh()), Ok(true));
+        assert_eq!(processor.driver.write_calls, 3);
+        assert_eq!(processor.driver.last_frame, [2]);
+    }
+
+    #[test]
+    fn event_type_preserves_keyboard_position() {
+        let event = KeyboardEvent::key(4, 5, true);
+        let wrapped = LightingEvent::Keyboard(event);
+        assert_eq!(wrapped, LightingEvent::Keyboard(event));
+        assert_eq!(
+            event.pos,
+            crate::event::KeyboardEventPos::Key(KeyPos { row: 4, col: 5 })
+        );
+    }
+
+    #[test]
+    fn delivers_light_actions_through_the_command_boundary() {
+        let driver = FakeDriver::<u8, 1>::new(0);
+        let mut processor = LightingProcessor::new(driver, StateRenderer::default(), [0; 1]);
+        block_on(processor.refresh()).unwrap();
+
+        let event = LightingCommandEvent::from_action(LightAction::RgbTog, true);
+        block_on(processor.on_lighting_command_event(event));
+
+        assert_eq!(
+            processor.renderer.last_event,
+            Some(LightingEvent::Command(LightingCommandEvent(LightingCommand::Action {
+                action: LightAction::RgbTog,
+                pressed: true,
+            })))
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add an optional `lighting` feature with `LightingContext`, `LightingRenderer`, `LightingDriver`, and `LightingProcessor`
- monitor key, layer, host-indicator, and sleep events, and route resolved `LightAction`s through a dedicated `LightingCommandEvent`
- demonstrate both a one-bit indicator and an RGB strip in a `no_std` Rust example
- add feature-aware event subscriber sizing, tests, CI coverage, and documentation

## Why

This is a focused implementation of the two foundational concerns identified in #979: processing RMK events and supporting different lighting hardware.

The processor is the single owner of event-derived state, rendering state, frame storage, and hardware writes. The generic pixel and driver contracts cover simple GPIO indicators, addressable RGB chains, and composite physical outputs without coupling RMK to a HAL or LED protocol.

Resolved lighting key actions now enter the same owner through a typed command event. The command enum is non-exhaustive so later RMK versions can add protocol-facing commands, while Rynk or Vial remain adapters rather than owners of lighting state. Operations that require request/response acknowledgement or readback remain future protocol-service work.

This does not claim that topology or composition is unimportant. It deliberately keeps rendering replaceable: a geometry-aware compositor can implement `LightingRenderer` later without changing event ownership or the hardware boundary. `LightingContext` is non-exhaustive, and `LightingRenderResult` has a private representation so richer layer state and render deadlines can be added compatibly.

## Deliberate non-goals

- topology and key/LED association
- source composition and priority
- built-in effects and animation scheduling
- `keyboard.toml`, Rynk, Vial, persistence, or split-lighting integration
- concrete LED protocol drivers

The processor currently serializes rendering and driver writes inline, matching `DisplayProcessor`. A separate/coalescing output path can be considered with deadline work or concrete driver latency data.

## Validation

- `cargo check --manifest-path rmk/Cargo.toml --no-default-features --features lighting`
- `cargo clippy --manifest-path rmk/Cargo.toml --no-default-features --features lighting -- -D warnings`
- 521 RMK tests with `--no-default-features --features lighting`
- `thumbv7em-none-eabihf` no-default-feature lighting check
- custom lighting example release build with `RUSTFLAGS="-D warnings"`
- `rmk-config` lighting subscriber-count test
- nightly rustfmt check
- Prettier check and full documentation build
