### PR TITLE
fix(dongle): open the pairing window once at power-on while bonded

### DIFF
--- a/docs/docs/main/docs/configuration/appendix.md
+++ b/docs/docs/main/docs/configuration/appendix.md
@@ -357,8 +357,8 @@ split_central_sleep_timeout_seconds = 0
 protocol_macro_chunk_size = 64
 # Rynk RX/TX buffer size in bytes. 488 bytes = 2*BLE maximum packet size
 rynk_buffer_size = 488
-# Length of one dongle pairing scan in seconds. Dongle builds only; a dongle
-# repeats the scan whenever it has no keyboard to serve
+# Length of one dongle pairing window in seconds. Dongle builds only; repeated
+# while no keyboard is bonded, opened once at power-on otherwise
 dongle_pairing_window_secs = 30
 # Maximum number of [[behavior.auto_mouse_layer]] entries.
 # Auto-derived from the number of configured entries when unset

--- a/docs/docs/main/docs/configuration/rmk_config.md
+++ b/docs/docs/main/docs/configuration/rmk_config.md
@@ -44,7 +44,7 @@ protocol_macro_chunk_size = 64
 auto_mouse_layer_max_num = 2
 # Rynk RX/TX buffer size in bytes. 488 bytes = 2*BLE maximum packet size
 # rynk_buffer_size = 488
-# Length of one dongle pairing scan in seconds (dongle builds only)
+# Length of one dongle pairing window in seconds (dongle builds only)
 # dongle_pairing_window_secs = 30
 ```
 
@@ -100,7 +100,7 @@ These tune the [Rynk](../features/rynk) protocol and rarely need changing.
 
 - `ble_profiles_num`: The number of available Bluetooth profiles, default value is 3. This parameter defines how many Bluetooth paired devices the keyboard can store.
 - `split_central_sleep_timeout_seconds`: Sleep timeout for BLE split central in seconds, default value is 0 (disabled). When set to a non-zero value, the split central will enter sleep mode after this many seconds of inactivity to save power. Set to 0 to disable automatic sleep.
-- `dongle_pairing_window_secs`: Length of one dongle pairing scan in seconds, default value is 30. Used only by builds with the `dongle` feature. A dongle scans whenever it has no keyboard to serve — with no bond, and after a bonded keyboard fails to answer — so this sets how long each round listens, not a deadline after which pairing stops. A scan ends early if the bonded keyboard turns up during it.
+- `dongle_pairing_window_secs`: Length of one dongle pairing window in seconds, default value is 30. Used only by builds with the `dongle` feature. A dongle without a bonded keyboard repeats the window until one pairs. A bonded dongle opens it exactly once, at power-on, and afterwards reconnects only its bonded keyboard.
 
 ### Auto Mouse Layer Configuration
 

--- a/examples/use_rust/nrf_dongle/dongle/README.md
+++ b/examples/use_rust/nrf_dongle/dongle/README.md
@@ -14,9 +14,9 @@ cargo build --release
 ./run.sh target/thumbv8m.main-none-eabihf/release/rmk-nrf54lm20-dongle
 ```
 
-The dongle scans for a keyboard whenever it has none to serve: at power-on with
-no bond, and after a bonded keyboard fails to answer. A keyboard that pairs in
-that window replaces whatever the dongle was bonded to, so swapping keyboards
-needs nothing on the host side. Each scan lasts 30s
+A new keyboard pairs only while a window is open: once for 30s at power-on
 ([`dongle_pairing_window_secs`](../../../../docs/docs/main/docs/configuration/rmk_config.md)),
-and ends early if the bonded keyboard turns up after all.
+and continuously while the dongle has no bond. 
+The power-on window ends early if the bonded keyboard turns up after all. 
+Outside those windows the dongle only reconnects its bonded keyboard. 
+To pair with a new dongle: hold the keyboard's dongle key for 5s, then replug the dongle. 

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -309,8 +309,8 @@ pub(crate) struct RmkConstantsConfig {
     /// Default 488 fills exactly two BLE notifications.
     #[serde_inline_default(488)]
     pub rynk_buffer_size: usize,
-    /// Length of one dongle pairing scan in seconds; a dongle repeats it
-    /// whenever it has no keyboard to serve (dongle firmware only)
+    /// Length of one dongle pairing window in seconds: repeated while no
+    /// keyboard is bonded, opened once at power-on otherwise (dongle firmware only)
     #[serde_inline_default(30)]
     pub dongle_pairing_window_secs: u32,
 }

