### PR TITLE
Add application-defined Rynk build information

### DIFF
--- a/docs/docs/main/docs/development/rynk_protocol.md
+++ b/docs/docs/main/docs/development/rynk_protocol.md
@@ -4,7 +4,7 @@
 
 # Rynk Protocol Reference
 
-Current protocol version: **0.1**.
+Current protocol version: **0.2**.
 
 Every transport (USB CDC, BLE GATT, BLE HID) carries the same frame — a 5-byte header plus a [postcard](https://docs.rs/postcard)-encoded payload:
 
@@ -35,6 +35,7 @@ Which commands a firmware answers depends on the RMK Cargo features it was built
 | `0x0008` | `Lock`                | `()`                   | `()`                    |         | Relock immediately.                                                          |
 | `0x0009` | `GetLayout`           | `u32`                  | `LayoutChunk`           |         | Get layout blob chunk. `u32` is the byte offset.                             |
 | `0x000A` | `GetDeviceInfo`       | `()`                   | `DeviceInfo`            |         | Identity strings and USB ids; feature gating stays in `GetCapabilities`.     |
+| `0x000B` | `GetBuildInfo`        | `()`                   | `BuildInfo`             |         | Application-defined diagnostic build label; never used for compatibility.    |
 | `0x0101` | `GetKeyAction`        | `KeyPosition`          | `KeyAction`             |         |                                                                              |
 | `0x0102` | `SetKeyAction`        | `SetKeyRequest`        | `()`                    |         |                                                                              |
 | `0x0103` | `GetDefaultLayer`     | `()`                   | `u8`                    |         |                                                                              |

--- a/rmk-types/src/protocol/rynk/command.rs
+++ b/rmk-types/src/protocol/rynk/command.rs
@@ -13,11 +13,11 @@ use postcard::experimental::max_size::MaxSize;
 use super::endpoint::{Endpoint, Topic};
 use super::message::RynkMessage;
 use super::{
-    BehaviorConfig, DeviceCapabilities, DeviceInfo, GetComboBulkRequest, GetComboBulkResponse, GetEncoderRequest,
-    GetKeymapBulkRequest, GetKeymapBulkResponse, GetMacroRequest, GetMorseBulkRequest, GetMorseBulkResponse,
-    KeyPosition, LayoutChunk, LockStatus, MacroData, MatrixState, ProtocolVersion, RynkError, SetComboBulkRequest,
-    SetComboRequest, SetEncoderRequest, SetForkRequest, SetKeyRequest, SetKeymapBulkRequest, SetMacroRequest,
-    SetMorseBulkRequest, SetMorseRequest, StorageResetMode,
+    BehaviorConfig, BuildInfo, DeviceCapabilities, DeviceInfo, GetComboBulkRequest, GetComboBulkResponse,
+    GetEncoderRequest, GetKeymapBulkRequest, GetKeymapBulkResponse, GetMacroRequest, GetMorseBulkRequest,
+    GetMorseBulkResponse, KeyPosition, LayoutChunk, LockStatus, MacroData, MatrixState, ProtocolVersion, RynkError,
+    SetComboBulkRequest, SetComboRequest, SetEncoderRequest, SetForkRequest, SetKeyRequest, SetKeymapBulkRequest,
+    SetMacroRequest, SetMorseBulkRequest, SetMorseRequest, StorageResetMode,
 };
 use crate::action::{EncoderAction, KeyAction};
 #[cfg(feature = "_ble")]
@@ -289,6 +289,8 @@ endpoints! {
     GetLayout = 0x0009: u32 => LayoutChunk;
     /// Identity strings and USB ids; feature gating stays in `GetCapabilities`.
     GetDeviceInfo = 0x000A: () => DeviceInfo;
+    /// Application-defined diagnostic build label; never used for compatibility.
+    GetBuildInfo = 0x000B: () => BuildInfo;
 
     // Keymap (0x01xx) — includes encoder.
     GetKeyAction = 0x0101: KeyPosition => KeyAction;

--- a/rmk-types/src/protocol/rynk/payload/system.rs
+++ b/rmk-types/src/protocol/rynk/payload/system.rs
@@ -9,6 +9,9 @@ use serde::{Deserialize, Serialize};
 /// Maximum byte length of each `DeviceInfo` string field.
 pub const DEVICE_INFO_STRING_SIZE: usize = 32;
 
+/// Maximum byte length of the application-defined build label.
+pub const BUILD_INFO_STRING_SIZE: usize = 128;
+
 /// Protocol version advertised during the connection handshake.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, MaxSize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
@@ -20,8 +23,27 @@ pub struct ProtocolVersion {
 
 impl ProtocolVersion {
     /// Current protocol version for this firmware release.
-    /// Now the protocol is still being developed, so the version is v0.1
-    pub const CURRENT: Self = Self { major: 0, minor: 1 };
+    /// The protocol is still under development; build-info discovery was
+    /// added in v0.2.
+    pub const CURRENT: Self = Self { major: 0, minor: 2 };
+}
+
+/// Human-readable identity of the firmware build.
+///
+/// Unlike [`ProtocolVersion`], this label is deliberately application-defined:
+/// it is for diagnostics and display, never compatibility decisions. RMK
+/// supplies an RMK-only default and downstream firmware may replace it with a
+/// label containing its own package, source revision, or configuration name.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+pub struct BuildInfo {
+    #[cfg_attr(feature = "wasm", tsify(type = "string"))]
+    pub label: String<BUILD_INFO_STRING_SIZE>,
+}
+
+impl MaxSize for BuildInfo {
+    const POSTCARD_MAX_SIZE: usize = crate::heapless_vec_max_size::<u8, BUILD_INFO_STRING_SIZE>();
 }
 
 /// Device capabilities discovered during the connection handshake.
@@ -236,6 +258,15 @@ mod tests {
             product_name: full.clone(),
             serial_number: full,
         };
+        round_trip(&info);
+        assert_max_size_bound(&info);
+    }
+
+    #[test]
+    fn round_trip_build_info() {
+        let full: String<BUILD_INFO_STRING_SIZE> =
+            String::try_from("x".repeat(BUILD_INFO_STRING_SIZE).as_str()).unwrap();
+        let info = BuildInfo { label: full };
         round_trip(&info);
         assert_max_size_bound(&info);
     }

--- a/rmk-types/src/protocol/rynk/snapshots/wire_frames.snap
+++ b/rmk-types/src/protocol/rynk/snapshots/wire_frames.snap
@@ -12,6 +12,8 @@ BootloaderJump request ()                                               04 00 01
 ConnectionChange topic ConnectionStatus{Configured,{1,Adv},Ble}         03 80 00 04 00 02 01 00 01
 GetBehaviorConfig reply Ok(BehaviorConfig{50,500,200,20})               01 06 01 07 00 00 32 f4 03 c8 01 14
 GetBehaviorConfig request ()                                            01 06 01 00 00
+GetBuildInfo reply Ok(BuildInfo{my-firmware..})                         0b 00 01 21 00 00 1f 6d 79 2d 66 69 72 6d 77 61 72 65 20 76 34 2e 35 2e 36 20 2f 20 52 4d 4b 20 76 31 2e 32 2e 33
+GetBuildInfo request ()                                                 0b 00 01 00 00
 GetCapabilities reply Ok(DeviceCapabilities{1..16})                     02 00 01 16 00 00 01 02 03 04 05 06 07 08 09 0a 01 00 01 0b 00 0c 0d 0e 0f 10 01
 GetCapabilities request ()                                              02 00 01 00 00
 GetCombo reply Ok(Combo{[Single(A)],Morse(1),L2})                       01 03 01 0a 00 00 01 02 01 00 04 05 01 01 02
@@ -44,7 +46,7 @@ GetMorse reply Ok(Morse{TAP->Key(A)})                                   01 04 01
 GetMorse request 0                                                      01 04 01 01 00 00
 GetSleepState reply Ok(true)                                            06 08 01 02 00 00 01
 GetSleepState request ()                                                06 08 01 00 00
-GetVersion reply Ok(CURRENT)                                            01 00 01 03 00 00 00 01
+GetVersion reply Ok(CURRENT)                                            01 00 01 03 00 00 00 02
 GetVersion request ()                                                   01 00 01 00 00
 GetWpm reply Ok(42)                                                     05 08 01 02 00 00 2a
 GetWpm request ()                                                       05 08 01 00 00

--- a/rmk-types/src/protocol/rynk/snapshots/wire_values.snap
+++ b/rmk-types/src/protocol/rynk/snapshots/wire_values.snap
@@ -33,6 +33,7 @@ BleState::Advertising                     00
 BleState::Connected                       01
 BleState::Inactive                        02
 BleStatus{2,Connected}                    02 01
+BuildInfo{my-firmware..}                  1f 6d 79 2d 66 69 72 6d 77 61 72 65 20 76 34 2e 35 2e 36 20 2f 20 52 4d 4b 20 76 31 2e 32 2e 33
 ChargeState::Charging                     00
 ChargeState::Discharging                  01
 ChargeState::Unknown                      02
@@ -64,7 +65,7 @@ ModifierCombination(LCtrl|RGui)           81
 MorseProfile(Normal,200,150)              c8 81 b0 89 0c
 Morse{TAP->Key(A)}                        00 01 02 01 00 04
 MouseButtons(B1|B8)                       81
-ProtocolVersion::CURRENT                  00 01
+ProtocolVersion::CURRENT                  00 02
 ProtocolVersion{1,0}                      01 00
 Result<(),RynkError>::Err(StorageFault)   01 02
 Result<(),RynkError>::Ok                  00

--- a/rmk-types/src/protocol/rynk/tests.rs
+++ b/rmk-types/src/protocol/rynk/tests.rs
@@ -206,6 +206,7 @@ struct Exemplars {
     matrix: MatrixState,
     capabilities: DeviceCapabilities,
     device_info: DeviceInfo,
+    build_info: BuildInfo,
     behavior: BehaviorConfig,
     connection: ConnectionStatus,
     state_bits: StateBits,
@@ -257,6 +258,9 @@ fn exemplars() -> Exemplars {
         manufacturer: heapless::String::try_from("RMK").unwrap(),
         product_name: heapless::String::try_from("RMK Keyboard").unwrap(),
         serial_number: heapless::String::try_from("rynk:0001").unwrap(),
+    };
+    let build_info = BuildInfo {
+        label: heapless::String::try_from("my-firmware v4.5.6 / RMK v1.2.3").unwrap(),
     };
     let behavior = BehaviorConfig {
         combo_timeout_ms: 50,
@@ -310,6 +314,7 @@ fn exemplars() -> Exemplars {
         matrix,
         capabilities,
         device_info,
+        build_info,
         behavior,
         connection,
         state_bits,
@@ -466,6 +471,7 @@ fn wire_values_locked() {
         ("MatrixState{[0x05,0x00,0x20]}", encode(&ex.matrix)),
         ("DeviceCapabilities{1..16}", encode(&ex.capabilities)),
         ("DeviceInfo{1.2.3,4,5,RMK,..}", encode(&ex.device_info)),
+        ("BuildInfo{my-firmware..}", encode(&ex.build_info)),
         ("BehaviorConfig{50,500,200,20}", encode(&ex.behavior)),
         ("ConnectionStatus{Configured,{1,Adv},Ble}", encode(&ex.connection)),
         ("ProtocolVersion{1,0}", encode(&ProtocolVersion { major: 1, minor: 0 })),
@@ -675,6 +681,15 @@ fn wire_frames_locked() {
                 Cmd::GetDeviceInfo,
                 SEQ,
                 &Ok::<DeviceInfo, RynkError>(ex.device_info.clone())
+            ),
+        ),
+        ("GetBuildInfo request ()", encode_frame(Cmd::GetBuildInfo, SEQ, &())),
+        (
+            "GetBuildInfo reply Ok(BuildInfo{my-firmware..})",
+            encode_frame(
+                Cmd::GetBuildInfo,
+                SEQ,
+                &Ok::<BuildInfo, RynkError>(ex.build_info.clone())
             ),
         ),
         // Keymap / encoder (0x01xx).

--- a/rmk/src/host/mod.rs
+++ b/rmk/src/host/mod.rs
@@ -26,5 +26,8 @@ pub use rynk::RynkService as HostService;
 /// UART-backed rynk transport helper.
 #[cfg(feature = "rynk")]
 pub use rynk::run_rynk_uart;
+/// RMK's semantic version, available to downstream firmware build labels.
+#[cfg(feature = "rynk")]
+pub use rynk::{RMK_VERSION, RMK_VERSION_STRING};
 #[cfg(feature = "vial")]
 pub use via::VialService as HostService;

--- a/rmk/src/host/rynk/handlers/system.rs
+++ b/rmk/src/host/rynk/handlers/system.rs
@@ -2,14 +2,15 @@
 
 use rmk_types::constants;
 use rmk_types::protocol::rynk::command::{
-    BootloaderJump, GetCapabilities, GetDeviceInfo, GetLockStatus, GetVersion, Lock, Reboot, StorageReset, UnlockPoll,
+    BootloaderJump, GetBuildInfo, GetCapabilities, GetDeviceInfo, GetLockStatus, GetVersion, Lock, Reboot,
+    StorageReset, UnlockPoll,
 };
 use rmk_types::protocol::rynk::{
-    DEVICE_INFO_STRING_SIZE, DeviceCapabilities, DeviceInfo, LockStatus, ProtocolVersion, RYNK_HEADER_SIZE, RynkError,
+    BuildInfo, DeviceCapabilities, DeviceInfo, LockStatus, ProtocolVersion, RYNK_HEADER_SIZE, RynkError,
     StorageResetMode,
 };
 
-use super::super::{RMK_VERSION, RynkService, RynkSession};
+use super::super::{RMK_VERSION, RynkService, RynkSession, truncated};
 use super::Handle;
 
 impl Handle<GetVersion> for RynkService<'_> {
@@ -117,14 +118,8 @@ impl Handle<GetDeviceInfo> for RynkService<'_> {
     }
 }
 
-/// Copy `s` into the bounded wire string; over-long input is cut at the last
-/// whole char that fits, so multi-byte content can never panic or split.
-fn truncated(s: &str) -> heapless::String<DEVICE_INFO_STRING_SIZE> {
-    let mut out = heapless::String::new();
-    for c in s.chars() {
-        if out.push(c).is_err() {
-            break;
-        }
+impl Handle<GetBuildInfo> for RynkService<'_> {
+    async fn handle(&self, _: ()) -> Result<BuildInfo, RynkError> {
+        Ok(self.build_info.clone())
     }
-    out
 }

--- a/rmk/src/host/rynk/mod.rs
+++ b/rmk/src/host/rynk/mod.rs
@@ -10,7 +10,9 @@ mod uart;
 use embassy_futures::select::{Either, select};
 use embedded_io_async::{Read, Write};
 use rmk_types::constants::RYNK_BUFFER_SIZE;
-use rmk_types::protocol::rynk::{Cmd, FirmwareVersion, RYNK_HEADER_SIZE, RynkError, RynkHeader, RynkMessage, command};
+use rmk_types::protocol::rynk::{
+    BuildInfo, Cmd, FirmwareVersion, RYNK_HEADER_SIZE, RynkError, RynkHeader, RynkMessage, command,
+};
 #[allow(unused_imports)] // re-exported at `crate::host` for downstream users
 pub use uart::run_rynk_uart;
 
@@ -23,7 +25,8 @@ use crate::keymap::KeyMap;
 /// Unlock attempts live long enough for BLE WebHID round trips.
 const RYNK_UNLOCK_WINDOW: embassy_time::Duration = embassy_time::Duration::from_millis(500);
 
-const RMK_VERSION: FirmwareVersion = {
+/// Semantic version of the RMK crate serving Rynk.
+pub const RMK_VERSION: FirmwareVersion = {
     const fn component(s: &str) -> u8 {
         let bytes = s.as_bytes();
         let mut i = 0;
@@ -42,6 +45,22 @@ const RMK_VERSION: FirmwareVersion = {
     }
 };
 
+/// String form of [`RMK_VERSION`] for application-defined build labels.
+pub const RMK_VERSION_STRING: &str = env!("CARGO_PKG_VERSION");
+
+const DEFAULT_BUILD_LABEL: &str = concat!("RMK v", env!("CARGO_PKG_VERSION"));
+
+/// Copy a string into a bounded wire value without splitting UTF-8.
+fn truncated<const N: usize>(s: &str) -> heapless::String<N> {
+    let mut out = heapless::String::new();
+    for c in s.chars() {
+        if out.push(c).is_err() {
+            break;
+        }
+    }
+    out
+}
+
 /// Transport-agnostic Rynk service.
 pub struct RynkService<'a> {
     ctx: KeyboardContext<'a>,
@@ -49,6 +68,8 @@ pub struct RynkService<'a> {
     device: DeviceConfig<'static>,
     /// Policy copied into each session's authorization gate.
     lock_config: LockConfig,
+    /// Human-readable firmware identity served by `GetBuildInfo`.
+    build_info: BuildInfo,
 }
 
 struct RynkSession<'a> {
@@ -65,7 +86,19 @@ impl<'a> RynkService<'a> {
             ctx,
             device: config.device_config,
             lock_config: config.lock_config,
+            build_info: BuildInfo {
+                label: truncated(DEFAULT_BUILD_LABEL),
+            },
         }
+    }
+
+    /// Replace the diagnostic build label advertised by `GetBuildInfo`.
+    ///
+    /// The label is for display and support diagnostics only. Protocol
+    /// compatibility continues to use `GetVersion`.
+    pub fn with_build_label(mut self, label: &str) -> Self {
+        self.build_info.label = truncated(label);
+        self
     }
 
     /// Whether `cmd` needs an unlocked device.
@@ -110,6 +143,7 @@ impl<'a> RynkService<'a> {
             Cmd::UnlockPoll => Serve::<command::UnlockPoll, _>::serve(session, msg).await,
             Cmd::Lock => Serve::<command::Lock, _>::serve(session, msg).await,
             Cmd::GetDeviceInfo => Serve::<command::GetDeviceInfo, _>::serve(self, msg).await,
+            Cmd::GetBuildInfo => Serve::<command::GetBuildInfo, _>::serve(self, msg).await,
 
             Cmd::GetKeyAction => Serve::<command::GetKeyAction, _>::serve(self, msg).await,
             Cmd::SetKeyAction => Serve::<command::SetKeyAction, _>::serve(self, msg).await,

--- a/rmk/tests/rynk_loopback.rs
+++ b/rmk/tests/rynk_loopback.rs
@@ -30,9 +30,10 @@ use rmk_types::fork::Fork;
 use rmk_types::led_indicator::LedIndicator;
 use rmk_types::morse::{Morse, MorseMode, MorseProfile};
 use rmk_types::protocol::rynk::{
-    BehaviorConfig as WireBehaviorConfig, Cmd, DeviceCapabilities, DeviceInfo, GetEncoderRequest, GetMacroRequest,
-    KeyPosition, LockStatus, MacroData, MatrixState, ProtocolVersion, RYNK_HEADER_SIZE, RynkError, SetComboRequest,
-    SetEncoderRequest, SetForkRequest, SetKeyRequest, SetMacroRequest, SetMorseRequest, StorageResetMode,
+    BehaviorConfig as WireBehaviorConfig, BuildInfo, Cmd, DeviceCapabilities, DeviceInfo, GetEncoderRequest,
+    GetMacroRequest, KeyPosition, LockStatus, MacroData, MatrixState, ProtocolVersion, RYNK_HEADER_SIZE, RynkError,
+    SetComboRequest, SetEncoderRequest, SetForkRequest, SetKeyRequest, SetMacroRequest, SetMorseRequest,
+    StorageResetMode,
 };
 
 use crate::common::rynk_link::{RynkHostClient, link_session, link_two_sessions};
@@ -153,6 +154,27 @@ fn get_device_info() {
         assert_eq!(info.rmk_version.major, env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap());
         assert_eq!(info.rmk_version.minor, env!("CARGO_PKG_VERSION_MINOR").parse().unwrap());
         assert_eq!(info.rmk_version.patch, env!("CARGO_PKG_VERSION_PATCH").parse().unwrap());
+    });
+}
+
+#[test]
+fn get_build_info_defaults_to_rmk_and_allows_application_override() {
+    let default_service = service();
+    link_session(&default_service, async |client| {
+        let info = client
+            .request::<(), BuildInfo>(Cmd::GetBuildInfo, 0x09, &())
+            .await
+            .expect("Ok envelope");
+        assert_eq!(info.label.as_str(), concat!("RMK v", env!("CARGO_PKG_VERSION")));
+    });
+
+    let custom_service = service().with_build_label("my-keyboard v2 / custom-config");
+    link_session(&custom_service, async |client| {
+        let info = client
+            .request::<(), BuildInfo>(Cmd::GetBuildInfo, 0x0a, &())
+            .await
+            .expect("Ok envelope");
+        assert_eq!(info.label.as_str(), "my-keyboard v2 / custom-config");
     });
 }
 

--- a/rynk/rynk-wasm/src/client.rs
+++ b/rynk/rynk-wasm/src/client.rs
@@ -22,9 +22,9 @@ use rynk::rmk_types::fork::Fork;
 use rynk::rmk_types::led_indicator::LedIndicator;
 use rynk::rmk_types::morse::Morse;
 use rynk::rmk_types::protocol::rynk::{
-    BehaviorConfig, DeviceCapabilities, DeviceInfo, GetComboBulkResponse, GetKeymapBulkResponse, GetMorseBulkResponse,
-    LockStatus, MacroData, MatrixState, PeripheralStatus, ProtocolVersion, SetComboBulkRequest, SetKeymapBulkRequest,
-    SetMorseBulkRequest, StorageResetMode,
+    BehaviorConfig, BuildInfo, DeviceCapabilities, DeviceInfo, GetComboBulkResponse, GetKeymapBulkResponse,
+    GetMorseBulkResponse, LockStatus, MacroData, MatrixState, PeripheralStatus, ProtocolVersion, SetComboBulkRequest,
+    SetKeymapBulkRequest, SetMorseBulkRequest, StorageResetMode,
 };
 use rynk::{Client, Driver, LayoutInfo, RynkDevice, RynkHostError, TopicEvent};
 use wasm_bindgen::prelude::*;
@@ -108,6 +108,7 @@ endpoints! {
     get_version() -> ProtocolVersion,
     get_capabilities() -> DeviceCapabilities,
     get_device_info() -> DeviceInfo,
+    get_build_info() -> BuildInfo,
     reboot() -> (),
     bootloader_jump() -> (),
     storage_reset(mode: StorageResetMode) -> (),

--- a/rynk/src/api.rs
+++ b/rynk/src/api.rs
@@ -13,11 +13,11 @@ use rmk_types::fork::Fork;
 use rmk_types::led_indicator::LedIndicator;
 use rmk_types::morse::Morse;
 use rmk_types::protocol::rynk::{
-    BehaviorConfig, Cmd, DeviceCapabilities, DeviceInfo, GetComboBulkRequest, GetComboBulkResponse, GetEncoderRequest,
-    GetKeymapBulkRequest, GetKeymapBulkResponse, GetMacroRequest, GetMorseBulkRequest, GetMorseBulkResponse,
-    KeyPosition, LockStatus, MacroData, MatrixState, PeripheralStatus, ProtocolVersion, SetComboBulkRequest,
-    SetComboRequest, SetEncoderRequest, SetForkRequest, SetKeyRequest, SetKeymapBulkRequest, SetMacroRequest,
-    SetMorseBulkRequest, SetMorseRequest, StorageResetMode, command,
+    BehaviorConfig, BuildInfo, Cmd, DeviceCapabilities, DeviceInfo, GetComboBulkRequest, GetComboBulkResponse,
+    GetEncoderRequest, GetKeymapBulkRequest, GetKeymapBulkResponse, GetMacroRequest, GetMorseBulkRequest,
+    GetMorseBulkResponse, KeyPosition, LockStatus, MacroData, MatrixState, PeripheralStatus, ProtocolVersion,
+    SetComboBulkRequest, SetComboRequest, SetEncoderRequest, SetForkRequest, SetKeyRequest, SetKeymapBulkRequest,
+    SetMacroRequest, SetMorseBulkRequest, SetMorseRequest, StorageResetMode, command,
 };
 
 use crate::driver::{Client, RynkHostError};
@@ -57,6 +57,11 @@ impl Client {
     /// Read the firmware and device identity.
     pub async fn get_device_info(&self) -> Result<DeviceInfo, RynkHostError> {
         self.request::<command::GetDeviceInfo>(&()).await
+    }
+
+    /// Read the application-defined diagnostic build label.
+    pub async fn get_build_info(&self) -> Result<BuildInfo, RynkHostError> {
+        self.request::<command::GetBuildInfo>(&()).await
     }
 
     /// Reboot the device — fire-and-forget: the firmware resets before its


### PR DESCRIPTION
Adds an additive `GetBuildInfo` endpoint whose bounded display label is deliberately separate from the structured Rynk protocol version. RMK advertises `RMK v<version>` by default; downstream firmware can override it with `HostService::with_build_label`, and the RMK version string is exported for composing richer labels. Includes native and Wasm client APIs, wire snapshots, generated protocol documentation, and loopback coverage.