### PR TITLE
Expose custom host and runnable macro hooks

### DIFF
--- a/rmk-macro/src/codegen/orchestrator.rs
+++ b/rmk-macro/src/codegen/orchestrator.rs
@@ -470,11 +470,12 @@ fn expand_main(
             // Set all keyboard config
             #rmk_config
 
-            // Initialize the registered processors
-            #registered_processor_initializers
-
             // Initialize the storage and keymap, as `storage` and `keymap`
             #keymap_and_storage
+
+            // Initialize registered processors after the keymap so custom
+            // processor constructors can use authoritative keymap state.
+            #registered_processor_initializers
 
             // Initialize the matrix + keyboard, as `matrix` and `keyboard`
             #matrix_and_keyboard

--- a/rmk-macro/src/codegen/orchestrator.rs
+++ b/rmk-macro/src/codegen/orchestrator.rs
@@ -1,3 +1,4 @@
+use darling::FromMeta;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use rmk_config::DebouncerType;
@@ -23,6 +24,7 @@ use super::keyboard_config::{
 };
 use super::keymap::expand_default_keymap;
 use super::matrix::{expand_bootmagic_check, expand_matrix_config};
+use super::override_helper::Overwritten;
 use super::registered_processor::expand_registered_processor_init;
 use super::split::central::expand_split_central_config;
 use super::watchdog::expand_watchdog_init;
@@ -350,9 +352,29 @@ fn expand_main(
     };
 
     let host_service_init = if host.rynk_enabled || host.vial_enabled {
-        quote! {
-            let host_service = ::rmk::host::HostService::new(&keymap, &rmk_config);
-        }
+        item_mod
+            .content
+            .as_ref()
+            .and_then(|(_, items)| {
+                items.iter().find_map(|item| {
+                    let syn::Item::Fn(item_fn) = item else {
+                        return None;
+                    };
+                    item_fn.attrs.iter().find_map(|attr| {
+                        (Overwritten::from_meta(&attr.meta).ok() == Some(Overwritten::HostService))
+                            .then_some(())
+                    })?;
+                    let body = &item_fn.block;
+                    Some(quote! {
+                        let host_service = #body;
+                    })
+                })
+            })
+            .unwrap_or_else(|| {
+                quote! {
+                    let host_service = ::rmk::host::HostService::new(&keymap, &rmk_config);
+                }
+            })
     } else {
         quote! {}
     };

--- a/rmk-macro/src/codegen/override_helper.rs
+++ b/rmk-macro/src/codegen/override_helper.rs
@@ -1,10 +1,11 @@
 use darling::FromMeta;
 
 /// List of functions that can be overwritten
-#[derive(Debug, Clone, Copy, FromMeta)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, FromMeta)]
 pub enum Overwritten {
     Usb,
     ChipConfig,
     ChipInit,
+    HostService,
     Entry,
 }

--- a/rmk-macro/src/codegen/registered_processor.rs
+++ b/rmk-macro/src/codegen/registered_processor.rs
@@ -40,31 +40,48 @@ pub(crate) fn expand_registered_processor_init(
             };
 
             let (custom_init, custom_exec) = expand_custom_processor(item_fn);
-            let mut mode: Option<bool> = None; // Some(true) = event, Some(false) = poll
+            enum Mode {
+                Event,
+                Poll,
+                Runnable,
+            }
+            let mut mode: Option<Mode> = None;
 
             attr.parse_nested_meta(|meta| {
                 let is_event = meta.path.is_ident("event");
                 let is_poll = meta.path.is_ident("poll");
+                let is_runnable = meta.path.is_ident("runnable");
 
-                if !is_event && !is_poll {
-                    return Err(meta.error("expected `event` or `poll`"));
+                if !is_event && !is_poll && !is_runnable {
+                    return Err(meta.error("expected `event`, `poll`, or `runnable`"));
                 }
                 if mode.is_some() {
                     return Err(meta.error("cannot specify multiple modes"));
                 }
-                mode = Some(is_event);
+                mode = Some(if is_event {
+                    Mode::Event
+                } else if is_poll {
+                    Mode::Poll
+                } else {
+                    Mode::Runnable
+                });
                 Ok(())
             })
             .unwrap_or_else(|e| panic!("#[register_processor] {e}"));
 
             let executor = match mode {
-                Some(true) => quote! {
+                Some(Mode::Event) => quote! {
                     async { use ::rmk::processor::Processor; #custom_exec.process_loop().await }
                 },
-                Some(false) => quote! {
+                Some(Mode::Poll) => quote! {
                     async { use ::rmk::processor::PollingProcessor; #custom_exec.polling_loop().await }
                 },
-                None => panic!("#[register_processor] requires `event` or `poll` argument"),
+                Some(Mode::Runnable) => quote! {
+                    async { use ::rmk::core_traits::Runnable; #custom_exec.run().await }
+                },
+                None => {
+                    panic!("#[register_processor] requires `event`, `poll`, or `runnable` argument")
+                }
             };
 
             initializers.extend(custom_init);


### PR DESCRIPTION
## What

- allow `#[Overwritten(HostService)]` to construct an application-defined host service
- add `#[register_processor(runnable)]` for `Runnable` components
- initialize registered processors after keymap and storage setup so constructors can use authoritative keymap state

## Why

Applications that compose RMK services need a supported macro-level extension point rather than copying the generated orchestrator. This keeps custom services and long-running processors inside the normal `#[rmk_keyboard]` lifecycle.

## Impact

Existing generated code is unchanged unless the new annotations are used. Event and polling processor modes retain their current behavior.

## Checks

- repository formatter
- full RMK feature-matrix tests
- Rynk host tests, doctests, WASM checks/package typecheck, and clippy