### PR TITLE
fix(keyboard): deduplicate held keycodes in the keyboard report

### DIFF
--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix override attributes (`#[Override(...)]` / `#[Overwritten(...)]`) silently falling back to the generated default: an unknown or miscased variant (e.g. `Entry` instead of `entry`) is now a compile error carrying darling's diagnostic, and an extra attribute on the function (doc comments included) no longer disables a valid override ([#966](https://github.com/rmk-rs/rmk/issues/966))
 - Fix `#[Override(bind_interrupt)]` (the form the stm32h7 example documents) never taking effect: the custom interrupt binding is now selected through the shared override matcher instead of being silently dropped in favor of the generated default. The legacy bare `#[bind_interrupt]` marker keeps working unchanged
 - Fix non-`defmt` DFU builds (e.g. `dfu_rp` with `usb_log`) failing with a borrow-of-moved-value error on `central_attrs`: embassy-usb's `DfuAttributes` is `Copy` only under `defmt`, so the DFU descriptor now reads the attribute bits before handing the attributes to `DfuState` ([#973](https://github.com/rmk-rs/rmk/issues/973))
+- Fix a dropped keypress when two keys resolve to the same HID keycode with different modifiers (a plain bracket and its `SHIFTED()` neighbor). Rolling them quickly sent the same usage in two report slots, which some hosts read as a release of the held key and dropped the second key. Keyboard reports now deduplicate keycodes so the shared usage stays down until the last holder releases it
 
 ## [0.8.2] - 2025-12-18
 

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1841,20 +1841,40 @@ impl<'a> Keyboard<'a> {
         }
     }
 
