### PR TITLE
feat(ble): Enable Bluetooth LE Connection Subrating for split communication

### DIFF
--- a/docs/docs/main/docs/features/low_power.md
+++ b/docs/docs/main/docs/features/low_power.md
@@ -67,6 +67,19 @@ Two related behaviors are always on:
 - When BLE advertising times out without a connection (after 5 minutes), the keyboard sleeps immediately and waits for a key or pointing event before it advertises again.
 - `NrfAdc` takes a `light_sleep` interval as its last argument. When the analog inputs have been idle for more than 1.2 seconds, the ADC polls at that interval instead of `polling_interval`. A joystick configured in `keyboard.toml` uses 350ms.
 
+### Split central sleep using BLE Connection Subrating (nrf52840 only)
+
+To improve central power usage and decrease peripheral latency problems during wake-up you can activate the `subrating` feature in your `Cargo.toml`.
+This enables BLE Connection Subrating which lets the central sleep for longer intervals, while allowing for a quick switch back to the fast connection intervals.
+
+The mean perihperal latency is ~450ms for the first keypress only. The keyboard instantly switches to the active connection settings after that. Depending on your layout and habits this allows to use the sleep feature more agressively. Try to reduce the timeout to get lower battery usage, e.g.:
+```toml
+[rmk]
+split_central_sleep_timeout_seconds = 60
+```
+
+If the central is not connected to a host, the latency is further increased to ~1867ms which reduces the power consumption of the central to ~20µA, barely more then the peripheral.
+
 ## External VCC
 
 Some boards, such as the nice!nano have an external 3.3V regulator that can be used to power the LEDs. If not used, the regulator can be disabled by pulling `P0_13` low to safe power.

--- a/examples/use_config/nrf52840_ble_split/Cargo.toml
+++ b/examples/use_config/nrf52840_ble_split/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-rmk = { path = "../../../rmk", default-features = false, features = ["defmt", "storage", "vial", "watchdog", "nrf52840_ble", "split", "async_matrix", "adafruit_bl"] }
+rmk = { path = "../../../rmk", default-features = false, features = ["defmt", "storage", "vial", "watchdog", "nrf52840_ble", "split", "async_matrix", "adafruit_bl", "subrating"] }
 nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc", rev = "f54b6389ffa2750d4d3a4f5435660cb66b47e51a", features = [
     "defmt",
     "peripheral",

--- a/examples/use_config/nrf52840_ble_split_direct_pin/Cargo.toml
+++ b/examples/use_config/nrf52840_ble_split_direct_pin/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-rmk = { path = "../../../rmk", default-features = false, features = ["defmt", "storage", "vial", "watchdog", "nrf52840_ble", "split", "async_matrix", "adafruit_bl"] }
+rmk = { path = "../../../rmk", default-features = false, features = ["defmt", "storage", "vial", "watchdog", "nrf52840_ble", "split", "async_matrix", "adafruit_bl", "subrating"] }
 nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc", rev = "f54b6389ffa2750d4d3a4f5435660cb66b47e51a", features = [
     "defmt",
     "peripheral",

--- a/examples/use_rust/nrf52840_ble_split/Cargo.toml
+++ b/examples/use_rust/nrf52840_ble_split/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-rmk = { path = "../../../rmk", default-features = false, features = ["defmt", "storage", "vial", "watchdog", "nrf52840_ble", "split", "async_matrix", "adafruit_bl"] }
+rmk = { path = "../../../rmk", default-features = false, features = ["defmt", "storage", "vial", "watchdog", "nrf52840_ble", "split", "async_matrix", "adafruit_bl", "subrating"] }
 nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc", rev = "f54b6389ffa2750d4d3a4f5435660cb66b47e51a", features = [
     "defmt",
     "peripheral",

--- a/rmk-macro/src/codegen/chip/bind_interrupt.rs
+++ b/rmk-macro/src/codegen/chip/bind_interrupt.rs
@@ -176,6 +176,11 @@ pub(crate) fn bind_interrupt_default(hardware: &Hardware, item_mod: &ItemMod) ->
             };
 
             let ble_config = communication.get_ble_config().unwrap();
