### PR TITLE
fix(dfu_split): wait for passthrough signal instead of polling

### DIFF
--- a/rmk/src/dfu/mod.rs
+++ b/rmk/src/dfu/mod.rs
@@ -58,7 +58,8 @@ mod split;
 use self::split::PassthroughDfuHandler;
 #[cfg(feature = "dfu_split")]
 pub(crate) use self::split::{
-    PASSTHROUGH_TARGET, PassthroughCommand, passthrough_done_if_empty, passthrough_pending, passthrough_take_command,
+    PASSTHROUGH_SIGNAL, PASSTHROUGH_TARGET, PassthroughCommand, passthrough_done_if_empty, passthrough_pending,
+    passthrough_take_command,
 };
 #[cfg(feature = "dfu_split")]
 pub use self::split::{

--- a/rmk/src/dfu/split/central.rs
+++ b/rmk/src/dfu/split/central.rs
@@ -3,6 +3,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 
 use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
 use embassy_usb::class::dfu::consts::Status;
 use embassy_usb::class::dfu::dfu_mode::{self};
 use heapless;
@@ -217,6 +218,9 @@ static PASSTHROUGH_CMD: Mutex<
     RefCell<heapless::Vec<PassthroughCommand, PASSTHROUGH_QUEUE_SIZE>>,
 > = Mutex::new(RefCell::new(heapless::Vec::new()));
 
+/// Wakeup signal: set when a command is pushed to [`PASSTHROUGH_CMD`].
+pub(crate) static PASSTHROUGH_SIGNAL: Signal<CriticalSectionRawMutex, u8> = Signal::new();
+
 /// Doorbell atomic: set to a peripheral ID when there is work in
 /// [`PASSTHROUGH_CMD`], `usize::MAX` when idle.
 ///
@@ -232,7 +236,9 @@ pub(crate) fn passthrough_pending(id: usize) -> bool {
 
 /// Push a command into the queue (ISR-safe).
 fn passthrough_push(cmd: PassthroughCommand) -> Result<(), ()> {
-    PASSTHROUGH_CMD.lock(|c| c.borrow_mut().push(cmd).map_err(|_| ()))
+    PASSTHROUGH_CMD.lock(|c| c.borrow_mut().push(cmd).map_err(|_| ()))?;
+    PASSTHROUGH_SIGNAL.signal(1);
+    Ok(())
 }
 
 /// Pop the next pending command (async task).

--- a/rmk/src/dfu/split/mod.rs
+++ b/rmk/src/dfu/split/mod.rs
@@ -155,8 +155,8 @@ mod central;
 mod peripheral;
 
 pub(crate) use central::{
-    PASSTHROUGH_TARGET, PassthroughCommand, PassthroughDfuHandler, passthrough_done_if_empty, passthrough_pending,
-    passthrough_take_command,
+    PASSTHROUGH_SIGNAL, PASSTHROUGH_TARGET, PassthroughCommand, PassthroughDfuHandler, passthrough_done_if_empty,
+    passthrough_pending, passthrough_take_command,
 };
 pub use central::{get_firmware_update_data, set_firmware_update_data};
 pub use peripheral::{SplitDfuHandler, read_embedded_firmware_hash};

--- a/rmk/src/split/driver.rs
+++ b/rmk/src/split/driver.rs
@@ -230,9 +230,12 @@ impl<const ROW: usize, const COL: usize, const ROW_OFFSET: usize, const COL_OFFS
                 }
             };
 
-            let event_or_timer = select(next_event_to_peri, embassy_time::Timer::after_millis(5));
+            #[cfg(feature = "dfu_split")]
+            let event_or_signal = select(next_event_to_peri, crate::dfu::PASSTHROUGH_SIGNAL.wait());
+            #[cfg(not(feature = "dfu_split"))]
+            let event_or_signal = next_event_to_peri;
 
-            match select(self.transceiver.read(), event_or_timer).await {
+            match select(self.transceiver.read(), event_or_signal).await {
                 Either::First(read_result) => match read_result {
                     #[cfg(feature = "dfu_split")]
                     Ok(SplitMessage::FirmwareHashResponse(hash)) => {
@@ -241,12 +244,21 @@ impl<const ROW: usize, const COL: usize, const ROW_OFFSET: usize, const COL_OFFS
                     Ok(split_message) => self.process_peripheral_message(split_message).await,
                     Err(e) => error!("Peripheral message read error: {:?}", e),
                 },
-                Either::Second(Either::First(msg)) => {
+                #[cfg(feature = "dfu_split")]
+                Either::Second(result) => match result {
+                    Either::First(msg) => {
+                        if self.send(&msg).await.is_err() {
+                            return;
+                        }
+                    }
+                    Either::Second(_) => {}
+                },
+                #[cfg(not(feature = "dfu_split"))]
+                Either::Second(msg) => {
                     if self.send(&msg).await.is_err() {
                         return;
                     }
                 }
-                Either::Second(Either::Second(())) => {}
             }
         }
     }


### PR DESCRIPTION
Quick and easy fix for #1010 by using embassy_sync's signal instead of polling every 5ms. 

Maybe I will revisit this in the future and do some refinement, but this should do the trick for now. 

fix: #1010