### PR TITLE
Expose held modifier combinations in keyboard.toml

### DIFF
--- a/docs/docs/main/docs/configuration/layout.md
+++ b/docs/docs/main/docs/configuration/layout.md
@@ -104,6 +104,8 @@ The `layer.keys` string should follow several rules:
 
    For simple keycodes with modifiers active, you can use `WM(key, modifier)` to create a keypress with modifier action. Modifiers can be chained together like `LShift | RGui` to have multiple modifiers active.
 
+   To hold one or more modifiers without sending a non-modifier key, use `MOD(modifier)`. For example, `MOD(LCtrl | LAlt | LGui)` holds all three modifiers until the bound key is released.
+
    You may use aliases, prefixed with `@`, like `@my_copy` in the above example. The alias names are case sensitive. The definition of aliases is described below.
 
    You may use layer names instead of layer numbers, like `TO(base_layer)` in the above example.

--- a/rmk-config/src/keymap.pest
+++ b/rmk-config/src/keymap.pest
@@ -54,6 +54,9 @@ transparent_action = @{ ("_")+ | (^"Trns" ~ !ASCII_ALPHANUMERIC) } // One or mor
 // Rule 1: WM(key, modifier) - Key with Modifier
 wm_action = { ^"WM" ~ "(" ~ keycode_name ~ "," ~ modifier_combination ~ ")" }
 
+// MOD(modifier) - Held Modifier Combination
+mod_action = { ^"MOD" ~ "(" ~ modifier_combination ~ ")" }
+
 // Rule 4.6: OSM(modifier) - One-Shot Modifier (requires quotes)
 osm_action = { ^"OSM" ~ "(" ~ modifier_combination ~ ")" }
 
@@ -93,7 +96,7 @@ layer_action = _{
 // `keycode_name` fallback (not `simple_keycode`) keeps a lone `,` from being
 // accepted as a slot argument.
 nestable_action = _{
-    wm_action | osm_action | shifted_action | trigger_macro_action |
+    wm_action | mod_action | osm_action | shifted_action | trigger_macro_action |
     df_action | mo_action | lm_action | osl_action | tg_action | to_action |
     keycode_name
 }
@@ -118,7 +121,7 @@ trigger_macro_action = { ^"MACRO" ~ "(" ~ number ~ ")" }
 // A single key action entry in the map
 // Order is important: more specific function-like rules first, then aliases/specials, then simple keycodes.
 key_action = _{ // Consume surrounding whitespace/comments implicitly
-    wm_action | osm_action | layer_action | mt_action | th_action | shifted_action | morse_action | trigger_macro_action | no_action | transparent_action | simple_keycode
+    wm_action | mod_action | osm_action | layer_action | mt_action | th_action | shifted_action | morse_action | trigger_macro_action | no_action | transparent_action | simple_keycode
 }
 
 // The entire key map string: Start, zero or more key actions, End.

--- a/rmk-config/src/layout.rs
+++ b/rmk-config/src/layout.rs
@@ -580,6 +580,17 @@ mod tests {
     }
 
     #[test]
+    fn test_held_modifier_action_parsing() {
+        let aliases = HashMap::new();
+        let layer_names = HashMap::new();
+
+        let keymap = "MOD(LCtrl | LAlt | LGui) mod(RShift)";
+        let result = KeyboardTomlConfig::keymap_parser(keymap, &aliases, &layer_names);
+
+        assert_eq!(result.unwrap(), vec!["MOD(LCtrl | LAlt | LGui)", "mod(RShift)"]);
+    }
+
+    #[test]
     fn test_morse_action_grammar() {
         // Test that TD actions are parsed correctly by the grammar
         let test_cases = vec![
@@ -670,9 +681,9 @@ mod tests {
         let aliases = HashMap::new();
         let layer_names = HashMap::new();
 
-        // A single-action form (here WM) can appear in the tap/hold slots of
+        // Single-action forms can appear in the tap/hold slots of
         // MT/TH/LT and is forwarded verbatim for the proc-macro to expand.
-        let keymap = "MT(WM(P, RAlt), LShift, HRM) TH(WM(A, LShift), MO(2)) LT(1, WM(Q, LGui))";
+        let keymap = "MT(WM(P, RAlt), LShift, HRM) TH(WM(A, LShift), MO(2)) LT(1, MOD(LCtrl | LGui))";
         let result = KeyboardTomlConfig::keymap_parser(keymap, &aliases, &layer_names);
 
         assert!(result.is_ok(), "{:?}", result);
@@ -681,7 +692,7 @@ mod tests {
             vec![
                 "MT(WM(P, RAlt), LShift, HRM)",
                 "TH(WM(A, LShift), MO(2))",
-                "LT(1, WM(Q, LGui))",
+                "LT(1, MOD(LCtrl | LGui))",
             ]
         );
     }

--- a/rmk-macro/src/codegen/action_parser.rs
+++ b/rmk-macro/src/codegen/action_parser.rs
@@ -208,6 +208,14 @@ fn parse_action(key: &str) -> TokenStream2 {
 
     if lower == "no" {
         return quote! { ::rmk::types::action::Action::No };
+    } else if lower.starts_with("mod(") {
+        let modifiers = parse_modifiers(strip_call(key));
+        if modifiers.is_empty() {
+            panic!(
+                "\n\u{274c} keyboard.toml: modifier in MOD(modifier) is not valid! Please check the documentation: https://rmk.rs/docs/features/configuration/layout.html"
+            );
+        }
+        return quote! { ::rmk::types::action::Action::Modifier(#modifiers) };
     } else if lower.starts_with("wm(") {
         let keys = split_top_level(strip_call(key));
         if keys.len() != 2 {
@@ -513,6 +521,7 @@ mod tests {
                 .contains("KeyAction::Single(::rmk::types::action::Action::LayerOn(1u8))")
         );
         assert!(squash(&expand("WM(C,LCtrl)")).contains("Action::KeyWithModifier"));
+        assert!(squash(&expand("MOD(LCtrl | LAlt | LGui)")).contains("Action::Modifier"));
         assert!(squash(&expand("OSM(LShift)")).contains("Action::OneShotModifier"));
     }
 


### PR DESCRIPTION
## What changed

- Add `MOD(modifier)` to the `keyboard.toml` grammar and action parser.
- Expand it to RMK’s existing `Action::Modifier`, without changing `WM(key, modifier)` semantics.
- Document the syntax and test modifier combinations, case-insensitive parsing, and use inside a nestable action slot.

## Motivation

A dedicated modifier-combination key (for example, Hyper) needs to hold several modifiers while arbitrary other keys are pressed. `WM` describes a self-contained key-with-modifiers action, while `MOD` directly expresses the intended held-modifier action.

```toml
MOD(LCtrl | LAlt | LGui)
```

## Validation

- `cargo fmt` / formatting checks
- `rmk-config`: 92 unit tests and 6 integration tests passed
- focused `rmk-macro` parsing and expansion tests passed
- Glove80 `thumbv7em-none-eabihf` firmware check passed using a real `MOD(LCtrl | LAlt | LGui)` configuration