### PR TITLE
Docs: Replace broken keycode enum links

### DIFF
--- a/docs/docs/main/docs/configuration/layout.md
+++ b/docs/docs/main/docs/configuration/layout.md
@@ -121,7 +121,7 @@ The `layer.keys` string should follow several rules:
    1. Use `DF(n)` to create a switch default layer action, `n` is the layer number. Use `PDF(n)` for a persistent version that is saved to storage and restored after reboot
    2. Use `MO(n)` to create a layer activate action, `n` is the layer number
    3. Use `LM(n, modifier)` to create layer activate with modifier action. The modifier can be chained in the same way as `WM`
-   4. Use `LT(n, key, <profile_name>)` to create a layer activate action or tap key(tap/hold). The `key` here is the RMK [`KeyCode`](https://docs.rs/rmk/latest/rmk/keycode/enum.KeyCode.html), The `profile_name` is optional, which defines the key's [profile](./behavior#per-key-profiles-for-morse-tapdance-tap-hold-fine-tuning)
+   4. Use `LT(n, key, <profile_name>)` to create a layer activate action or tap key(tap/hold). The `key` here is the RMK [`KeyCode`](./keymap_configuration/keycodes), The `profile_name` is optional, which defines the key's [profile](./behavior#per-key-profiles-for-morse-tapdance-tap-hold-fine-tuning)
    5. Use `OSL(n)` to create a one-shot layer action, `n` is the layer number
    6. Use `OSM(modifier)` to create a one-shot modifier action. The modifier can be chained in the same way as `WM`
    7. Use `TT(n)` to create a layer activate or tap toggle action, `n` is the layer number

--- a/docs/docs/main/docs/configuration/layout.md
+++ b/docs/docs/main/docs/configuration/layout.md
@@ -98,9 +98,9 @@ In each `layer.keys`, the keys are bound to various key actions. Due to the limi
 
 The `layer.keys` string should follow several rules:
 
-1. For a simple keycode (i.e., keys in RMK's [`HidKeyCode`](https://docs.rs/rmk/latest/rmk/keycode/enum.HidKeyCode.html) enum), just fill in its name.
+1. For a simple keycode (i.e., keys in RMK's [`HidKeyCode`](https://github.com/HaoboGu/rmk/blob/main/rmk-types/src/keycode/hid.rs) enum), just fill in its name as listed in the [KeyCode table](./keymap_configuration/keycodes).
 
-   For example, if you set a keycode `Backspace`, it will be turned to the corresponding HID keycode. So you have to ensure that the keycode string is valid, or RMK wouldn't compile! However, to make things easier a number of alternative key names (see alias column in [KeyCode table](./keymap_configuration/keycodes)) were added and also case-insensitive search is used to find the valid keycode.
+   For example, if you set a keycode `Backspace`, it will be turned to the corresponding HID keycode. So you have to ensure that the keycode string is valid, or RMK won't compile! However, to make things easier a number of alternative key names (see alias column in [KeyCode table](./keymap_configuration/keycodes)) were added and also case-insensitive search is used to find the valid keycode.
 
    For simple keycodes with modifiers active, you can use `WM(key, modifier)` to create a keypress with modifier action. Modifiers can be chained together like `LShift | RGui` to have multiple modifiers active.
 


### PR DESCRIPTION
https://docs.rs/rmk/latest/rmk/keycode/enum.HidKeyCode.html and https://docs.rs/rmk/latest/rmk/keycode/enum.KeyCode.html don't work any more, use https://rmk.rs/main/docs/configuration/keymap_configuration/keycodes instead.