### PR TITLE
Add stm32 bootloader support

### DIFF
--- a/rmk-macro/src/codegen/chip/chip_init.rs
+++ b/rmk-macro/src/codegen/chip/chip_init.rs
@@ -5,6 +5,7 @@ use rmk_config::resolved::Hardware;
 use rmk_config::resolved::hardware::{BoardConfig, ChipModel, ChipSeries, CommunicationConfig};
 use syn::{ItemFn, ItemMod};
 
+use crate::codegen::chip::stm32_bootloader::stm32_bootloader_prelude;
 use crate::codegen::override_helper::Overwritten;
 
 /// Expand chip initialization code
@@ -29,9 +30,13 @@ pub(crate) fn expand_chip_init(
                             return Some(override_chip_config(&hardware.chip, item_fn));
                         }
                         Ok(Overwritten::ChipInit) => {
-                            // Override the whole chip initialization
+                            // Override the whole chip initialization, keeping the bootloader check
                             let stmts = &item_fn.block.stmts;
-                            return Some(quote! { #(#stmts)* });
+                            let stm32_bootloader = stm32_bootloader_prelude(&hardware.chip);
+                            return Some(quote! {
+                                #stm32_bootloader
+                                #(#stmts)*
+                            });
                         }
                         _ => (),
                     }
@@ -59,10 +64,14 @@ pub(crate) fn chip_init_default(hardware: &Hardware, peripheral_id: Option<usize
         quote! {}
     };
     match chip.series {
-        ChipSeries::Stm32 => quote! {
+        ChipSeries::Stm32 => {
+            let stm32_bootloader = stm32_bootloader_prelude(chip);
+            quote! {
+                #stm32_bootloader
                 let config = ::embassy_stm32::Config::default();
                 let mut p = ::embassy_stm32::init(config);
-        },
+            }
+        }
         ChipSeries::Nrf52 => {
             let chip_cfg = &hardware.chip_config;
             let dcdc_config = if chip.chip == "nrf52840" {
@@ -246,7 +255,10 @@ pub(crate) fn chip_init_default(hardware: &Hardware, peripheral_id: Option<usize
 
 fn override_chip_config(chip: &ChipModel, item_fn: &ItemFn) -> TokenStream2 {
     let initialization = item_fn.block.to_token_stream();
+    // The ROM bootloader expects the chip in its reset state, so check before the user's config
+    let stm32_bootloader = stm32_bootloader_prelude(chip);
     let mut initialization_tokens = quote! {
+        #stm32_bootloader
         let config = #initialization;
     };
     match chip.series {

--- a/rmk-macro/src/codegen/chip/mod.rs
+++ b/rmk-macro/src/codegen/chip/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod chip_init;
 pub(crate) mod comm;
 pub(crate) mod flash;
 pub(crate) mod gpio;
+pub(crate) mod stm32_bootloader;

--- a/rmk-macro/src/codegen/chip/stm32_bootloader.rs
+++ b/rmk-macro/src/codegen/chip/stm32_bootloader.rs
@@ -1,0 +1,85 @@
+//! STM32 ROM bootloader (DFU) support.
+//!
+//! Emits the boot-time bootloader check and registers the request function for the
+//! `Bootloader` keycode. See `rmk::boot::stm32` for the mechanism.
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use rmk_config::resolved::hardware::{ChipModel, ChipSeries};
+
+/// System memory (ROM bootloader) base address for an STM32 chip, from AN2606.
+///
+/// Cross-checked against QMK's `platforms/chibios/mcu_selection.mk` defaults for
+/// `bootloader = stm32-dfu`. `None` for chips not covered yet.
+fn stm32_system_memory_address(chip: &str) -> Option<u32> {
+    // keyboard.toml isn't case-normalized
+    let chip = chip.to_ascii_lowercase();
+
+    // H7R/H7S have their own address, don't let them fall into the generic H7 entry
+    if chip.starts_with("stm32h7r") || chip.starts_with("stm32h7s") {
+        return None;
+    }
+
+    // More specific prefixes first
+    let table: &[(&str, u32)] = &[
+        // F030xC is the outlier within F03x (AN2606 table 27 vs 26)
+        ("stm32f030cc", 0x1FFF_D800),
+        ("stm32f030rc", 0x1FFF_D800),
+        ("stm32f04", 0x1FFF_C400),
+        ("stm32f07", 0x1FFF_C800),
+        ("stm32f09", 0x1FFF_D800),
+        ("stm32f0", 0x1FFF_EC00),
+        // F1 connectivity line
+        ("stm32f105", 0x1FFF_B000),
+        ("stm32f107", 0x1FFF_B000),
+        ("stm32f2", 0x1FFF_0000),
+        ("stm32f3", 0x1FFF_D800),
+        ("stm32f4", 0x1FFF_0000),
+        ("stm32f7", 0x1FF0_0000),
+        ("stm32g0", 0x1FFF_0000),
+        ("stm32g4", 0x1FFF_0000),
+        ("stm32h503", 0x0BF8_7000),
+        ("stm32h5", 0x0BF9_7000),
+        ("stm32h7a", 0x1FF0_A800),
+        ("stm32h7b", 0x1FF0_A000),
+        ("stm32h7", 0x1FF0_9800),
+        ("stm32l0", 0x1FF0_0000),
+        ("stm32l1", 0x1FF0_0000),
+        ("stm32l4", 0x1FFF_0000),
+        ("stm32l5", 0x0BF9_0000),
+        ("stm32u5", 0x0BF9_0000),
+        // WBA differs from WB, match first
+        ("stm32wba", 0x0BF8_8000),
+        ("stm32wb", 0x1FFF_0000),
+        ("stm32wl", 0x1FFF_0000),
+        ("stm32c0", 0x1FFF_0000),
+    ];
+    if let Some((_, addr)) = table.iter().find(|(prefix, _)| chip.starts_with(prefix)) {
+        return Some(*addr);
+    }
+    // F1 XL-density (flash size code F or G) has its own address
+    if chip.starts_with("stm32f1") {
+        return match chip.as_bytes().last() {
+            Some(b'f' | b'g') => Some(0x1FFF_E000),
+            _ => Some(0x1FFF_F000),
+        };
+    }
+    None
+}
+
+/// Bootloader check and `Bootloader` keycode registration for STM32 chip init. Empty
+/// for other chips and for STM32 chips without a known address.
+///
+/// Must come before any clock or peripheral configuration.
+pub(crate) fn stm32_bootloader_prelude(chip: &ChipModel) -> TokenStream2 {
+    if chip.series != ChipSeries::Stm32 {
+        return quote! {};
+    }
+    match stm32_system_memory_address(&chip.chip) {
+        Some(addr) => quote! {
+            ::rmk::boot::stm32::enter_bootloader_if_requested(#addr);
+            ::rmk::boot::register_bootloader_jump(::rmk::boot::stm32::request_bootloader);
+        },
+        None => quote! {},
+    }
+}

--- a/rmk/src/boot/mod.rs
+++ b/rmk/src/boot/mod.rs
@@ -1,4 +1,40 @@
+use core::sync::atomic::{AtomicPtr, Ordering};
+
+/// User-registered bootloader jump, invoked by the `Bootloader` keycode in place of
+/// the built-in chip support.
+///
+/// A raw pointer so it fits in an atomic; null means unregistered. Pointee type is
+/// `fn() -> !`.
+static BOOTLOADER_JUMP: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
+
+/// Registers a custom bootloader jump for chips without built-in support.
+///
+/// Entering the ROM bootloader is board-specific on some chips, so firmware supplies
+/// the sequence here and the `Bootloader` keycode calls it instead of the built-in
+/// default.
+///
+/// `jump` must not return. End it by resetting the chip or jumping to the bootloader.
+/// Register it before the keyboard starts processing keys, for example inside
+/// `#[Override(chip_config)]`.
+pub fn register_bootloader_jump(jump: fn() -> !) {
+    BOOTLOADER_JUMP.store(jump as *mut (), Ordering::Relaxed);
+}
+
+#[cfg(all(
+    target_arch = "arm",
+    target_os = "none",
+    any(target_abi = "eabi", target_abi = "eabihf")
+))]
+pub mod stm32;
+
 pub fn jump_to_bootloader() {
+    let jump = BOOTLOADER_JUMP.load(Ordering::Relaxed);
+    if !jump.is_null() {
+        // Cast back to the fn pointer stored in `register_bootloader_jump`
+        let jump: fn() -> ! = unsafe { core::mem::transmute(jump) };
+        jump();
+    }
+
     #[cfg(feature = "adafruit_bl")]
     // Reference: https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/d6b28e66053eea467166f44875e3c7ec741cb471/src/main.c#L107
     embassy_nrf::pac::POWER

--- a/rmk/src/boot/stm32.rs
+++ b/rmk/src/boot/stm32.rs
@@ -1,0 +1,96 @@
+//! STM32 ROM bootloader (DFU) support for the `Bootloader` keycode.
+
+/// Request handoff from [`request_bootloader`] to the next boot: the magic and its
+/// complement.
+///
+/// `.uninit` keeps cortex-m-rt startup from zeroing it, so it survives the reset.
+#[unsafe(link_section = ".uninit.RMK_BOOTLOADER_REQUEST")]
+static mut BOOTLOADER_REQUEST: core::mem::MaybeUninit<[u32; 2]> = core::mem::MaybeUninit::uninit();
+
+/// Same magic QMK's `stm32_dfu.c` uses
+const BOOTLOADER_REQUEST_MAGIC: u32 = 0xDEAD_BEEF;
+
+fn request_ptr() -> *mut u32 {
+    (&raw mut BOOTLOADER_REQUEST) as *mut u32
+}
+
+/// Complement of `x`, computed in asm.
+///
+/// As a constant it would sit next to the magic in the literal pool, putting a valid
+/// pair in the firmware image. The ROM bootloader buffers the image in RAM during DFU,
+/// which can leave that pair in the request words and send the board straight back into
+/// DFU.
+fn opaque_complement(x: u32) -> u32 {
+    let out;
+    unsafe { core::arch::asm!("mvns {o}, {i}", o = lateout(reg) out, i = in(reg) x, options(pure, nomem, nostack)) };
+    out
+}
+
+/// Writes the request words back to SRAM if the D-cache is on.
+///
+/// A system reset invalidates the D-cache without writing it back. `DC` reads 0 where
+/// there is no cache.
+fn clean_request_dcache() {
+    const SCB_CCR: *const u32 = 0xE000_ED14 as *const u32;
+    const SCB_CCR_DC: u32 = 1 << 16;
+    const CBP_DCCMVAC: *mut u32 = 0xE000_EF68 as *mut u32;
+
+    if unsafe { core::ptr::read_volatile(SCB_CCR) } & SCB_CCR_DC == 0 {
+        return;
+    }
+
+    // One clean per word, the pair can span two cache lines
+    let p = request_ptr();
+    cortex_m::asm::dsb();
+    unsafe {
+        core::ptr::write_volatile(CBP_DCCMVAC, p as u32);
+        core::ptr::write_volatile(CBP_DCCMVAC, p.add(1) as u32);
+    }
+    cortex_m::asm::dsb();
+}
+
+/// Stores a bootloader request and resets the chip, mirroring `bootloader_jump` in
+/// QMK's `stm32_dfu.c`.
+///
+/// [`enter_bootloader_if_requested`] consumes the request on the next boot, so the
+/// reset that leaves DFU (dfu-util's `:leave`) boots the firmware.
+///
+/// Registered by the `rmk_keyboard` macro for known STM32 chips, otherwise pass it to
+/// [`register_bootloader_jump`](super::register_bootloader_jump).
+pub fn request_bootloader() -> ! {
+    let p = request_ptr();
+    unsafe {
+        core::ptr::write_volatile(p, BOOTLOADER_REQUEST_MAGIC);
+        core::ptr::write_volatile(p.add(1), opaque_complement(BOOTLOADER_REQUEST_MAGIC));
+    }
+    clean_request_dcache();
+    cortex_m::peripheral::SCB::sys_reset()
+}
+
+/// Jumps to the ROM bootloader if the last reset came from [`request_bootloader`],
+/// consuming the request either way.
+///
+/// `system_memory` is the chip's system memory base address from AN2606, `0x1FFF_0000`
+/// on STM32F4.
+///
+/// Must run before `embassy_stm32::init`, while the chip is still in its reset state.
+/// Emitted by the `rmk_keyboard` macro for known STM32 chips.
+pub fn enter_bootloader_if_requested(system_memory: u32) {
+    let p = request_ptr();
+    let (w0, w1) = unsafe { (core::ptr::read_volatile(p), core::ptr::read_volatile(p.add(1))) };
+
+    // Consume unconditionally, a stale or partial pair must not reach a later boot
+    unsafe {
+        core::ptr::write_volatile(p, 0);
+        core::ptr::write_volatile(p.add(1), 0);
+    }
+
+    if w0 != BOOTLOADER_REQUEST_MAGIC || w1 != opaque_complement(BOOTLOADER_REQUEST_MAGIC) {
+        return;
+    }
+
+    // Don't mask interrupts: the ROM bootloader expects PRIMASK in its reset state and
+    // never clears it, so masking here stops USB enumeration. Nothing is enabled this
+    // early anyway
+    unsafe { cortex_m::asm::bootload(system_memory as *const u32) }
+}


### PR DESCRIPTION
I have two Mode Design keyboards which use the stm32 chip, specifically the `STM32F401RC` chip.

This is PR1 of two.

I ported the way QMK does a software restart on these boards (before keys are processed) to enter DFU, and then jumping to the actual keyboard firmware after flashing.

Works well on my two boards and been flashing/restarting/using it the past week. Let me know if there's anything you would want changed!