### PR TITLE
refactor(split): share the advertising company id via rmk-types

### DIFF
--- a/rmk-types/src/ble.rs
+++ b/rmk-types/src/ble.rs
@@ -1,7 +1,10 @@
-//! BLE status types.
+//! BLE status types and advertising constants.
 
 use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
+
+/// Company identifier in RMK's manufacturer-specific advertising data.
+pub const RMK_ADV_COMPANY_ID: u16 = 0x5253;
 
 /// BLE state (what the BLE subsystem is currently doing).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, MaxSize)]

--- a/rmk/src/split/ble/central.rs
+++ b/rmk/src/split/ble/central.rs
@@ -6,6 +6,7 @@ use embassy_futures::select::{Either, Either3, select, select3};
 use embassy_sync::mutex::Mutex;
 use embassy_sync::signal::Signal;
 use embassy_time::{Duration, Timer, with_timeout};
+use rmk_types::ble::RMK_ADV_COMPANY_ID;
 use trouble_host::prelude::*;
 
 use super::GattSplitMessage;
@@ -119,7 +120,8 @@ impl EventHandler for ScanHandler {
             }
             if report.data[4] == 0x07
                 && report.data[5..].starts_with(&SPLIT_SERVICE_UUID)
-                && report.data[21..25] == [0x04, 0xff, 0x18, 0xe1]
+                && report.data[21..23] == [0x04, 0xff]
+                && report.data[23..25] == RMK_ADV_COMPANY_ID.to_le_bytes()
             {
                 // Uuid and manufacturer specific data check passed
                 let peripheral_id = report.data[25];

--- a/rmk/src/split/ble/peripheral.rs
+++ b/rmk/src/split/ble/peripheral.rs
@@ -250,7 +250,7 @@ fn get_peri_advertiser<'a, C: Controller>(
                         ],
                     ]),
                     AdStructure::ManufacturerSpecificData {
-                        company_identifier: 0xe118,
+                        company_identifier: rmk_types::ble::RMK_ADV_COMPANY_ID,
                         payload: &[id as u8],
                     },
                 ],


### PR DESCRIPTION
Both split halves hardcoded the manufacturer-specific company id in RMK's advertising data: the peripheral as `0xe118`, the central as the wire bytes `[0x18, 0xe1]` buried inside a larger byte match. This gives it one home in `rmk_types::ble::RMK_ADV_COMPANY_ID`.

Split out of #1028, which needs the constant for the dongle's seeking advertisement. It stands on its own, and it is the only breaking change in that stack — worth its own review rather than eight lines inside ten thousand.

## Breaking

The id changes to `0x5253`. **A keyboard's two halves must be reflashed together**: a new central will not find an old peripheral, or the other way round. The failure is silent — the central simply never matches, so the peripheral looks absent. Needs a release note.

Neither value is Bluetooth SIG assigned, so this is a rename rather than a correctness fix; doing it now, before the constant grows a second user, is cheaper than doing it later.