### PR TITLE
Make rust-analyzer work out of the box in Emacs

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,35 @@
+;;; Directory Local Variables            -*- no-byte-compile: t -*-
+;;; For more information see (info "(emacs) Directory Variables")
+
+;; This repository has no Cargo.toml at its root: every crate is a separate
+;; workspace. rust-analyzer therefore finds nothing to load here and instead
+;; walks up the directory tree, adopting whichever outer workspace happens to
+;; contain the checkout. Every file in the repository is then reported as not
+;; belonging to any project, and completion, hover and diagnostics all go
+;; silent.
+;;
+;; The project list below is the Emacs counterpart of the
+;; `rust-analyzer.linkedProjects' settings in .vscode/settings.json and
+;; .zed/settings.json, and is spelled twice so that it applies whether Eglot or
+;; lsp-mode is driving the server. To work on one of the crates under
+;; examples/, add its Cargo.toml to both lists.
+
+((nil
+  . ((eglot-workspace-configuration
+      . (:rust-analyzer
+         (:linkedProjects ["rmk/Cargo.toml"
+                           "rmk-config/Cargo.toml"
+                           "rmk-macro/Cargo.toml"
+                           "rmk-types/Cargo.toml"
+                           "rynk/Cargo.toml"]
+          :cargo (:noDefaultFeatures t)
+          :check (:allTargets :json-false))))
+
+     (lsp-rust-analyzer-linked-projects
+      . ["rmk/Cargo.toml"
+         "rmk-config/Cargo.toml"
+         "rmk-macro/Cargo.toml"
+         "rmk-types/Cargo.toml"
+         "rynk/Cargo.toml"])
+     (lsp-rust-no-default-features . t)
+     (lsp-rust-analyzer-check-all-targets . nil))))

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 channel = "stable"
-components = ["rust-src", "rustfmt", "llvm-tools", "clippy"]
+components = ["rust-src", "rustfmt", "llvm-tools", "clippy", "rust-analyzer"]
 targets = [
     "thumbv7em-none-eabi",
     "thumbv7m-none-eabi",


### PR DESCRIPTION
## Problem

This repository has no `Cargo.toml` at its root: each crate is a separate workspace. rust-analyzer therefore finds nothing to load when it starts here, and falls back to walking up the directory tree until it finds *some* manifest — adopting whichever outer workspace happens to contain the checkout.

When that happens every file in the repository is reported as belonging to no project, so completion, hover and diagnostics are silent everywhere. It reads as "LSP is completely broken" rather than as a misconfiguration.

`.vscode/settings.json` and `.zed/settings.json` already avoid this by pinning `rust-analyzer.linkedProjects`. Emacs had no equivalent.

## Changes

**`.dir-locals.el`** — the Emacs counterpart of the existing VS Code and Zed settings. The project list is spelled twice, once as `eglot-workspace-configuration` and once as the lsp-mode variables, so it works with either client without the user configuring anything. It carries the same `cargo.noDefaultFeatures` and `check.allTargets` values the other two editors already use.

**`rust-toolchain.toml`** — add `rust-analyzer` to `components`. This is an independent bug and can be dropped from this PR without affecting the first commit. `rust-toolchain.toml` pins the stable channel but never requests the component, so rustup has no rust-analyzer for the toolchain it selects; its shim falls back to the next `rust-analyzer` on `PATH`, which is the same shim. Running `rust-analyzer` in the repository currently exits with:

```
info: `rust-analyzer` is unavailable for the active toolchain
info: falling back to "/…/bin/rust-analyzer"
error: infinite recursion detected
```

After the change it resolves to the binary matching the pinned toolchain. Nix flake users are unaffected either way, since the flake already supplies rust-analyzer.

## Verification

- The dir-locals are applied and serialize to the settings rust-analyzer expects:
  ```json
  {"linkedProjects":["rmk/Cargo.toml","rmk-config/Cargo.toml","rmk-macro/Cargo.toml","rmk-types/Cargo.toml","rynk/Cargo.toml"],
   "cargo":{"noDefaultFeatures":true},"check":{"allTargets":false}}
  ```
- All five linked manifests load: `cargo metadata --no-default-features` succeeds in each.
- `rust-analyzer --version` in the repository returns `1.97.1` instead of `infinite recursion detected`.

No Rust source or build behaviour is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)