### PR TITLE
Docs: Suggest SHIFTED and WM after modifiers keycodes list

### DIFF
--- a/docs/docs/main/docs/configuration/keymap_configuration/keycodes.md
+++ b/docs/docs/main/docs/configuration/keymap_configuration/keycodes.md
@@ -111,6 +111,8 @@ When used in configuration files, all keycodes are case-insensitive.
 | `RAlt`   | `r_alt`, `rightalt`, `right_alt`, `ropt`         | Right Alt     |
 | `RGui`   | `r_gui`, `rightgui`, `right_gui`, `rcmd`, `rwin` | Right GUI     |
 
+For simple keycodes with shift active you can use `SHIFTED(key)` in your [layout](../layout#layout), or more generally expressions like `WM(key, LShift | RGui)` with modifiers.
+
 ## Function keys
 
 | Keycode | Aliases | Usage |


### PR DESCRIPTION
This addresses my query on Discord, having failed to find this in the docs last night.