-    pub(crate) async fn send_keyboard_report_with_resolved_modifiers(&mut self, pressed: bool) {
-        // all modifier related effects are combined here to be sent with the hid report:
+    /// Build the keyboard report for the current held keycodes with modifiers
+    /// resolved.
+    ///
+    /// Multiple slots can hold the same HID usage, but the host only tracks
+    /// each usage as up or down, so duplicates are collapsed to the first slot
+    /// that holds them. This keeps the shared usage down until the last holder
+    /// releases it.
+    pub(crate) fn build_keyboard_report(&mut self, pressed: bool) -> KeyboardReport {
         let modifiers = self.resolve_modifiers(pressed);
         info!(
             "Sending keyboard report, modifiers: {:?}, keycodes: {:?}",
             modifiers, &self.held_keycodes,
         );
-        self.send_report(Report::KeyboardReport(KeyboardReport {
+        let mut keycodes = [0u8; 6];
+        let mut n = 0;
+        for k in self.held_keycodes {
+            let code = k as u8;
+            if code != 0 && !keycodes[..n].contains(&code) {
+                keycodes[n] = code;
+                n += 1;
+            }
+        }
+        KeyboardReport {
             modifier: modifiers.into_bits(),
             reserved: 0,
             leds: LOCK_LED_STATES.load(core::sync::atomic::Ordering::Relaxed),
-            keycodes: self.held_keycodes.map(|k| k as u8),
-        }))
-        .await;
+            keycodes,
+        }
+    }
+
+    /// Send the keyboard report with resolved modifiers to the host.
+    pub(crate) async fn send_keyboard_report_with_resolved_modifiers(&mut self, pressed: bool) {
+        let report = self.build_keyboard_report(pressed);
+        self.send_report(Report::KeyboardReport(report)).await;
 
         // Yield once after sending the report to channel
         yield_now().await;
@@ -1902,26 +1922,17 @@ impl<'a> Keyboard<'a> {
 
     /// Register a key to be sent in hid report.
     fn register_keycode(&mut self, key: HidKeyCode, event: KeyboardEvent) {
-        // First, find the key event slot according to the position
-        let slot = self.registered_keys.iter().enumerate().find_map(|(i, k)| {
-            if let Some(e) = k
-                && event.pos == e.pos
-            {
-                return Some(i);
-            }
-            None
-        });
+        // First, find the key event slot according to the position, then the first
+        // free slot.
+        let slot = self
+            .registered_keys
+            .iter()
+            .position(|k| k.is_some_and(|e| e.pos == event.pos))
+            .or_else(|| self.held_keycodes.iter().position(|&k| k == HidKeyCode::No));
 
-        // If the slot is found, update the key in the slot
-        if let Some(index) = slot {
-            self.held_keycodes[index] = key;
-            self.registered_keys[index] = Some(event);
-        } else {
-            // Otherwise, find the first free slot
-            if let Some(index) = self.held_keycodes.iter().position(|&k| k == HidKeyCode::No) {
-                self.held_keycodes[index] = key;
-                self.registered_keys[index] = Some(event);
-            }
+        if let Some(slot) = slot {
+            self.held_keycodes[slot] = key;
+            self.registered_keys[slot] = Some(event);
         }
     }
 

--- a/rmk/tests/scenarios/hid_reports.toml
+++ b/rmk/tests/scenarios/hid_reports.toml
@@ -2,14 +2,33 @@
 # rather than in the keyboard report, and each sends an all-released report on
 # key up. Three keys, three pages — this file carries its own keyboard instead
 # of the shared board because none of these keys is a fixture anyone else needs.
+#
+# `MO(1)` at (0,3) adds a second layer for the rollover cases below: layer 1
+# row 1 pairs a plain keycode with its `SHIFTED()` twin, row 2 is four
+# distinct keycodes as a control.
 
 [layout]
-rows = 1
-cols = 3
-map = "(0,0)  (0,1)  (0,2)"
+rows = 3
+cols = 4
+map = """
+(0,0)  (0,1)  (0,2)  (0,3)
+(1,0)  (1,1)  (1,2)  (1,3)
+(2,0)  (2,1)  (2,2)  (2,3)
+"""
 
 [[keymap.layer]]
-keys = "AudioVolUp  SystemSleep  MouseRight"
+keys = """
+AudioVolUp  SystemSleep  MouseRight  MO(1)
+No          No           No          No
+No          No           No          No
+"""
+
+[[keymap.layer]]
+keys = """
+No            No            No                      No
+SHIFTED(Dot)  RightBracket  SHIFTED(RightBracket)  SHIFTED(Kc0)
+Minus         Kc7           Kc8                     Kc9
+"""
 
 [[test]]
 name = "consumer_key_reports_on_the_consumer_page"
@@ -34,3 +53,59 @@ steps = [
   { release = [0, 2] },
 ]
 expect = [{ mouse = { x = 5 } }, { mouse = { } }]
+
+# `]` and its `SHIFTED()` twin `}` share one HID usage. The report
+# deduplicates held keycodes so the shared usage stays down until the
+# last holder releases it; the second key no longer vanishes on a roll.
+[[test]]
+name = "shared_keycode_roll_keeps_second_key"
+steps = [
+  { press = [0, 3] },   # MO(1)
+  { press = [1, 0] },   # >
+  { press = [1, 1] },   # ]
+  { release = [1, 0] },
+  { press = [1, 2] },   # }
+  { release = [1, 1] },
+  { press = [1, 3] },   # )
+  { release = [1, 2] },
+  { release = [1, 3] },
+  { release = [0, 3] },
+]
+expect = [
+  ["LShift", "Dot"],
+  ["Dot", "RightBracket"],
+  ["RightBracket"],
+  ["LShift", "RightBracket"],
+  ["LShift", "RightBracket"],
+  ["LShift", "RightBracket", "Kc0"],
+  ["Kc0"],
+  [],
+]
+
+# Control: same roll shape over `-`, `7`, `8`, `9`, four distinct keycodes
+# with no collision. Plays clean, which rules out a general rollover or
+# report-timing bug.
+[[test]]
+name = "distinct_keycode_roll_types_clean"
+steps = [
+  { press = [0, 3] },   # MO(1)
+  { press = [2, 0] },   # -
+  { press = [2, 1] },   # 7
+  { release = [2, 0] },
+  { press = [2, 2] },   # 8
+  { release = [2, 1] },
+  { press = [2, 3] },   # 9
+  { release = [2, 2] },
+  { release = [2, 3] },
+  { release = [0, 3] },
+]
+expect = [
+  ["Minus"],
+  ["Kc7", "Minus"],
+  ["Kc7"],
+  ["Kc7", "Kc8"],
+  ["Kc8"],
+  ["Kc8", "Kc9"],
+  ["Kc9"],
+  [],
+]


### PR DESCRIPTION
Whilst testing another change, I rolled the brackets row on my symbol layer (`>]})`) - I discovered the the `}` would disappear with a rapid roll as it has the same HID code as `]`.