### PR TITLE
fix(dfu): fix non-defmt DFU builds and reject dfu_split + BLE clearly

### DIFF
--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix spurious "Timer buffer full" warns after 16 distinct key positions are pressed. The per-position timer `LinearMap` is gone; press time is now threaded as a parameter through the morse-press dispatch.
 - Fix override attributes (`#[Override(...)]` / `#[Overwritten(...)]`) silently falling back to the generated default: an unknown or miscased variant (e.g. `Entry` instead of `entry`) is now a compile error carrying darling's diagnostic, and an extra attribute on the function (doc comments included) no longer disables a valid override ([#966](https://github.com/rmk-rs/rmk/issues/966))
 - Fix `#[Override(bind_interrupt)]` (the form the stm32h7 example documents) never taking effect: the custom interrupt binding is now selected through the shared override matcher instead of being silently dropped in favor of the generated default. The legacy bare `#[bind_interrupt]` marker keeps working unchanged
+- Fix non-`defmt` DFU builds (e.g. `dfu_rp` with `usb_log`) failing with a borrow-of-moved-value error on `central_attrs`: embassy-usb's `DfuAttributes` is `Copy` only under `defmt`, so the DFU descriptor now reads the attribute bits before handing the attributes to `DfuState` ([#973](https://github.com/rmk-rs/rmk/issues/973))
 
 ## [0.8.2] - 2025-12-18
 

--- a/rmk/src/dfu/mod.rs
+++ b/rmk/src/dfu/mod.rs
@@ -327,6 +327,8 @@ pub fn register_dfu_interface<D: Driver<'static>>(
 
     // Alt 0: Central flash
     let central_attrs = DfuAttributes::CAN_DOWNLOAD | DfuAttributes::WILL_DETACH;
+    // embassy-usb's DfuAttributes is Copy only under defmt, so read the bits before the move
+    let central_attrs_bits = central_attrs.bits();
     let central_handler = RmkDfuHandler {
         inner: FirmwareHandler::new(updater, ResetImmediate),
         target_id: None,
@@ -364,7 +366,7 @@ pub fn register_dfu_interface<D: Driver<'static>>(
     alt.descriptor(
         0x21,
         &[
-            central_attrs.bits(),
+            central_attrs_bits,
             0xc4,
             0x09,
             (BLOCK_SIZE_DFU & 0xff) as u8,

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -34,6 +34,12 @@ compile_error!(
      Use `defmt` logging on these chips."
 );
 
+#[cfg(all(feature = "dfu_split", feature = "_ble"))]
+compile_error!(
+    "`dfu_split` is not supported on BLE keyboards yet: the DFU passthrough only \
+     runs over the wired split transport. Disable `dfu_split` on BLE builds."
+);
+
 // Re-export self as ::rmk for macro-generated code to work both inside and outside the crate
 extern crate self as rmk;
 


### PR DESCRIPTION
Fixes #973

Two DFU build fixes:

1. **Non-`defmt` DFU builds failed with E0382** (`borrow of moved value: central_attrs`): embassy-usb's `DfuAttributes` derives `Copy` only under `defmt`, so building with `dfu_rp`/`dfu_nrf` plus `usb_log`/`log` hit a use-after-move at the DFU descriptor write. The descriptor now reads the attribute bits before handing the attributes to `DfuState`.

2. **`dfu_split` + BLE now fails fast with a clear `compile_error!`**: the BLE split transport has never compiled with `dfu_split` (missing `UpdatePolicy` plumbing, split message buffers outgrow derived `Default`), and the docs already scope DFU passthrough to serial splits. Instead of four obscure type errors, the build now reports: `dfu_split is not supported on BLE keyboards yet`.

## Verification (thumbv7em, all via `cargo check`)

| Feature combo | Before | After |
|---|---|---|
| `dfu_nrf` + `log` (non-defmt) | E0382 | ✅ |
| `dfu_nrf` + `defmt` | ✅ | ✅ |
| `dfu_nrf,dfu_split,split` + `log` (serial split) | ✅ | ✅ |
| `dfu_nrf` + `_ble` + `log` (non-split BLE + USB DFU, documented combo) | ✅ | ✅ |
| `dfu_nrf,dfu_split,split,_ble` | 4 obscure type errors | clear `compile_error!` first |
