### PR TITLE
fix(split): adv data bounds check and shorter supervision timeout

### DIFF
--- a/rmk/src/split/ble/central.rs
+++ b/rmk/src/split/ble/central.rs
@@ -132,8 +132,8 @@ pub(crate) struct ScanHandler {}
 impl EventHandler for ScanHandler {
     fn on_adv_reports(&self, mut it: LeAdvReportsIter<'_>) {
         while let Some(Ok(report)) = it.next() {
-            // Check advertisement data
-            if report.data.len() < 25 {
+            // Check advertisement data, `report.data[25]` is read below
+            if report.data.len() < 26 {
                 continue;
             }
             if report.data[4] == 0x07

--- a/rmk/src/split/ble/central.rs
+++ b/rmk/src/split/ble/central.rs
@@ -253,7 +253,7 @@ fn default_central_conn_param() -> RequestedConnParams {
         min_connection_interval: Duration::from_micros(7500),
         max_connection_interval: Duration::from_micros(7500),
         max_latency: 10, // 75ms
-        supervision_timeout: Duration::from_secs(10),
+        supervision_timeout: Duration::from_secs(5),
         ..Default::default()
     }
 }


### PR DESCRIPTION
Two independent fixes in the BLE split central.

## Advertisement data length check

`ScanHandler::on_adv_reports` guarded the advertisement report with `report.data.len() < 25`, but the peripheral id is read from `report.data[25]`, which needs 26 bytes. A report of exactly 25 bytes that matched the UUID and manufacturer-data checks passed the guard and then panicked on an out-of-bounds index.

## Supervision timeout

The central -> peripheral link used a 10s supervision timeout, so a dead link took 10s to detect. Shortened to 5s, which stays well above the spec minimum of `(1 + 10) * 7.5ms * 2 = 165ms`.

## Test plan

- `cargo check --no-default-features --features=split,vial,storage,async_matrix,_ble`
