### PR TITLE
feat(keyboard): hold a BLE profile key 5s to forget its bond and re-pair

### DIFF
--- a/docs/docs/main/docs/features/wireless.md
+++ b/docs/docs/main/docs/features/wireless.md
@@ -48,7 +48,7 @@ RMK has multiple BLE profile support. The number of profiles can be set in the [
 
 Vial user keycodes can be configured to operate wireless profiles. Suppose that you have N BLE profiles, then:
 
-- `User0` - `User(N-1)`: switch to a specific profile
+- `User0` - `User(N-1)`: switch to a specific profile. Hold the key for 5 seconds to clear that profile's bond and pair a new host: the keyboard switches to the cleared profile and advertises openly.
 - `UserN`: switch to the next profile
 - `User(N+1)`: switch to the previous profile
 - `User(N+2)`: clear current profile bond info
@@ -58,7 +58,7 @@ Vial user keycodes can be configured to operate wireless profiles. Suppose that 
 
 Vial also provides a way to customize the displayed keycode, see `customKeycodes` in [this example](https://github.com/rmk-rs/rmk/blob/main/examples/use_rust/nrf52840_ble/vial.json). If `customKeycodes` are configured, the `User0` ~ `User(N+3)` will be displayed as `BT0`, ..., `Switch Output`.
 
-If you've connected a host to a profile, other devices will not be able to connect to this profile: the keyboard immediately disconnects any device that doesn't match the profile's stored bond. To pair a different host to that profile, clear it first.
+If you've connected a host to a profile, other devices will not be able to connect to this profile: the keyboard immediately disconnects any device that doesn't match the profile's stored bond. To pair a different host to that profile, clear it first, for example by holding the profile's key for 5 seconds.
 
 ## BLE Passkey Entry
 

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-#[cfg(all(feature = "_ble", any(feature = "split", feature = "dongle")))]
+#[cfg(feature = "_ble")]
 use embassy_futures::select::{Either, select};
 use embassy_futures::yield_now;
 #[cfg(feature = "_ble")]
@@ -1668,7 +1668,7 @@ impl<'a> Keyboard<'a> {
 
     /// True when the key is still down 5s later. A release inside the window is
     /// pushed back to `unprocessed_events`, so it replays as a short press.
-    #[cfg(all(feature = "_ble", any(feature = "split", feature = "dongle")))]
+    #[cfg(feature = "_ble")]
     async fn held_for_5s(&mut self) -> bool {
         match select(
             embassy_time::Timer::after_millis(5000),
@@ -1695,6 +1695,14 @@ impl<'a> Keyboard<'a> {
             use crate::ble::profile::BleProfileAction;
             use crate::channel::BLE_PROFILE_CHANNEL;
             if event.pressed {
+                // The uniform gesture across all bond slots: tap switches, a 5s
+                // hold forgets the slot's bond and re-pairs. Holding a profile key
+                // clears that profile and switches to it, so it advertises openly.
+                if id < NUM_BLE_PROFILE as u8 && self.held_for_5s().await {
+                    info!("Profile key held: clearing bond on profile {}", id);
+                    BLE_PROFILE_CHANNEL.send(BleProfileAction::ClearSlot(id)).await;
+                    BLE_PROFILE_CHANNEL.send(BleProfileAction::Switch(id)).await;
+                }
                 // A 5s hold of the dongle key clears the local dongle bond and goes
                 // seeking, which is how a keyboard moves to a different dongle.
                 #[cfg(feature = "dongle")]


### PR DESCRIPTION
Stacked on #1044.

Forgetting a bond had a different gesture per slot kind: host profiles needed the separate clear-bond key (destructive on a bare tap), while the dongle slot and the split peer already used a 5s hold.

Profile keys now follow the same rule — tap switches, a 5s hold clears that slot's bond and switches to it, so the keyboard advertises openly for a new host. Implementation reuses the dongle key's existing pattern (`held_for_5s` + `ClearSlot`/`Switch`); the release-time `Switch` after a hold stays a no-op via the same-profile guard. The clear-bond user key (`User(N+2)`) is kept for compatibility.

Docs: updated the user-key table and the re-pairing note in `wireless.md`.