### PR TITLE
fix: sdc memory pool size calculation for nrf52840

### DIFF
--- a/examples/use_rust/nrf52832_ble/src/main.rs
+++ b/examples/use_rust/nrf52832_ble/src/main.rs
@@ -105,7 +105,7 @@ async fn main(spawner: Spawner) {
         p.PPI_CH27, p.PPI_CH28, p.PPI_CH29,
     );
     let mut rng = rng::Rng::new(p.RNG, Irqs);
-    let mut sdc_mem = sdc::Mem::<3072>::new();
+    let mut sdc_mem = sdc::Mem::<4696>::new();
     let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
     let mut host_resources = HostResources::new();
     let stack = build_ble_stack(sdc, ble_addr(), &mut host_resources).await;

--- a/examples/use_rust/nrf52840_ble/src/main.rs
+++ b/examples/use_rust/nrf52840_ble/src/main.rs
@@ -133,7 +133,7 @@ async fn main(spawner: Spawner) {
         p.PPI_CH27, p.PPI_CH28, p.PPI_CH29,
     );
     let mut rng = rng::Rng::new(p.RNG, Irqs);
-    let mut sdc_mem = sdc::Mem::<4096>::new();
+    let mut sdc_mem = sdc::Mem::<4696>::new();
     let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
     let mut host_resources = HostResources::new();
     let stack = build_ble_stack(sdc, ble_addr(), &mut host_resources).await;

--- a/examples/use_rust/nrf52840_ble_split/src/central.rs
+++ b/examples/use_rust/nrf52840_ble_split/src/central.rs
@@ -140,7 +140,7 @@ async fn main(spawner: Spawner) {
         p.PPI_CH27, p.PPI_CH28, p.PPI_CH29,
     );
     let mut rng = rng::Rng::new(p.RNG, Irqs);
-    let mut sdc_mem = sdc::Mem::<8192>::new();
+    let mut sdc_mem = sdc::Mem::<6080>::new();
     let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
     let mut host_resources = HostResources::new();
     let stack = build_ble_stack(sdc, ble_addr(), &mut host_resources).await;

--- a/examples/use_rust/nrf52840_ble_split/src/peripheral.rs
+++ b/examples/use_rust/nrf52840_ble_split/src/peripheral.rs
@@ -122,7 +122,7 @@ async fn main(spawner: Spawner) {
         p.PPI_CH27, p.PPI_CH28, p.PPI_CH29,
     );
     let mut rng = rng::Rng::new(p.RNG, Irqs);
-    let mut sdc_mem = sdc::Mem::<4624>::new();
+    let mut sdc_mem = sdc::Mem::<4696>::new();
     let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
 
     let mut resources = HostResources::new();

--- a/rmk-macro/src/codegen/chip/chip_init.rs
+++ b/rmk-macro/src/codegen/chip/chip_init.rs
@@ -96,13 +96,15 @@ pub(crate) fn chip_init_default(hardware: &Hardware, peripheral_id: Option<usize
             };
             let ble_addr = get_ble_addr(hardware, peripheral_id);
             // Calculate the size of sdc memory pool.
-            // By default it's 6KB, each peripheral increases 2304 bytes
+            // Unibody: 4696. Split central: 6080 + (N-1) * 2288 per peripheral.
             let sdc_mem_size = if peripheral_id.is_none() {
-                // For central
-                4096 + peri_num * 2304
+                if peri_num > 0 {
+                    6080 + (peri_num.saturating_sub(1)) * 2288
+                } else {
+                    4696
+                }
             } else {
-                // For peripheral
-                6144
+                4696
             };
             let ble_init = match &communication {
                 CommunicationConfig::Ble(_) | CommunicationConfig::Both(_, _) => quote! {


### PR DESCRIPTION
In `a5da70f2` we updated nrf-sdc from `3f3a5070` to `abe49d22`. Apparently the new commit of nrf-sdc needs bigger memory pools probably due to `6527dec chore: update to nrfxlib 3.3.0`

This fixes only the use_rust nRF52840 and nRF52832 examples and the calculation for all nRF528xx chips. 
I can not runtime test nRF54 due to the lack of hardware. 