+            let support_subrating = if is_feature_enabled(&get_rmk_features(), "subrating") {
+                quote! { .support_connection_subrating_central() }
+            } else {
+                quote! {}
+            };
             let tx_power = if let Some(pwr) = ble_config.default_tx_power {
                 quote! { .default_tx_power(#pwr)?  }
             } else {
@@ -201,6 +206,7 @@ pub(crate) fn bind_interrupt_default(hardware: &Hardware, item_mod: &ItemMod) ->
                         .support_dle_central()
                         .support_phy_update_central()
                         .support_phy_update_peripheral()
+                        #support_subrating
                         #use_2m_phy
                         #tx_power
                         .central_count(#num_peri)?
@@ -215,6 +221,7 @@ pub(crate) fn bind_interrupt_default(hardware: &Hardware, item_mod: &ItemMod) ->
                     .support_peripheral()
                     .support_dle_peripheral()
                     .support_phy_update_peripheral()
+                    #support_subrating
                     #use_2m_phy
                     #tx_power
                     .peripheral_count(1)?

--- a/rmk-macro/src/codegen/chip/chip_init.rs
+++ b/rmk-macro/src/codegen/chip/chip_init.rs
@@ -5,6 +5,7 @@ use rmk_config::resolved::Hardware;
 use rmk_config::resolved::hardware::{BoardConfig, ChipModel, ChipSeries, CommunicationConfig};
 use syn::{ItemFn, ItemMod};
 
+use crate::codegen::feature::{get_rmk_features, is_feature_enabled};
 use crate::codegen::override_helper::{Overwritten, find_overwritten};
 
 /// Expand chip initialization code
@@ -83,14 +84,36 @@ pub(crate) fn chip_init_default(hardware: &Hardware, peripheral_id: Option<usize
             let ble_addr = get_ble_addr(hardware, peripheral_id);
             // Calculate the size of sdc memory pool.
             // Unibody: 4696. Split central: 6080 + (N-1) * 2288 per peripheral.
-            let sdc_mem_size = if peripheral_id.is_none() {
-                if peri_num > 0 {
-                    6080 + (peri_num.saturating_sub(1)) * 2288
+            // Base memory sizes for the nrf-sdc memory pool
+            const SDC_MEM_UNIBODY: usize = 4696;
+            const SDC_MEM_SPLIT_BASE: usize = 6080;
+            const SDC_MEM_PER_EXTRA_PERIPHERAL: usize = 2288;
+
+            // Connection subrating adds extra memory per connection
+            const SDC_MEM_SUBRATING_BASE: usize = 136;
+            const SDC_MEM_SUBRATING_PER_PERIPHERAL: usize = 56;
+            const SDC_MEM_SUBRATING_PER_EXTRA_PERIPHERAL: usize = 8;
+
+            let subrating_enabled = is_feature_enabled(&get_rmk_features(), "subrating");
+
+            let sdc_mem_size = if peripheral_id.is_none() && peri_num > 0 {
+                // Split central
+                let base =
+                    SDC_MEM_SPLIT_BASE + peri_num.saturating_sub(1) * SDC_MEM_PER_EXTRA_PERIPHERAL;
+                if subrating_enabled {
+                    base + SDC_MEM_SUBRATING_BASE
+                        + peri_num.saturating_sub(1) * SDC_MEM_SUBRATING_PER_PERIPHERAL
+                        + peri_num.saturating_sub(2) * SDC_MEM_SUBRATING_PER_EXTRA_PERIPHERAL
                 } else {
-                    4696
+                    base
                 }
             } else {
-                4696
+                // Unibody or split peripheral
+                if subrating_enabled {
+                    SDC_MEM_UNIBODY + SDC_MEM_SUBRATING_BASE
+                } else {
+                    SDC_MEM_UNIBODY
+                }
             };
             let ble_init = match &communication {
                 CommunicationConfig::Ble(_) | CommunicationConfig::Both(_, _) => quote! {

--- a/rmk-macro/src/codegen/split/peripheral.rs
+++ b/rmk-macro/src/codegen/split/peripheral.rs
@@ -161,6 +161,11 @@ fn expand_bind_interrupt_for_split_peripheral(
             };
 
             let ble_config = communication.get_ble_config().unwrap();
+            let support_subrating = if is_feature_enabled(&get_rmk_features(), "subrating") {
+                quote! { .support_connection_subrating_peripheral() }
+            } else {
+                quote! {}
+            };
             let tx_power = if let Some(pwr) = ble_config.default_tx_power {
                 quote! { .default_tx_power(#pwr)?  }
             } else {
@@ -263,6 +268,7 @@ fn expand_bind_interrupt_for_split_peripheral(
                         .support_dle_central()
                         .support_phy_update_central()
                         .support_phy_update_peripheral()
+                        #support_subrating
                         #use_2m_phy
                         #tx_power
                         .peripheral_count(1)?

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -183,7 +183,7 @@ defmt = [
 ]
 
 ## Enable logging via usb
-usb_log = ["dep:embassy-usb-logger", "log", "log/max_level_debug"]
+usb_log = ["dep:embassy-usb-logger", "log"]
 ## Use log, this feature cannot be enabled when defmt is enabled
 log = ["dep:log", "trouble-host?/log"]
 
@@ -275,6 +275,11 @@ _usb_high_speed = []
 ## Internal marker for chips without SAADC; compiles out `NrfAdc`.
 _no_saadc = []
 
+## Enable BLE connection subrating for split Connections
+subrating = []
+## Internal feature that indicates that subrating is not supported, this will be auto-activated for some chips
+_no_subrating = []
+
 #! ### BLE feature flags
 #!
 #! ⚠️ Due to the limitation of docs.rs, functions gated by BLE features won't show in docs.rs. You have to head to [`examples`](https://github.com/rmk-rs/rmk/tree/main/examples) folder of RMK repo for their usages.
@@ -307,7 +312,7 @@ esp32s3_ble = ["_esp_ble"]
 _esp_ble = ["_ble", "dep:esp-hal"]
 
 ## Enable feature if you want to use RP2040W with BLE.
-pico_w_ble = ["_ble", "dep:embassy-rp"]
+pico_w_ble = ["_ble", "_no_subrating", "dep:embassy-rp"]
 
 ## Enable feature if you want to use SF32LB52x with BLE.
 sf32lb52x_ble = ["_ble"]

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -1,4 +1,6 @@
 use bt_hci::cmd::le::{LeReadLocalSupportedFeatures, LeSetPhy};
+#[cfg(feature = "subrating")]
+use bt_hci::cmd::le::{LeSetHostFeature, LeSubrateRequest, LeSubrateRequestParams};
 use bt_hci::controller::{ControllerCmdAsync, ControllerCmdSync};
 use bt_hci::param::Error as HciError;
 use embassy_futures::join::join3;
@@ -50,6 +52,9 @@ pub(crate) mod profile;
 #[cfg(any(feature = "split", feature = "dongle"))]
 pub(crate) mod scan;
 pub(crate) mod sleep;
+
+#[cfg(all(feature = "subrating", feature = "_no_subrating"))]
+compile_error!("You may not enable feature `subrating` on unsupported platforms!");
 
 /// Max number of connections of a keyboard's BLE stack; a dongle sizes its
 /// own — see [`crate::dongle::Dongle`].
@@ -146,12 +151,19 @@ where
 }
 
 #[cfg(feature = "split")]
-impl<'a, C> Runnable for BleTransport<'a, C>
-where
-    C: Controller
+impl<
+    'a,
+    #[cfg(not(feature = "subrating"))] C: Controller
         + ControllerCmdAsync<LeSetPhy>
         + ControllerCmdSync<LeReadLocalSupportedFeatures>
         + ControllerCmdSync<bt_hci::cmd::le::LeSetScanParams>,
+    #[cfg(feature = "subrating")] C: Controller
+        + ControllerCmdAsync<LeSetPhy>
+        + ControllerCmdSync<LeReadLocalSupportedFeatures>
+        + ControllerCmdSync<bt_hci::cmd::le::LeSetScanParams>
+        + ControllerCmdSync<LeSetHostFeature>
+        + ControllerCmdAsync<LeSubrateRequest>,
+> Runnable for BleTransport<'a, C>
 {
     async fn run(&mut self) -> ! {
         // Load the preferred connection from storage
@@ -193,15 +205,19 @@ where
 
 /// Owns the GATT server and the profile manager, and advertises→connects→
 /// serves forever, joined with the stack runner and the sleep manager.
-async fn run_ble_keyboard<#[cfg(feature = "host")] 'r, C>(
+async fn run_ble_keyboard<
+    #[cfg(feature = "host")] 'r,
+    #[cfg(not(feature = "subrating"))] C: Controller + ControllerCmdAsync<LeSetPhy> + ControllerCmdSync<LeReadLocalSupportedFeatures>,
+    #[cfg(feature = "subrating")] C: Controller
+        + ControllerCmdAsync<LeSetPhy>
+        + ControllerCmdSync<LeReadLocalSupportedFeatures>
+        + ControllerCmdSync<LeSetHostFeature>,
+>(
     stack: &Stack<'_, C, DefaultPacketPool>,
     device_config: &DeviceConfig<'static>,
     config: &BleBatteryConfig<'static>,
     #[cfg(feature = "host")] host_service: Option<&'r crate::host::HostService<'r>>,
-) -> !
-where
-    C: Controller + ControllerCmdAsync<LeSetPhy> + ControllerCmdSync<LeReadLocalSupportedFeatures>,
-{
+) -> ! {
     let product_name = device_config.product_name;
     #[cfg(feature = "_nrf_ble")]
     let serial_number = crate::ble::nrf::get_serial_number();
@@ -259,6 +275,12 @@ where
     let profile_manager = &mut profile_manager;
 
     let connection_loop = async {
+        // Subrating: set host feature flag BEFORE ANY CONNECTIONS
+        // This must run concurrently with the ble_task runner (which processes HCI commands).
+        #[cfg(feature = "subrating")]
+        init_subrating_host_feature(stack).await;
+        STACK_STARTED.signal(());
+
         loop {
             // On the dongle slot, advertise directed to the bonded dongle or
             // as a seeking broadcast; on the normal profiles, plain HID.
@@ -378,6 +400,23 @@ where
     unreachable!("BleTransport sub-tasks must run forever")
 }
 
+/// Initialize subrating host support.
+///
+/// **Must** be called concurrently with `ble_task()` (the runner processes the
+/// HCI command) and **before** any advertising, scanning or connecting, because
+/// the controller only applies the feature flag to connections established after
+/// it is set.
+#[cfg(feature = "subrating")]
+pub(crate) async fn init_subrating_host_feature<C: Controller + ControllerCmdSync<LeSetHostFeature>>(
+    stack: &Stack<'_, C, impl PacketPool>,
+) {
+    const CONN_SUBRATING_HOST_BIT: u8 = 38;
+    let cmd = LeSetHostFeature::new(CONN_SUBRATING_HOST_BIT, 1);
+    if let Err(e) = stack.command(cmd).await {
+        error!("[Host] error setting subrating host feature flag: {:?}", e);
+    }
+}
+
 /// NoopHandler is used on the device which never scans,
 /// such as a split peripheral or a normal keyboard.
 pub(crate) struct NoopHandler;
@@ -398,11 +437,7 @@ pub(crate) async fn wait_for_stack_started() {
 }
 
 /// This is a background task that is required to run forever alongside any other BLE tasks.
-pub(crate) async fn ble_task<C: Controller + ControllerCmdAsync<LeSetPhy>, P: PacketPool, E: EventHandler>(
-    mut runner: Runner<'_, C, P>,
-    handler: &E,
-) {
-    STACK_STARTED.signal(());
+pub(crate) async fn ble_task<C: Controller, P: PacketPool, E: EventHandler>(mut runner: Runner<'_, C, P>, handler: &E) {
     loop {
         if let Err(e) = runner.run_with_handler(handler).await {
             error!("[ble_task] runner error: {:?}", e);
@@ -706,13 +741,19 @@ pub(crate) async fn set_conn_params<
     for interval in [Duration::from_millis(15), Duration::from_micros(7500)] {
         // Wait 5 seconds before each request to avoid connection drop
         embassy_time::Timer::after_secs(5).await;
+        let max_latency = if cfg!(feature = "subrating") {
+            // Set Central sleep for up to 2.25s to save power when the keyboard is asleep
+            (Duration::from_millis(2250).as_micros() / interval.as_micros()) as u16
+        } else {
+            30
+        };
         update_conn_params(
             stack,
             conn.raw(),
             &RequestedConnParams {
                 min_connection_interval: interval,
                 max_connection_interval: interval,
-                max_latency: 30,
+                max_latency,
                 supervision_timeout: Duration::from_secs(10),
                 ..Default::default()
             },
@@ -886,6 +927,40 @@ pub(crate) async fn update_conn_params<
         }
     }
     warn!("[update_conn_params] controller stayed busy, giving up");
+    false
+}
+
+/// Update the subrate factor.
+///
+/// Returns whether the request reached the controller, so callers that mirror
+/// the parameters in their own state don't record params that never landed.
+#[cfg(feature = "subrating")]
+pub(crate) async fn update_subrate_factor<C: Controller + ControllerCmdAsync<LeSubrateRequest>, P: PacketPool>(
+    stack: &Stack<'_, C, P>,
+    params: LeSubrateRequestParams,
+) -> bool {
+    for _ in 0..10 {
+        let subrate_request = LeSubrateRequest::from(params);
+        match stack.async_command(subrate_request).await {
+            Ok(_) => return true,
+            Err(BleHostError::BleHost(Error::Hci(error))) => {
+                if 0x3A == error.to_status().into_inner() {
+                    info!("[update_subrate_factor] HCI busy: {:?}", error);
+                    embassy_time::Timer::after_millis(100).await;
+                    continue;
+                }
+                error!("[update_subrate_factor] HCI error: {:?}", error);
+                return false;
+            }
+            Err(e) => {
+                #[cfg(feature = "defmt")]
+                let e = defmt::Debug2Format(&e);
+                error!("[update_subrate_factor] BLE host error: {:?}", e);
+                return false;
+            }
+        }
+    }
+    warn!("[update_subrate_factor] controller stayed busy, giving up");
     false
 }
 

--- a/rmk/src/split/ble/central.rs
+++ b/rmk/src/split/ble/central.rs
@@ -1,5 +1,9 @@
 use bt_hci::cmd::le::{LeReadLocalSupportedFeatures, LeSetPhy, LeSetScanParams};
+#[cfg(feature = "subrating")]
+use bt_hci::cmd::le::{LeSubrateRequest, LeSubrateRequestParams};
 use bt_hci::controller::{ControllerCmdAsync, ControllerCmdSync};
+#[cfg(feature = "subrating")]
+use bt_hci::param::ConnHandle;
 use embassy_futures::select::{Either, Either3, select, select3};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::channel::Channel;
@@ -11,6 +15,8 @@ use super::GattSplitMessage;
 use crate::ble::adv::Adv;
 use crate::ble::scan::{SPLIT_CENTRAL_SCAN_WINDOW, scan_config, start_scan};
 use crate::ble::sleep::report_activity;
+#[cfg(feature = "subrating")]
+use crate::ble::update_subrate_factor;
 use crate::ble::{update_ble_phy, update_conn_params, wait_for_stack_started};
 use crate::channel::FLASH_CHANNEL;
 use crate::event::{EventSubscriber, SleepStateEvent, SubscribableEvent};
@@ -172,7 +178,15 @@ impl EventHandler for ScanHandler {
 /// report back so the radio reconnects or rediscovers the peripheral.
 pub(crate) async fn run_peripheral_session<
     'a,
-    C: Controller + ControllerCmdAsync<LeSetPhy> + ControllerCmdSync<LeReadLocalSupportedFeatures>,
+    #[cfg(not(feature = "subrating"))] C: Controller
+        + ControllerCmdSync<LeSetScanParams>
+        + ControllerCmdAsync<LeSetPhy>
+        + ControllerCmdSync<LeReadLocalSupportedFeatures>,
+    #[cfg(feature = "subrating")] C: Controller
+        + ControllerCmdSync<LeSetScanParams>
+        + ControllerCmdAsync<LeSetPhy>
+        + ControllerCmdSync<LeReadLocalSupportedFeatures>
+        + ControllerCmdAsync<LeSubrateRequest>,
 >(
     id: usize,
     conns: &Channel<NoopRawMutex, Connection<'a, DefaultPacketPool>, 1>,
@@ -203,9 +217,21 @@ fn default_central_conn_param() -> RequestedConnParams {
     RequestedConnParams {
         min_connection_interval: Duration::from_micros(7500),
         max_connection_interval: Duration::from_micros(7500),
-        max_latency: 10, // 75ms
+        max_latency: 300, // 2250ms
         supervision_timeout: Duration::from_secs(5),
         ..Default::default()
+    }
+}
+
+#[cfg(feature = "subrating")]
+fn default_central_subrate_params(handle: ConnHandle) -> LeSubrateRequestParams {
+    LeSubrateRequestParams {
+        handle,
+        subrate_min: 1,
+        subrate_max: 1,
+        max_latency: 300, // 2250ms
+        continuation_number: 0,
+        supervision_timeout: ::bt_hci::param::Duration::from_secs(5),
     }
 }
 
@@ -235,10 +261,39 @@ fn sleep_central_conn_param() -> RequestedConnParams {
     }
 }
 
+#[cfg(feature = "subrating")]
+fn sleep_central_subrate_params(handle: ConnHandle) -> LeSubrateRequestParams {
+    if crate::state::active_transport().is_some() {
+        // Host connected — short subrate so key presses arrive quickly
+        LeSubrateRequestParams {
+            handle,
+            subrate_min: 60, // 450ms effective interval → 457.5ms key press latency
+            subrate_max: 60,
+            max_latency: 7,         // 3.6s sleep for peripheral
+            continuation_number: 2, // assure low-latency reset of subrate factor
+            supervision_timeout: ::bt_hci::param::Duration::from_secs(8),
+        }
+    } else {
+        // No host — very long interval, peripheral will be unresponsive for ~2s after reconnect
+        LeSubrateRequestParams {
+            handle,
+            subrate_min: 249, // 1867.5ms effective interval
+            subrate_max: 249,
+            max_latency: 1,         // 3.6s sleep for peripheral
+            continuation_number: 2, // assure low-latency reset of subrate factor
+            supervision_timeout: ::bt_hci::param::Duration::from_secs(8),
+        }
+    }
+}
+
 async fn run_central_manager_task<
     'b,
     's: 'b,
-    C: Controller + ControllerCmdAsync<LeSetPhy> + ControllerCmdSync<LeReadLocalSupportedFeatures>,
+    #[cfg(not(feature = "subrating"))] C: Controller + ControllerCmdAsync<LeSetPhy> + ControllerCmdSync<LeReadLocalSupportedFeatures>,
+    #[cfg(feature = "subrating")] C: Controller
+        + ControllerCmdAsync<LeSetPhy>
+        + ControllerCmdSync<LeReadLocalSupportedFeatures>
+        + ControllerCmdAsync<LeSubrateRequest>,
     P: PacketPool,
 >(
     id: usize,
@@ -373,7 +428,8 @@ impl<'a, 'b, 'c, C: Controller + ControllerCmdAsync<LeSetPhy>, P: PacketPool> Sp
 async fn follow_sleep_state<
     'b,
     's: 'b,
-    C: Controller + ControllerCmdAsync<LeSetPhy> + ControllerCmdSync<LeReadLocalSupportedFeatures>,
+    #[cfg(not(feature = "subrating"))] C: Controller + ControllerCmdAsync<LeSetPhy> + ControllerCmdSync<LeReadLocalSupportedFeatures>,
+    #[cfg(feature = "subrating")] C: Controller + ControllerCmdAsync<LeSetPhy> + ControllerCmdAsync<LeSubrateRequest>,
     P: PacketPool,
 >(
     stack: &'b Stack<'s, C, P>,
@@ -396,13 +452,28 @@ async fn follow_sleep_state<
         if sleeping == applied {
             continue;
         }
-        let params = if sleeping {
-            sleep_central_conn_param()
-        } else {
-            default_central_conn_param()
-        };
-        if update_conn_params(stack, conn, &params).await {
-            applied = sleeping;
+        #[cfg(not(feature = "subrating"))]
+        {
+            let params = if sleeping {
+                sleep_central_conn_param()
+            } else {
+                default_central_conn_param()
+            };
+            if update_conn_params(stack, conn, &params).await {
+                applied = sleeping;
+            }
+        }
+
+        #[cfg(feature = "subrating")]
+        {
+            let params = if sleeping {
+                sleep_central_subrate_params(conn.handle())
+            } else {
+                default_central_subrate_params(conn.handle())
+            };
+            if update_subrate_factor(stack, params).await {
+                applied = sleeping;
+            }
         }
     }
 }

--- a/rmk/src/split/ble/peripheral.rs
+++ b/rmk/src/split/ble/peripheral.rs
@@ -1,5 +1,5 @@
-use bt_hci::cmd::le::LeSetPhy;
-use bt_hci::controller::ControllerCmdAsync;
+#[cfg(feature = "subrating")]
+use bt_hci::{cmd::le::LeSetHostFeature, controller::ControllerCmdSync};
 use embassy_futures::join::join;
 use embassy_time::{Duration, Timer};
 use rmk_types::connection::ConnectionStatus;
@@ -130,7 +130,12 @@ impl<'stack, 'server, 'c, P: PacketPool> SplitWriter for BleSplitPeripheralDrive
 /// * `id` - The id of the peripheral
 /// * `central_addr` - The address of the central
 /// * `stack` - The stack to use
-pub async fn initialize_nrf_ble_split_peripheral_and_run<'b, 's: 'b, C: Controller + ControllerCmdAsync<LeSetPhy>>(
+pub async fn initialize_nrf_ble_split_peripheral_and_run<
+    'b,
+    's: 'b,
+    #[cfg(feature = "subrating")] C: Controller + ControllerCmdSync<LeSetHostFeature>,
+    #[cfg(not(feature = "subrating"))] C: Controller,
+>(
     id: usize,
     stack: &'b Stack<'s, C, DefaultPacketPool>,
 ) {
@@ -146,6 +151,10 @@ pub async fn initialize_nrf_ble_split_peripheral_and_run<'b, 's: 'b, C: Controll
         .map(|a| a.address);
 
     let peri_task = async {
+        // Set subrating host support before any advertising/connecting
+        #[cfg(feature = "subrating")]
+        crate::ble::init_subrating_host_feature(stack).await;
+
         let server = BleSplitPeripheralServer::new_default("rmk").unwrap();
         loop {
             update_status(|c| *c = ConnectionStatus::new());

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "_ble")]
-use bt_hci::{cmd::le::LeSetPhy, controller::ControllerCmdAsync};
+#[cfg(all(feature = "_ble", feature = "subrating"))]
+use bt_hci::{cmd::le::LeSetHostFeature, controller::ControllerCmdSync};
 use embassy_futures::select::{Either, select};
 #[cfg(not(feature = "_ble"))]
 use embedded_io_async::{Read, Write};
@@ -35,7 +36,8 @@ use crate::state::update_status;
 /// * `address` - (optional) The BLE address of this peripheral
 /// * `serial` - (optional) serial port used to send peripheral split message. This argument is enabled only for serial split now
 pub async fn run_rmk_split_peripheral<
-    #[cfg(feature = "_ble")] C: Controller + ControllerCmdAsync<LeSetPhy>,
+    #[cfg(all(feature = "_ble", feature = "subrating"))] C: Controller + ControllerCmdSync<LeSetHostFeature>,
+    #[cfg(all(feature = "_ble", not(feature = "subrating")))] C: Controller,
     #[cfg(not(feature = "_ble"))] S: Write + Read,
 >(
     #[cfg(feature = "_ble")] id: usize,


### PR DESCRIPTION
As promised a few months back, here is a first draft for enabling connection subrating support on the peripheral connection.

#### Initial Results
Using a subrating factor of **30** (equivalent to a connection interval of **225ms**):
* **Central:** 50–80 µA
* **Peripheral:** ~30 µA

The latency to return to 7.5ms intervals is **225ms + 2×7.5ms** (compared to 5–7 seconds when using standard connection updates). 

This allows us to use sleep mode much more aggressively, as input lag only impacts the very first keystroke.

#### Open Questions / Next Steps 

- [X] **Fast Polling Loop (Resolved)**  
   [#886](https://github.com/HaoboGu/rmk/issues/886) introduced a fast polling loop (5ms) leading to 500–700 µA current draw on Central. *(Tracked/resolved via [#1010](https://github.com/HaoboGu/rmk/issues/1010)).*

- [X] **Central Max Latency**  
   I adjusted Central max latency to match the subrating duration. Unsure what effect this has on OS-level support.
   We will use max_latency = 30 for now and leave timing optimization for a later commit.

- [X] **GATT Buffer Sizing (Resolved)**  
   `SplitMessage` GATT messages were sending the entire buffer rather than just the encoded payload. Truncating to the encoded data allows faster resets of the subrate factor. *(Merged via [#1011](https://github.com/HaoboGu/rmk/pull/1011)).*  
   * Reference: [`rmk/src/split/ble/peripheral.rs#L113-L116`](https://github.com/HaoboGu/rmk/blob/936a2a828fddc195d20e42bd952119cd3afa8172/rmk/src/split/ble/peripheral.rs#L113-L116) and [`rmk/src/split/ble/central.rs#L449-L450`](https://github.com/HaoboGu/rmk/blob/936a2a828fddc195d20e42bd952119cd3afa8172/rmk/src/split/ble/central.rs#L449-L450).