--- a/rmk-types/build.rs
+++ b/rmk-types/build.rs
@@ -146,8 +146,8 @@ fn generate_constants(bc: &BuildConstants, config: &KeyboardTomlConfig) -> Strin
         lines.push(format!("pub const LAYOUT_BLOB: &[u8] = b\"{}\";", blob.escape_ascii()));
     }
 
-    // How long one dongle pairing scan lasts. It bonds exactly one keyboard, so
-    // there is nothing else about the relay to size.
+    // How long one dongle pairing window lasts. It bonds exactly one keyboard,
+    // so there is nothing else about the relay to size.
     if env::var("CARGO_FEATURE_DONGLE").is_ok() {
         lines.push(format!(
             "pub const DONGLE_PAIRING_WINDOW_SECS: u32 = {};",

--- a/rmk/src/dongle/mod.rs
+++ b/rmk/src/dongle/mod.rs
@@ -164,22 +164,29 @@ where
         + ControllerCmdSync<LeReadLocalSupportedFeatures>
         + ControllerCmdSync<LeSetScanParams>,
 {
-    /// The dongle's whole state machine: serve the bond, and whenever it does not
-    /// answer, listen for a keyboard seeking a dongle. Seeking follows a deliberate
-    /// 5s hold on the keyboard, so a replacement is never adopted by accident.
     async fn run(&mut self) -> ! {
         wait_for_stack_started().await;
         self.profiles.load_bonded_devices().await;
         self.profiles.update_stack_bonds();
 
+        let bonded = self.profiles.active_bond_info().map(|b| b.info.identity.addr);
+        self.scan.bonded_addr.lock(|a| a.set(bonded.map(|addr| addr.addr)));
+        if bonded.is_some()
+            && let Some((kind, addr)) = self.run_pairing_window().await
+            && let Some(conn) = self.connect(Address { kind, addr }).await
+        {
+            self.run_connection(conn, Peer::New).await;
+        }
+
         loop {
             let bonded = self.profiles.active_bond_info().map(|b| b.info.identity.addr);
             self.scan.bonded_addr.lock(|a| a.set(bonded.map(|addr| addr.addr)));
 
-            if let Some(addr) = bonded
-                && let Some(conn) = self.connect(addr).await
-            {
-                self.run_connection(conn, Peer::Bonded).await;
+            if let Some(addr) = bonded {
+                // If there is bonded keyboard, repeatly connect to that keyboard.
+                if let Some(conn) = self.connect(addr).await {
+                    self.run_connection(conn, Peer::Bonded).await;
+                }
             } else if let Some((kind, addr)) = self.run_pairing_window().await
                 && let Some(conn) = self.connect(Address { kind, addr }).await
             {
@@ -206,7 +213,7 @@ where
                 ..scan_config(DONGLE_SCAN_WINDOW)
             },
         };
-        // A keyboard that is away burns this whole timeout before a window opens.
+        // An absent keyboard times out the attempt; the caller's loop retries.
         match with_timeout(Duration::from_secs(15), central.connect(&config)).await {
             Ok(Ok(conn)) => Some(conn),
             Ok(Err(e)) => {
@@ -221,7 +228,8 @@ where
 
     /// Scan for keyboards seeking a dongle, returning the strongest sighted
     /// within 2s of the first. Ends early with `None` when the bonded keyboard
-    /// turns up, so one back from sleep is not left waiting out the window.
+    /// turns up, so the power-on window with the keyboard present skips
+    /// straight to reconnecting.
     async fn run_pairing_window(&self) -> Option<(AddrKind, BdAddr)> {
         info!("[dongle] pairing window open for {}s", DONGLE_PAIRING_WINDOW_SECS);
         self.scan.seeking_keyboard.reset();


### PR DESCRIPTION
A bonded dongle used to reopen the 30s pairing window whenever its keyboard failed to answer, so a keyboard that was merely away (asleep, switched to a BLE profile) could be usurped by any seeking keyboard nearby.
Now the window opens exactly once, at power-on; outside it a bonded dongle only reconnects its own keyboard. A bondless dongle (fresh, or after its key was refused) keeps pairing until a keyboard is adopted.
To swap keyboards: hold the new keyboard's dongle key for 5s, then replug the dongle. The power-on window still closes early when the bonded keyboard turns up, so replug reconnection stays fast.