### PR TITLE
feat(dongle): relay Vial keyboards

### DIFF
--- a/.github/ci/_lib.sh
+++ b/.github/ci/_lib.sh
@@ -56,6 +56,8 @@ RMK_FEATURESETS=(
     "dongle,_ble,storage"
     "dongle,rynk,split,_ble,storage"
     "dongle,rynk,_ble,storage"
+    "dongle,vial,split,_ble,storage"
+    "dongle,vial,_ble,storage"
 )
 
 # Behavioral coverage only; RMK_FEATURESETS remains the compile/clippy matrix.
@@ -64,6 +66,7 @@ RMK_TEST_FEATURESETS=(
     "vial,host_lock,_no_usb,steno,passkey_entry"
     "rynk,_ble,split,async_matrix,storage"
     "dongle,_ble,storage"
+    "dongle,vial,_ble,storage"
 )
 
 # Examples auto-discovery skiplist. Reasons:

--- a/examples/use_rust/nrf_dongle/README.md
+++ b/examples/use_rust/nrf_dongle/README.md
@@ -30,3 +30,8 @@ Holding the dongle key for 5s clears the central's dongle bond, which is how a
 keyboard moves to another dongle. A dongle bonds one keyboard, and goes looking
 for a new one whenever the bonded keyboard stops answering, so the replacement
 just has to be seeking — no host involvement, and no reflashing.
+
+The dongle relays whichever host protocol its keyboard speaks. This example is
+Rynk; swapping `rynk` for `vial` on the central and adding `vial` to the dongle
+crate yields a Vial dongle instead, whose USB side is the standard Vial HID
+interface.

--- a/examples/use_rust/nrf_dongle/central/.cargo/config.toml
+++ b/examples/use_rust/nrf_dongle/central/.cargo/config.toml
@@ -1,9 +1,10 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# runner = "probe-rs run --chip nrf52833_xxAA"
-runner = "./run.sh"
+runner = "probe-rs run --chip nrf52833_xxAA"
+# runner = "./run.sh"
 
 [build]
 target = "thumbv7em-none-eabihf"
 
 [env]
 DEFMT_LOG = "debug"
+KEYBOARD_TOML_PATH = { value = "keyboard.toml", relative = true }

--- a/examples/use_rust/nrf_dongle/central/keyboard.toml
+++ b/examples/use_rust/nrf_dongle/central/keyboard.toml
@@ -1,0 +1,20 @@
+# All a `use_rust` keyboard still reads from TOML: the layout rynk serves over
+# `GetLayout`. The two halves share one 7x7 unified matrix, but they are two
+# separate boards, so the map draws them apart.
+#
+# Left: the Elytra left hand, taken from the Elytra firmware's own `vial.json`
+# (its cols 0-6) — a 6-degree tilt, a widening pinky column down the left edge,
+# and a bottom row of three 1.25u keys plus a 2.25u thumb key. Right: the
+# nRF54L15 DK's four buttons, flat and on their own.
+[layout]
+rows = 7
+cols = 7
+map = """
+[r=6.0@(8.0,-1.0)] [0.75] (0,0) (0,1) (0,2) (0,3) (0,4) (0,5) (0,6)
+[0.75] (1,0,@1.5u) (1,1) (1,2) (1,3) (1,4) (1,5)
+[0.75] (2,0,@1.75u) (2,1) (2,2) (2,3) (2,4) (2,5)
+[0.75] (3,0,@2.25u) (3,1) (3,2) (3,3) (3,4) (3,5)
+[0.75] (4,0,@1.25u) (4,1,@1.25u) (4,2,@1.25u) [1.25] (4,4,@2.25u)
+[r=0] [y=-4] [9.5] (5,0) (5,1)
+[9.5] (6,0) (6,1)
+"""

--- a/examples/use_rust/nrf_dongle/dongle/src/main.rs
+++ b/examples/use_rust/nrf_dongle/dongle/src/main.rs
@@ -38,7 +38,7 @@ async fn mpsl_task(mpsl: &'static MultiprotocolServiceLayer<'static>) -> ! {
     mpsl.run().await
 }
 
-const SDC_MEM_SIZE: usize = 10240;
+const SDC_MEM_SIZE: usize = 5960;
 const FLASH_START_ADDR: usize = 0x120000;
 const FLASH_SECTORS: u8 = 6;
 

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -139,12 +139,13 @@ rynk = ["host", "host_lock", "rmk-types/rynk"]
 
 ## Enable dongle support. Both sides of a dongle setup enable it: the keyboard
 ## gets a bond slot of its own for the dongle plus the `SwitchToDongle` key, the
-## dongle binary gets `rmk::dongle`.
+## dongle binary gets `rmk::dongle`. The dongle relays the keyboard's host
+## protocol: Rynk by default, or Vial when both binaries also enable `vial`.
 dongle = [
     "storage",
-    # Both sides speak Rynk on the wire — the keyboard serves it, the dongle
-    # relays it — and the dongle binary has no `rynk` of its own to pull the
-    # frame types in.
+    # In the default Rynk setup both sides speak Rynk on the wire — the keyboard
+    # serves it, the dongle relays it — and the dongle binary has no `rynk` of
+    # its own to pull the frame types in.
     "rmk-types/rynk",
     "rmk-types/dongle",
     "trouble-host?/connection-event-queue-size-2",

--- a/rmk/src/dongle/mod.rs
+++ b/rmk/src/dongle/mod.rs
@@ -1,17 +1,20 @@
 //! Dongle firmware (`dongle` feature): a BLE central that relays one bonded
 //! RMK keyboard to a USB host.
 //!
-//! It is a HID-over-GATT client toward the keyboard and a byte relay for
-//! everything else — Rynk frames pass through unparsed in both directions, so
-//! the dongle answers no command of its own and never tracks the protocol.
-//! Keymaps and storage stay on the keyboard; the dongle persists one bond.
+//! It is a HID-over-GATT client toward the keyboard and a relay for everything
+//! else — the keyboard's host protocol (Rynk frames, or Vial reports with the
+//! `vial` feature) passes through unparsed in both directions, so the dongle
+//! answers no command of its own and never tracks the protocol. Keymaps and
+//! storage stay on the keyboard; the dongle persists one bond.
 //!
 //! Task layout (both joined by [`Dongle::run`]):
 //! - `ble_task`: trouble runner with the seeking-advertisement scan handler;
 //! - [`DongleCentral::run`]: find a keyboard, connect, secure, relay, repeat.
 
+#[cfg(not(feature = "vial"))]
 mod router;
-
+#[cfg(feature = "vial")]
+mod vial_router;
 use core::cell::Cell;
 
 use bt_hci::cmd::le::{LeReadLocalSupportedFeatures, LeSetPhy, LeSetScanParams};
@@ -22,10 +25,15 @@ use embassy_futures::select::{Either, select, select3};
 use embassy_sync::blocking_mutex::Mutex as BlockingMutex;
 use embassy_sync::signal::Signal;
 use embassy_time::{Duration, Instant, Timer, with_deadline, with_timeout};
+#[cfg(not(feature = "vial"))]
 use rmk_types::protocol::rynk::{RYNK_BLE_CHUNK_SIZE, RYNK_INPUT_CHAR_UUID, RYNK_OUTPUT_CHAR_UUID, RYNK_SERVICE_UUID};
 pub use router::DongleRouter;
+#[cfg(feature = "vial")]
+use router::VialReport;
 use trouble_host::prelude::*;
 use usbd_hid::descriptor::{MediaKeyboardReport, MouseReport, SystemControlReport};
+#[cfg(feature = "vial")]
+use vial_router as router;
 
 use crate::ble::adv::Adv;
 use crate::ble::profile::{ProfileInfo, ProfileManager};
@@ -45,7 +53,7 @@ const DONGLE_L2CAP_CHANNELS_MAX: usize = DONGLE_CONNECTIONS_MAX * 4; // Signal +
 type DongleBleResources = HostResources<DefaultPacketPool, DONGLE_CONNECTIONS_MAX, DONGLE_L2CAP_CHANNELS_MAX>;
 
 /// The services discovery keeps: 0x1812 matches both the report service and the
-/// rynk HID service, plus the rynk service itself.
+/// host-protocol HID service (rynk or vial), plus rynk's custom service.
 type Client<'a, C> = GattClient<'a, C, DefaultPacketPool, 3>;
 
 const BOND_SLOT: u8 = 0;
@@ -384,7 +392,14 @@ where
 
         self.router.link_up();
         info!("[dongle] relaying");
-        self.relay(conn, client, &mut listener, &chars).await;
+        self.relay(
+            #[cfg(not(feature = "vial"))]
+            conn,
+            client,
+            &mut listener,
+            &chars,
+        )
+        .await;
         Some(())
     }
 
@@ -392,13 +407,14 @@ where
     /// out to USB/router, LED state and router frames back to the keyboard.
     async fn relay(
         &self,
-        conn: &Connection<'_, DefaultPacketPool>,
+        #[cfg(not(feature = "vial"))] conn: &Connection<'_, DefaultPacketPool>,
         client: &Client<'_, C>,
         listener: &mut NotificationListener<'_, 512>,
         chars: &KeyboardCharacteristics,
     ) {
         // Largest single write chunk on the Rynk characteristic: ATT MTU minus the
-        // 3-byte write header.
+        // 3-byte write header. Vial reports are 32 bytes and cross whole.
+        #[cfg(not(feature = "vial"))]
         let chunk_size = RYNK_BLE_CHUNK_SIZE
             .min((conn.att_mtu() as usize).saturating_sub(3))
             .max(1);
@@ -407,15 +423,27 @@ where
             loop {
                 let notification = listener.next().await;
                 let (handle, data) = (notification.handle(), notification.as_ref());
-                // Only the Rynk stream is opaque, and it goes straight to the host.
-                if handle == chars.rynk_input.handle {
-                    // Never block: the typing path shares this notification queue.
-                    if !matches!(self.router.to_host.try_write(data), Ok(n) if n == data.len()) {
-                        // Terminate what got through, so the truncated frame fails on
-                        // its own rather than gluing to the next notify — which would
-                        // decode as one bogus frame and cost the host that reply too.
+                // Only the config stream is opaque, and it goes straight to the host.
+                if handle == chars.config_input.handle {
+                    // A full pipe is usually a host a moment behind, so wait for 20ms at most.
+                    #[cfg(not(feature = "vial"))]
+                    if with_timeout(Duration::from_millis(20), self.router.to_host.write_all(data))
+                        .await
+                        .is_err()
+                    {
+                        // Try to send a delimeter and drop the bytes which cannot be written in 20ms.
                         let _ = self.router.to_host.try_write(&[0]);
                         warn!("[dongle] host config stream overflow, dropping bytes");
+                    }
+                    // Reports are atomic: a dropped one costs its reply, nothing else.
+                    #[cfg(feature = "vial")]
+                    match VialReport::try_from(data) {
+                        Ok(report) => {
+                            if self.router.to_host.try_send(report).is_err() {
+                                warn!("[dongle] host reply queue full, dropping a reply");
+                            }
+                        }
+                        Err(_) => warn!("[dongle] non-report-size vial notify dropped"),
                     }
                 } else if let Some(report) = chars.report(handle, data) {
                     send_hid_report(report).await;
@@ -423,31 +451,43 @@ where
             }
         };
 
-        let host_to_keyboard = async {
+        let led_to_keyboard = async {
             let mut led_events = LedIndicatorEvent::subscriber();
             loop {
-                match select(led_events.next_event(), self.router.to_keyboard.receive()).await {
-                    Either::First(event) => {
-                        let _ = client
-                            .write_characteristic_without_response(&chars.keyboard_output, &[event.0.into_bits()])
-                            .await;
-                    }
-                    Either::Second(frame) => {
-                        for part in frame.chunks(chunk_size) {
-                            if client
-                                .write_characteristic_without_response(&chars.rynk_output, part)
-                                .await
-                                .is_err()
-                            {
-                                break;
-                            }
-                        }
-                    }
+                let event = led_events.next_event().await;
+                let _ = client
+                    .write_characteristic_without_response(&chars.keyboard_output, &[event.0.into_bits()])
+                    .await;
+            }
+        };
+
+        // One characteristic write per pass. Rynk takes a write's worth out of the
+        // byte stream — the read itself is the chunker — while Vial takes one whole
+        // report, because a report can't be split.
+        #[cfg(not(feature = "vial"))]
+        let mut request = [0u8; RYNK_BLE_CHUNK_SIZE];
+        let request_to_keyboard = async {
+            loop {
+                #[cfg(not(feature = "vial"))]
+                {
+                    let n = self.router.to_keyboard.read(&mut request[..chunk_size]).await;
+                    let _ = client
+                        .write_characteristic_without_response(&chars.config_output, &request[..n])
+                        .await;
+                }
+                #[cfg(feature = "vial")]
+                {
+                    let report = self.router.to_keyboard.receive().await;
+                    let _ = client
+                        .write_characteristic_without_response(&chars.config_output, &report)
+                        .await;
                 }
             }
         };
 
-        select(keyboard_to_host, host_to_keyboard).await;
+        // Three independent errands, not one interleaved loop: an LED update must
+        // not wait behind a config write, nor the other way round.
+        select3(keyboard_to_host, led_to_keyboard, request_to_keyboard).await;
     }
 }
 
@@ -473,21 +513,24 @@ struct KeyboardCharacteristics {
     mouse: Characteristic<[u8]>,
     media: Characteristic<[u8]>,
     system: Characteristic<[u8]>,
-    rynk_input: Characteristic<[u8]>,
-    rynk_output: Characteristic<[u8]>,
+    /// The host-protocol pair: rynk's custom service, or the 32-byte report
+    /// pair of vial's own HID service.
+    config_input: Characteristic<[u8]>,
+    config_output: Characteristic<[u8]>,
 }
 
 impl KeyboardCharacteristics {
-    /// Discover the HID and Rynk services. The five HID report characteristics
-    /// share UUID 0x2A4D; both ends are RMK, so their declaration order is
-    /// fixed: keyboard input, keyboard output, mouse, media, system.
+    /// Discover the HID and host-protocol services. The report characteristics
+    /// share UUID 0x2A4D; both ends are RMK, so service and declaration order
+    /// are fixed: the report service comes first with keyboard input, keyboard
+    /// output, mouse, media, system.
     async fn discover<C: Controller>(client: &Client<'_, C>) -> Option<Self> {
-        let hid = client
+        let mut hid_services = client
             .services_by_uuid(&Uuid::new_short(0x1812))
             .await
             .ok()?
-            .into_iter()
-            .next()?;
+            .into_iter();
+        let hid = hid_services.next()?;
         let report_uuid = Uuid::new_short(0x2A4D);
         // Discovery fails unless every characteristic `HidService` declares fits.
         let mut reports = client
@@ -502,20 +545,37 @@ impl KeyboardCharacteristics {
         let media = reports.next()?;
         let system = reports.next()?;
 
-        let rynk = client
-            .services_by_uuid(&RYNK_SERVICE_UUID.into())
-            .await
-            .ok()?
-            .into_iter()
-            .next()?;
-        let rynk_input = client
-            .characteristic_by_uuid::<[u8]>(&rynk, &RYNK_INPUT_CHAR_UUID.into())
-            .await
-            .ok()?;
-        let rynk_output = client
-            .characteristic_by_uuid::<[u8]>(&rynk, &RYNK_OUTPUT_CHAR_UUID.into())
-            .await
-            .ok()?;
+        #[cfg(not(feature = "vial"))]
+        let (config_input, config_output) = {
+            let rynk = client
+                .services_by_uuid(&RYNK_SERVICE_UUID.into())
+                .await
+                .ok()?
+                .into_iter()
+                .next()?;
+            (
+                client
+                    .characteristic_by_uuid::<[u8]>(&rynk, &RYNK_INPUT_CHAR_UUID.into())
+                    .await
+                    .ok()?,
+                client
+                    .characteristic_by_uuid::<[u8]>(&rynk, &RYNK_OUTPUT_CHAR_UUID.into())
+                    .await
+                    .ok()?,
+            )
+        };
+        // Vial rides the second HID service instance: input notify, then output write.
+        #[cfg(feature = "vial")]
+        let (config_input, config_output) = {
+            let vial = hid_services.next()?;
+            let mut reports = client
+                .characteristics::<9>(&vial)
+                .await
+                .ok()?
+                .into_iter()
+                .filter(|c| c.uuid == report_uuid);
+            (reports.next()?, reports.next()?)
+        };
 
         Some(Self {
             keyboard_input,
@@ -523,8 +583,8 @@ impl KeyboardCharacteristics {
             mouse,
             media,
             system,
-            rynk_input,
-            rynk_output,
+            config_input,
+            config_output,
         })
     }
 
@@ -536,7 +596,7 @@ impl KeyboardCharacteristics {
             &self.mouse,
             &self.media,
             &self.system,
-            &self.rynk_input,
+            &self.config_input,
         ] {
             if let Some(cccd) = ch.cccd_handle {
                 client.write_handle(cccd, &[0x01, 0x00]).await.ok()?;

--- a/rmk/src/dongle/router.rs
+++ b/rmk/src/dongle/router.rs
@@ -6,8 +6,7 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use embassy_futures::select::{Either, select};
-use embassy_sync::channel::Channel;
+use embassy_futures::select::select;
 use embassy_sync::pipe::Pipe;
 use embassy_sync::signal::Signal;
 use embedded_io_async::{Read, Write};
@@ -15,9 +14,6 @@ use rmk_types::constants::RYNK_BUFFER_SIZE;
 use rmk_types::protocol::rynk::{RYNK_BLE_CHUNK_SIZE, RynkError, RynkHeader, encode_frame};
 
 use crate::RawMutex;
-
-/// A whole encoded frame, delimiter included.
-type RouterFrame = heapless::Vec<u8, RYNK_BUFFER_SIZE>;
 
 /// A whole max-size frame, plus two notifies of slack for a briefly stalled
 /// host. Anything less and one full frame in flight leaves no room for the
@@ -30,22 +26,22 @@ const TO_HOST_SIZE: usize = RYNK_BUFFER_SIZE + 2 * RYNK_BLE_CHUNK_SIZE;
 /// here: the [`crate::usb::UsbTransport`] running the sessions, and the
 /// [`super::Dongle`] whose dongle task relays what they queue.
 pub struct DongleRouter {
-    /// Frames waiting for the keyboard's `output_data` writes.
-    pub(super) to_keyboard: Channel<RawMutex, RouterFrame, 1>,
+    /// Raw bytes waiting for the keyboard's `output_data` writes.
+    pub(super) to_keyboard: Pipe<RawMutex, RYNK_BUFFER_SIZE>,
     /// Raw bytes waiting for the host: the keyboard's `input_data` notifies plus
     /// the relay's own replies.
     pub(super) to_host: Pipe<RawMutex, TO_HOST_SIZE>,
     /// The dongle task has a keyboard connected and is draining `to_keyboard`.
     link_connected: AtomicBool,
     /// Raised when a link stops relaying: only a live link drains `to_keyboard`,
-    /// so a waiting [`Self::forward_frame`] has to give up.
+    /// so a waiting [`Self::host_to_keyboard`] has to give up.
     link_dropped: Signal<RawMutex, ()>,
 }
 
 impl DongleRouter {
     pub const fn new() -> Self {
         Self {
-            to_keyboard: Channel::new(),
+            to_keyboard: Pipe::new(),
             to_host: Pipe::new(),
             link_connected: AtomicBool::new(false),
             link_dropped: Signal::new(),
@@ -79,50 +75,50 @@ impl DongleRouter {
         select(self.host_to_keyboard(rx), self.keyboard_to_host(tx)).await;
     }
 
-    /// Host→keyboard: deframe what the host sends and hand whole frames over.
+    /// Host→keyboard: bytes cross as they arrive, exactly as they do in the other
+    /// direction. The only state kept is the head of the frame in flight, which is
+    /// all [`RynkHeader::peek`] needs to answer an absent keyboard on the request's
+    /// own CMD and SEQ — the one thing this direction can't do byte-blind.
     async fn host_to_keyboard<R: Read>(&self, rx: &mut R) {
-        let mut frames = FrameSplitter::new("host");
+        let mut buf = [0u8; RYNK_BLE_CHUNK_SIZE];
+        let mut head: heapless::Vec<u8, 8> = heapless::Vec::new();
         loop {
-            let n = match rx.read(frames.spare()).await {
+            let n = match rx.read(&mut buf).await {
                 Ok(0) | Err(_) => return,
                 Ok(n) => n,
             };
-            frames.commit(n);
-            while let Some(frame) = frames.next_frame() {
-                self.forward_frame(frame).await;
-            }
-        }
-    }
+            // Each piece ends at a delimiter, except a trailing partial frame.
+            for piece in buf[..n].split_inclusive(|&b| b == 0) {
+                let ends_frame = piece.ends_with(&[0]);
+                let body = if ends_frame { &piece[..piece.len() - 1] } else { piece };
+                head.extend_from_slice(&body[..body.len().min(head.capacity() - head.len())])
+                    .ok();
 
-    /// Keyboard→host: one frame per write, which is what the host transport's
-    /// zero-length-packet rule is written for. Sole owner of that transport.
-    async fn keyboard_to_host<T: Write>(&self, tx: &mut T) {
-        let mut frames = FrameSplitter::new("keyboard");
-        loop {
-            let n = self.to_host.read(frames.spare()).await;
-            frames.commit(n);
-            while let Some(frame) = frames.next_frame() {
-                if tx.write_all(frame).await.is_err() {
-                    return;
+                // `link_dropped` is polled first so it wins the tie when the link
+                // dies mid-write; whatever got through is resynced by the
+                // keyboard's own deframer at the next delimiter.
+                if self.link_connected.load(Ordering::Relaxed) {
+                    let _ = select(self.link_dropped.wait(), self.to_keyboard.write_all(piece)).await;
                 }
+                if !ends_frame {
+                    continue;
+                }
+                // Whole frame seen. With no keyboard to serve it, queueing would
+                // strand it — nothing drains the queue while the keyboard is away —
+                // and the host has no timeout of its own, so answer it here. A bare
+                // delimiter carries no request, so there is nothing to answer.
+                if !head.is_empty() && !self.link_connected.load(Ordering::Relaxed) {
+                    self.answer_not_ready(&head).await;
+                }
+                head.clear();
             }
         }
     }
 
-    /// Hand one whole encoded frame (delimiter included) to the keyboard, or
-    /// answer it here if there is no keyboard to hand it to.
-    async fn forward_frame(&self, frame: &[u8]) {
-        // `link_dropped` is polled first so it wins the tie when the link dies mid-wait.
-        if self.link_connected.load(Ordering::Relaxed)
-            && let Ok(copy) = RouterFrame::from_slice(frame)
-            && let Either::Second(()) = select(self.link_dropped.wait(), self.to_keyboard.send(copy)).await
-        {
-            return;
-        }
-
-        // Queueing it would strand it — nothing drains the queue while the keyboard
-        // is away — and the host has no timeout of its own, so answer it here.
-        let Some(header) = RynkHeader::peek(&frame[..frame.len() - 1]) else {
+    /// Answer one request locally, on its own CMD and SEQ, so the host isn't left
+    /// waiting for a keyboard that isn't there.
+    async fn answer_not_ready(&self, head: &[u8]) {
+        let Some(header) = RynkHeader::peek(head) else {
             warn!("[dongle] undecodable host frame dropped");
             return;
         };
@@ -133,69 +129,26 @@ impl DongleRouter {
             Err(e) => warn!("[dongle] reply encode failed: {:?}", e),
         }
     }
+
+    /// Keyboard→host: raw bytes, forwarded as they arrive. The stream is
+    /// delimiter-framed and the host deframes it, so the relay never needs to
+    /// find a frame boundary — and holding bytes back until it finds one is what
+    /// turns a single lost notification into two lost replies, by gluing the
+    /// surviving half onto the frame behind it. Sole owner of the transport.
+    async fn keyboard_to_host<T: Write>(&self, tx: &mut T) {
+        let mut buf = [0u8; RYNK_BLE_CHUNK_SIZE];
+        loop {
+            let n = self.to_host.read(&mut buf).await;
+            if tx.write_all(&buf[..n]).await.is_err() {
+                return;
+            }
+        }
+    }
 }
 
 impl Default for DongleRouter {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-/// Splits a byte stream into whole delimiter-terminated frames without decoding
-/// them, which rmk_types' `Deframer` can't do — it decodes in place. Sized like
-/// the keyboard's session buffer, so anything a keyboard could parse fits.
-struct FrameSplitter {
-    buf: [u8; RYNK_BUFFER_SIZE],
-    len: usize,
-    /// Scan position: frames before it have been yielded.
-    start: usize,
-    /// Mid-oversized-frame: eat bytes until its delimiter resyncs the stream.
-    discard: bool,
-    /// Names the sender when an oversized frame is dropped.
-    from: &'static str,
-}
-
-impl FrameSplitter {
-    const fn new(from: &'static str) -> Self {
-        Self {
-            buf: [0; RYNK_BUFFER_SIZE],
-            len: 0,
-            start: 0,
-            discard: false,
-            from,
-        }
-    }
-
-    /// Free space to read the next chunk into; never empty. Follow with `commit`.
-    fn spare(&mut self) -> &mut [u8] {
-        &mut self.buf[self.len..]
-    }
-
-    fn commit(&mut self, n: usize) {
-        self.len += n;
-    }
-
-    /// The next whole frame (delimiter included), or `None` once the buffered
-    /// bytes hold no more — which compacts, so `spare` has room again.
-    fn next_frame(&mut self) -> Option<&[u8]> {
-        while let Some(pos) = self.buf[self.start..self.len].iter().position(|&b| b == 0) {
-            let start = self.start;
-            self.start += pos + 1;
-            if core::mem::take(&mut self.discard) || pos == 0 {
-                continue; // an oversized frame's delimiter, or a bare one
-            }
-            return Some(&self.buf[start..self.start]);
-        }
-        self.buf.copy_within(self.start..self.len, 0);
-        self.len -= self.start;
-        self.start = 0;
-        if self.len == self.buf.len() {
-            // No delimiter in a full buffer: drop and drain to the next one.
-            warn!("[dongle] oversized {} frame dropped", self.from);
-            self.len = 0;
-            self.discard = true;
-        }
-        None
     }
 }
 
@@ -304,19 +257,27 @@ mod tests {
         let captured = run(&router, VecDeque::from([request.clone()]), 0);
 
         assert!(captured.is_empty(), "forwarded frames get no local reply");
-        let forwarded = router.to_keyboard.try_receive().expect("frame routed to the keyboard");
-        assert_eq!(&forwarded[..], &request[..], "byte-for-byte pass-through");
+        let mut forwarded = [0u8; 64];
+        let n = router
+            .to_keyboard
+            .try_read(&mut forwarded)
+            .expect("bytes routed to the keyboard");
+        assert_eq!(&forwarded[..n], &request[..], "byte-for-byte pass-through");
     }
 
     #[test]
     fn a_forward_waiting_on_a_dying_link_answers_instead_of_replaying() {
         let router = DongleRouter::new();
         router.link_up();
-        // Occupy the single slot so the forward has to wait for room.
-        router.to_keyboard.try_send(RouterFrame::new()).unwrap();
+        // Fill the pipe so the forward has to wait for room.
+        while router.to_keyboard.try_write(&[0xFF; 64]).is_ok() {}
 
         let request = frame(Cmd::GetVersion, 11, &());
-        block_on(join(router.forward_frame(&request), async {
+        let mut rx = ChunkRead {
+            chunks: VecDeque::from([request.clone()]),
+            idle_reads: 4,
+        };
+        block_on(join(router.host_to_keyboard(&mut rx), async {
             yield_now().await;
             // The link drops with the forward still waiting.
             router.link_down();
@@ -331,8 +292,9 @@ mod tests {
             postcard::from_bytes::<Result<(), RynkError>>(&resp[0].2).unwrap(),
             Err(RynkError::NotReady),
         );
+        let mut parked = [0u8; 8];
         assert!(
-            router.to_keyboard.try_receive().is_err(),
+            router.to_keyboard.try_read(&mut parked).is_err(),
             "and the request is not parked for whichever keyboard reconnects next"
         );
     }
@@ -369,6 +331,20 @@ mod tests {
         assert_eq!(resp[0].1, 3, "and the next response reaches the host intact");
     }
 
+    /// The relay keeps no frame buffer, so a request split across reads must still
+    /// be answered exactly once — on the header it started with.
+    #[test]
+    fn a_request_split_across_reads_is_answered_once() {
+        let router = DongleRouter::new();
+        let request = frame(Cmd::GetVersion, 21, &());
+        let (head, tail) = request.split_at(2);
+        let captured = run(&router, VecDeque::from([head.to_vec(), tail.to_vec()]), 2);
+
+        let resp = decode_frames(&captured);
+        assert_eq!(resp.len(), 1, "one request, one answer");
+        assert_eq!(resp[0].1, 21, "seq echo survives the split");
+    }
+
     #[test]
     fn an_absent_keyboard_answers_not_ready_on_the_host_s_header() {
         let router = DongleRouter::new();
@@ -384,8 +360,9 @@ mod tests {
             postcard::from_bytes::<Result<(), RynkError>>(&resp[0].2).unwrap(),
             Err(RynkError::NotReady),
         );
+        let mut parked = [0u8; 8];
         assert!(
-            router.to_keyboard.try_receive().is_err(),
+            router.to_keyboard.try_read(&mut parked).is_err(),
             "and nothing is parked for later"
         );
     }

--- a/rmk/src/dongle/router.rs
+++ b/rmk/src/dongle/router.rs
@@ -15,16 +15,14 @@ use rmk_types::protocol::rynk::{RYNK_BLE_CHUNK_SIZE, RynkError, RynkHeader, enco
 
 use crate::RawMutex;
 
-/// A whole max-size frame, plus two notifies of slack for a briefly stalled
-/// host. Anything less and one full frame in flight leaves no room for the
-/// notify behind it, which costs a frame every bulk read.
+/// One max-size frame plus two notifies of slack: any less and a full frame in
+/// flight leaves no room for the notify behind it, costing a frame per bulk read.
 const TO_HOST_SIZE: usize = RYNK_BUFFER_SIZE + 2 * RYNK_BLE_CHUNK_SIZE;
 
 /// Serves the Rynk USB interface for a dongle binary, as `RynkService` does for
-/// a keyboard; [`crate::usb::rynk::run_host_usb`] drives one session per
-/// connection. The binary's `main` owns one and lends it to both sides that meet
-/// here: the [`crate::usb::UsbTransport`] running the sessions, and the
-/// [`super::Dongle`] whose dongle task relays what they queue.
+/// a keyboard. `main` owns one and lends it to both sides:
+/// [`crate::usb::rynk::run_host_usb`] drives a session per connection, and the
+/// [`super::Dongle`] task relays what the session queues.
 pub struct DongleRouter {
     /// Raw bytes waiting for the keyboard's `output_data` writes.
     pub(super) to_keyboard: Pipe<RawMutex, RYNK_BUFFER_SIZE>,
@@ -75,10 +73,9 @@ impl DongleRouter {
         select(self.host_to_keyboard(rx), self.keyboard_to_host(tx)).await;
     }
 
-    /// Host→keyboard: bytes cross as they arrive, exactly as they do in the other
-    /// direction. The only state kept is the head of the frame in flight, which is
-    /// all [`RynkHeader::peek`] needs to answer an absent keyboard on the request's
-    /// own CMD and SEQ — the one thing this direction can't do byte-blind.
+    /// Host -> keyboard: bytes cross as they arrive. The only state is the head of
+    /// the frame in flight — all [`RynkHeader::peek`] needs to answer an absent
+    /// keyboard on the request's own CMD and SEQ.
     async fn host_to_keyboard<R: Read>(&self, rx: &mut R) {
         let mut buf = [0u8; RYNK_BLE_CHUNK_SIZE];
         let mut head: heapless::Vec<u8, 8> = heapless::Vec::new();
@@ -94,47 +91,35 @@ impl DongleRouter {
                 head.extend_from_slice(&body[..body.len().min(head.capacity() - head.len())])
                     .ok();
 
-                // `link_dropped` is polled first so it wins the tie when the link
-                // dies mid-write; whatever got through is resynced by the
-                // keyboard's own deframer at the next delimiter.
+                // `link_dropped` is polled first so it wins the tie when the link dies
+                // mid-write; the keyboard's deframer resyncs at the next delimiter.
                 if self.link_connected.load(Ordering::Relaxed) {
                     let _ = select(self.link_dropped.wait(), self.to_keyboard.write_all(piece)).await;
                 }
                 if !ends_frame {
                     continue;
                 }
-                // Whole frame seen. With no keyboard to serve it, queueing would
-                // strand it — nothing drains the queue while the keyboard is away —
-                // and the host has no timeout of its own, so answer it here. A bare
-                // delimiter carries no request, so there is nothing to answer.
+                // Whole frame seen. Nothing drains the queue while the keyboard is
+                // away and the host has no timeout of its own, so answer here; a
+                // bare delimiter carries no request to answer.
                 if !head.is_empty() && !self.link_connected.load(Ordering::Relaxed) {
-                    self.answer_not_ready(&head).await;
+                    if let Some(header) = RynkHeader::peek(&head) {
+                        let mut reply = [0u8; 16];
+                        match encode_frame(&mut reply[1..], header, &Err::<(), RynkError>(RynkError::NotReady)) {
+                            // `reply[0]` is a bare delimiter, closing off any partial frame in the stream.
+                            Ok(n) => self.to_host.write_all(&reply[..n + 1]).await,
+                            Err(e) => warn!("[dongle] reply encode failed: {:?}", e),
+                        }
+                    } else {
+                        warn!("[dongle] undecodable host frame dropped");
+                    }
                 }
                 head.clear();
             }
         }
     }
 
-    /// Answer one request locally, on its own CMD and SEQ, so the host isn't left
-    /// waiting for a keyboard that isn't there.
-    async fn answer_not_ready(&self, head: &[u8]) {
-        let Some(header) = RynkHeader::peek(head) else {
-            warn!("[dongle] undecodable host frame dropped");
-            return;
-        };
-        let mut buf = [0u8; 16];
-        match encode_frame(&mut buf[1..], header, &Err::<(), RynkError>(RynkError::NotReady)) {
-            // `buf[0]` is a bare delimiter, closing off any partial frame in the stream.
-            Ok(n) => self.to_host.write_all(&buf[..n + 1]).await,
-            Err(e) => warn!("[dongle] reply encode failed: {:?}", e),
-        }
-    }
-
-    /// Keyboard→host: raw bytes, forwarded as they arrive. The stream is
-    /// delimiter-framed and the host deframes it, so the relay never needs to
-    /// find a frame boundary — and holding bytes back until it finds one is what
-    /// turns a single lost notification into two lost replies, by gluing the
-    /// surviving half onto the frame behind it. Sole owner of the transport.
+    /// Keyboard -> host: raw bytes forwarded as they arrive.
     async fn keyboard_to_host<T: Write>(&self, tx: &mut T) {
         let mut buf = [0u8; RYNK_BLE_CHUNK_SIZE];
         loop {

--- a/rmk/src/dongle/vial_router.rs
+++ b/rmk/src/dongle/vial_router.rs
@@ -1,0 +1,270 @@
+//! The dongle's USB session for a Vial keyboard: a 32-byte report relay.
+//!
+//! Vial is strict request/response with no framing, so whole reports cross 1:1
+//! in both directions. The relay reads nothing but the first byte — and only to
+//! echo the request back as `Unhandled` when there is no keyboard to ask.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use embassy_futures::select::{Either, select};
+use embassy_sync::channel::Channel;
+use embassy_sync::signal::Signal;
+use embedded_io_async::{Read, Write};
+use rmk_types::protocol::vial::{VIAL_EP_SIZE, ViaCommand};
+
+use crate::RawMutex;
+
+/// One Vial request or reply, always exactly one HID report.
+pub(super) type VialReport = [u8; VIAL_EP_SIZE];
+
+/// Serves the Vial USB interface for a dongle binary, as `VialService` does for
+/// a keyboard; [`crate::usb::vial::run_host_usb`] drives one session per
+/// connection. The binary's `main` owns one and lends it to both sides that meet
+/// here: the [`crate::usb::UsbTransport`] running the sessions, and the
+/// [`super::Dongle`] whose dongle task relays what they queue.
+pub struct DongleRouter {
+    /// Requests waiting for the keyboard's `output_data` writes.
+    pub(super) to_keyboard: Channel<RawMutex, VialReport, 1>,
+    /// Replies the keyboard notified, plus the relay's own answers. Vial is
+    /// turn-by-turn so one slot would do; the rest is headroom.
+    pub(super) to_host: Channel<RawMutex, VialReport, 4>,
+    /// The dongle task has a keyboard connected and is draining `to_keyboard`.
+    link_connected: AtomicBool,
+    /// Raised when a link stops relaying: only a live link drains `to_keyboard`,
+    /// so a waiting [`Self::forward_report`] has to give up.
+    link_dropped: Signal<RawMutex, ()>,
+}
+
+impl DongleRouter {
+    pub const fn new() -> Self {
+        Self {
+            to_keyboard: Channel::new(),
+            to_host: Channel::new(),
+            link_connected: AtomicBool::new(false),
+            link_dropped: Signal::new(),
+        }
+    }
+
+    /// Called by the dongle task once it is relaying: open the host→keyboard path.
+    pub(super) fn link_up(&self) {
+        // `link_dropped` latches; clear it and the queue before the first forward.
+        self.link_dropped.reset();
+        self.to_keyboard.clear();
+        self.link_connected.store(true, Ordering::Relaxed);
+    }
+
+    /// Called by the dongle task when the link drops: fail waiting forwards and
+    /// drop the queue, so a keyboard connecting later can't replay a stale request.
+    pub(super) fn link_down(&self) {
+        self.link_connected.store(false, Ordering::Relaxed);
+        self.link_dropped.signal(());
+        self.to_keyboard.clear();
+    }
+
+    pub async fn run_session<R: Read, T: Write>(&self, rx: &mut R, tx: &mut T) {
+        self.to_host.clear();
+        self.to_keyboard.clear();
+        // Concurrent, not turn by turn: a request can wait milliseconds for the
+        // dongle task, and replies must keep draining meanwhile.
+        select(self.host_to_keyboard(rx), self.keyboard_to_host(tx)).await;
+    }
+
+    async fn host_to_keyboard<R: Read>(&self, rx: &mut R) {
+        loop {
+            let mut report = [0u8; VIAL_EP_SIZE];
+            if rx.read_exact(&mut report).await.is_err() {
+                return;
+            }
+            self.forward_report(report).await;
+        }
+    }
+
+    async fn keyboard_to_host<T: Write>(&self, tx: &mut T) {
+        loop {
+            let report = self.to_host.receive().await;
+            if tx.write_all(&report).await.is_err() {
+                return;
+            }
+        }
+    }
+
+    /// Hand one request to the keyboard, or answer it here if there is no
+    /// keyboard to hand it to.
+    async fn forward_report(&self, mut report: VialReport) {
+        // `link_dropped` is polled first so it wins the tie when the link dies mid-wait.
+        if self.link_connected.load(Ordering::Relaxed)
+            && let Either::Second(()) = select(self.link_dropped.wait(), self.to_keyboard.send(report)).await
+        {
+            return;
+        }
+
+        // Queueing it would strand it — nothing drains the queue while the keyboard
+        // is away — and the host has no timeout of its own, so answer it here with
+        // the protocol's unknown-command echo.
+        report[0] = ViaCommand::Unhandled as u8;
+        self.to_host.send(report).await;
+    }
+}
+
+impl Default for DongleRouter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use alloc::collections::VecDeque;
+    use alloc::vec::Vec;
+
+    use embassy_futures::join::join;
+    use embassy_futures::yield_now;
+    use embedded_io_async::{ErrorKind, ErrorType};
+
+    use super::*;
+    use crate::test_support::test_block_on as block_on;
+
+    /// Returns each chunk as one `read`; once drained, yields `idle_reads`
+    /// times (so the session's other select arms get to run) and then EOF.
+    struct ChunkRead {
+        chunks: VecDeque<Vec<u8>>,
+        idle_reads: usize,
+    }
+
+    impl ErrorType for ChunkRead {
+        type Error = ErrorKind;
+    }
+
+    impl Read for ChunkRead {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+            loop {
+                let Some(chunk) = self.chunks.front_mut() else {
+                    if self.idle_reads == 0 {
+                        return Ok(0);
+                    }
+                    self.idle_reads -= 1;
+                    yield_now().await;
+                    continue;
+                };
+                let n = chunk.len().min(buf.len());
+                buf[..n].copy_from_slice(&chunk[..n]);
+                chunk.drain(..n);
+                if chunk.is_empty() {
+                    self.chunks.pop_front();
+                }
+                return Ok(n);
+            }
+        }
+    }
+
+    struct VecWrite {
+        captured: Vec<u8>,
+    }
+
+    impl ErrorType for VecWrite {
+        type Error = ErrorKind;
+    }
+
+    impl Write for VecWrite {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+            self.captured.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        async fn flush(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    fn request(cmd: u8) -> VialReport {
+        let mut report = [0u8; VIAL_EP_SIZE];
+        report[0] = cmd;
+        report[1] = 0xAB; // marker: replies must echo the request's tail
+        report
+    }
+
+    fn run(router: &DongleRouter, chunks: VecDeque<Vec<u8>>, idle_reads: usize) -> Vec<u8> {
+        let mut rx = ChunkRead { chunks, idle_reads };
+        let mut tx = VecWrite { captured: Vec::new() };
+        block_on(router.run_session(&mut rx, &mut tx));
+        tx.captured
+    }
+
+    #[test]
+    fn a_connected_keyboard_gets_the_report_byte_for_byte() {
+        let router = DongleRouter::new();
+        router.link_up();
+        let req = request(0x01);
+        let captured = run(&router, VecDeque::from([req.to_vec()]), 0);
+
+        assert!(captured.is_empty(), "forwarded requests get no local reply");
+        let forwarded = router.to_keyboard.try_receive().expect("report routed to the keyboard");
+        assert_eq!(forwarded, req, "byte-for-byte pass-through");
+    }
+
+    #[test]
+    fn an_absent_keyboard_answers_the_unhandled_echo() {
+        let router = DongleRouter::new();
+        // Idle reads let the host-transport task drain the queued answer before
+        // EOF ends the session.
+        let captured = run(&router, VecDeque::from([request(0x01).to_vec()]), 2);
+
+        assert_eq!(captured.len(), VIAL_EP_SIZE, "exactly one reply");
+        assert_eq!(captured[0], ViaCommand::Unhandled as u8);
+        assert_eq!(&captured[1..], &request(0x01)[1..], "the request's tail is echoed");
+        assert!(
+            router.to_keyboard.try_receive().is_err(),
+            "and nothing is parked for later"
+        );
+    }
+
+    #[test]
+    fn a_forward_waiting_on_a_dying_link_answers_instead_of_replaying() {
+        let router = DongleRouter::new();
+        router.link_up();
+        // Occupy the single slot so the forward has to wait for room.
+        router.to_keyboard.try_send([0u8; VIAL_EP_SIZE]).unwrap();
+
+        block_on(join(router.forward_report(request(0x02)), async {
+            yield_now().await;
+            // The link drops with the forward still waiting.
+            router.link_down();
+        }));
+
+        let reply = router.to_host.try_receive().expect("a reply is queued");
+        assert_eq!(reply[0], ViaCommand::Unhandled as u8);
+        assert_eq!(
+            &reply[1..],
+            &request(0x02)[1..],
+            "seqless protocol: the echo is the match"
+        );
+        assert!(
+            router.to_keyboard.try_receive().is_err(),
+            "and the request is not parked for whichever keyboard reconnects next"
+        );
+    }
+
+    #[test]
+    fn a_keyboard_reply_reaches_the_host_intact() {
+        let router = DongleRouter::new();
+        let mut reply = [0u8; VIAL_EP_SIZE];
+        reply[0] = 0x01;
+        reply[31] = 0xEE;
+        let mut rx = ChunkRead {
+            chunks: VecDeque::new(),
+            idle_reads: 4,
+        };
+        let mut tx = VecWrite { captured: Vec::new() };
+
+        block_on(join(router.run_session(&mut rx, &mut tx), async {
+            yield_now().await;
+            router.link_up();
+            router.to_host.try_send(reply).unwrap();
+            yield_now().await;
+        }));
+
+        assert_eq!(tx.captured, reply.to_vec(), "one whole report per write");
+    }
+}

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -30,11 +30,6 @@ compile_error!("feature `host` requires enabling either `rynk` or `vial`");
 #[cfg(all(feature = "dongle", not(feature = "_ble")))]
 compile_error!("feature `dongle` requires a BLE chip feature (e.g. `nrf52840_ble`)");
 
-#[cfg(all(feature = "dongle", feature = "vial"))]
-compile_error!(
-    "features `dongle` and `vial` are mutually exclusive: a dongle relays the Rynk service, which a Vial keyboard doesn't have"
-);
-
 #[cfg(all(feature = "usb_log", feature = "_usb_high_speed"))]
 compile_error!(
     "`usb_log` is not supported on high-speed USB chips yet: embassy-usb-logger \

--- a/rmk/src/usb/mod.rs
+++ b/rmk/src/usb/mod.rs
@@ -24,15 +24,16 @@ use crate::light::UsbLedReader;
 use crate::state::{current_usb_state, set_usb_state};
 
 // The Rynk vendor interface serves the keyboard's Rynk session and the dongle's router.
-#[cfg(any(feature = "rynk", feature = "dongle"))]
+#[cfg(any(feature = "rynk", all(feature = "dongle", not(feature = "vial"))))]
 pub(crate) mod rynk;
 #[cfg(feature = "vial")]
 pub(crate) mod vial;
 
 // A build has at most one host interface — Vial's HID report pair or the Rynk
-// vendor bulk pair, and the protocols are mutually exclusive. The two modules
+// vendor bulk pair, and the protocols are mutually exclusive. A dongle relays
+// its keyboard's protocol: Rynk unless `vial` says otherwise. The two modules
 // expose the same names, so the rest of the file only talks to `host_usb`.
-#[cfg(any(feature = "rynk", feature = "dongle"))]
+#[cfg(any(feature = "rynk", all(feature = "dongle", not(feature = "vial"))))]
 use rynk as host_usb;
 #[cfg(feature = "vial")]
 use vial as host_usb;
@@ -165,7 +166,7 @@ pub(crate) fn new_usb_builder<'d, D: Driver<'d>>(driver: D, keyboard_config: Dev
     usb_config.product = Some(keyboard_config.product_name);
     // Informational tag (visible in `lsusb` & co); host discovery keys on the
     // Rynk vendor interface triple, not the serial.
-    #[cfg(any(feature = "rynk", feature = "dongle"))]
+    #[cfg(any(feature = "rynk", all(feature = "dongle", not(feature = "vial"))))]
     let serial_number = {
         static SERIAL: StaticCell<heapless::String<64>> = StaticCell::new();
         let s = SERIAL.init(heapless::String::new());
@@ -173,7 +174,7 @@ pub(crate) fn new_usb_builder<'d, D: Driver<'d>>(driver: D, keyboard_config: Dev
         let _ = s.push_str(keyboard_config.serial_number);
         s.as_str()
     };
-    #[cfg(not(any(feature = "rynk", feature = "dongle")))]
+    #[cfg(not(any(feature = "rynk", all(feature = "dongle", not(feature = "vial")))))]
     let serial_number = keyboard_config.serial_number;
     usb_config.serial_number = Some(serial_number);
     usb_config.max_power = 450;
@@ -192,7 +193,7 @@ pub(crate) fn new_usb_builder<'d, D: Driver<'d>>(driver: D, keyboard_config: Dev
         feature = "steno",
         feature = "dfu",
         feature = "rynk",
-        feature = "dongle"
+        all(feature = "dongle", not(feature = "vial"))
     ));
     const USB_BUF_SIZE: usize = if EXTRA_INTERFACES { 256 } else { 128 };
 
@@ -204,7 +205,7 @@ pub(crate) fn new_usb_builder<'d, D: Driver<'d>>(driver: D, keyboard_config: Dev
 
     // The rynk MS OS 2.0 descriptor set (WinUSB binding) takes ~178 bytes, and
     // its BOS platform capability another 28 on top of the 5-byte BOS header.
-    const RYNK_INTERFACE: bool = cfg!(any(feature = "rynk", feature = "dongle"));
+    const RYNK_INTERFACE: bool = cfg!(any(feature = "rynk", all(feature = "dongle", not(feature = "vial"))));
     const BOS_BUF_SIZE: usize = if RYNK_INTERFACE { 64 } else { 16 };
     const MSOS_BUF_SIZE: usize = if RYNK_INTERFACE { 256 } else { 16 };
 

--- a/rmk/src/usb/rynk.rs
+++ b/rmk/src/usb/rynk.rs
@@ -130,12 +130,9 @@ impl<D: Driver<'static>> ErrorType for HostUsbWriter<D> {
     type Error = EndpointError;
 }
 
-/// Sends one frame per `write`, then a zero-length packet when the frame
-/// fills the last bulk-IN packet. A bulk IN transfer completes on the host
-/// only at a packet shorter than the max packet size, so a frame whose length
-/// is a multiple of it would otherwise hang the host read (hit at Full-Speed's
-/// 64-byte packets; masked at High-Speed's 512). `run_session` writes each
-/// frame with a single `write_all`, so `buf` is one whole frame.
+/// A bulk-IN transfer completes on the host only at a short packet, so a write
+/// that's a multiple of the max packet size is terminated with a zero-length
+/// packet — otherwise the host read hangs (hit at Full-Speed's 64 bytes).
 impl<D: Driver<'static>> Write for HostUsbWriter<D> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         for packet in buf.chunks(RYNK_USB_MAX_PACKET_SIZE) {

--- a/rmk/src/usb/vial.rs
+++ b/rmk/src/usb/vial.rs
@@ -28,6 +28,13 @@ impl super::HostSession for VialService<'_> {
     }
 }
 
+#[cfg(feature = "dongle")]
+impl super::HostSession for crate::dongle::DongleRouter {
+    async fn serve<R: Read, W: Write>(&self, rx: &mut R, tx: &mut W) {
+        self.run_session(rx, tx).await
+    }
+}
+
 /// Vial session loop.
 pub(crate) async fn run_host_usb<D: Driver<'static>, S: super::HostSession>(
     reader: &mut HostUsbReader<D>,

--- a/rynk/src/api.rs
+++ b/rynk/src/api.rs
@@ -208,18 +208,20 @@ impl Client {
                 "advertised layout blob length {total_len} exceeds maximum {MAX_LAYOUT_BLOB_LEN}"
             )));
         }
-        let mut collected: Vec<u8> = first.bytes.to_vec();
-        // An empty page means the firmware stopped sending, so stop rather than loop
-        // forever; a firmware with no `[layout].map` sends an empty first page.
-        while !collected.is_empty() && collected.len() < total_len {
-            let chunk = self.request::<command::GetLayout>(&(collected.len() as u32)).await?;
-            if chunk.bytes.is_empty() {
-                break;
-            }
-            collected.extend_from_slice(&chunk.bytes);
-        }
-        collected.truncate(total_len);
-        LayoutInfo::from_compressed_blob(&collected).map_err(RynkHostError::Layout)
+        // The first page fixes the page size, which is all [`Self::read_all`] needs to
+        // read the rest on lanes — one round trip per `MAX_IN_FLIGHT` pages instead of
+        // one each. It re-reads page 0, which rides an existing lane and costs nothing.
+        let page = first.bytes.len();
+        let mut blob: Vec<u8> = if page == 0 || total_len <= page {
+            first.bytes.to_vec()
+        } else {
+            self.read_all(total_len, page, async |c, offset| {
+                Ok(c.request::<command::GetLayout>(&(offset as u32)).await?.bytes.to_vec())
+            })
+            .await?
+        };
+        blob.truncate(total_len);
+        LayoutInfo::from_compressed_blob(&blob).map_err(RynkHostError::Layout)
     }
 
     /// Read one combo entry by index.
@@ -401,7 +403,7 @@ impl Client {
         let caps = self.capabilities;
         let (rows, cols) = (caps.num_rows as u16, caps.num_cols as u16);
         let total = caps.num_layers as usize * rows as usize * cols as usize;
-        self.read_all(total, caps.max_bulk_keys, async |c, start| {
+        self.read_all(total, caps.max_bulk_keys.into(), async |c, start| {
             let (layer, row, col) = keymap_pos(start, rows, cols);
             c.get_keymap_bulk(layer, row, col).await.map(|r| r.actions)
         })
@@ -411,7 +413,7 @@ impl Client {
     /// Read every combo slot with concurrent paged reads. A short page ends the read early.
     pub async fn read_all_combos(&self) -> Result<Vec<Combo>, RynkHostError> {
         let total = self.capabilities.max_combos as usize;
-        self.read_all(total, self.capabilities.max_bulk_items, async |c, start| {
+        self.read_all(total, self.capabilities.max_bulk_items.into(), async |c, start| {
             c.get_combo_bulk(start as u8).await.map(|r| r.configs)
         })
         .await
@@ -420,7 +422,7 @@ impl Client {
     /// Read every morse slot with concurrent paged reads. A short page ends the read early.
     pub async fn read_all_morses(&self) -> Result<Vec<Morse>, RynkHostError> {
         let total = self.capabilities.max_morse as usize;
-        self.read_all(total, self.capabilities.max_bulk_items, async |c, start| {
+        self.read_all(total, self.capabilities.max_bulk_items.into(), async |c, start| {
             c.get_morse_bulk(start as u8).await.map(|r| r.configs)
         })
         .await
@@ -481,11 +483,11 @@ impl Client {
     async fn read_all<Item>(
         &self,
         total: usize,
-        advertised: u8,
+        advertised: usize,
         fetch: impl AsyncFn(&Self, u16) -> Result<Vec<Item>, RynkHostError>,
     ) -> Result<Vec<Item>, RynkHostError> {
         let frame = RYNK_HEADER_SIZE + self.capabilities.max_payload_size as usize;
-        let spacing = (advertised as usize * frame.saturating_sub(MAX_IN_FLIGHT * PARKED_REQUEST_BYTES) / frame).max(1);
+        let spacing = (advertised * frame.saturating_sub(MAX_IN_FLIGHT * PARKED_REQUEST_BYTES) / frame).max(1);
         let next = AtomicUsize::new(0);
         let lanes = join_array(core::array::from_fn::<_, MAX_IN_FLIGHT, _>(|_| async {
             let mut pages = Vec::new();


### PR DESCRIPTION
## What

Lifts the `dongle` × `vial` mutual exclusion: the dongle now relays whichever host protocol its keyboard speaks — **Rynk by default (unchanged), or Vial when both binaries also enable the `vial` feature**.

## How

- **Feature gates** ([lib.rs](../blob/feat/vial-dongle/rmk/src/lib.rs), [usb/mod.rs](../blob/feat/vial-dongle/rmk/src/usb/mod.rs)): the `dongle`×`vial` `compile_error!` is gone; every Rynk-USB-interface gate becomes `any(rynk, all(dongle, not(vial)))` (the `host_usb` alias, the `rynk:` serial prefix, descriptor buffer sizing). A Vial dongle's USB face is identical to a plain Vial keyboard's: boot keyboard + composite + the 32-byte Via raw-HID interface.
- **`dongle/vial_router.rs`** (new): the Vial flavor of `DongleRouter`, swapped in per feature under the same public name. Vial is strict request/response with no framing, so both directions are `Channel<[u8; 32]>` — none of the Rynk router's stream deframing or truncation poisoning applies. With no keyboard connected it answers the request's echo with byte 0 = `ViaCommand::Unhandled` (0xFF), the protocol's own unknown-command convention, so the Vial GUI fails fast instead of hanging.
- **Dongle BLE side** ([dongle/mod.rs](../blob/feat/vial-dongle/rmk/src/dongle/mod.rs)): a Vial keyboard has no Rynk custom service; discovery instead takes the **second** 0x1812 service instance (both ends are RMK, service order is fixed) and its two 0x2A4D report characteristics. The characteristic pair is now protocol-neutral (`config_input`/`config_output`), so subscription and HID relay stay shared; only the config hop differs — chunked frames for Rynk, whole 32-byte writes for Vial.
- **Keyboard side: zero changes.** `VialGattService` is already served to any connected central, dongle included, with no profile gating.

## Testing

- New unit tests in `vial_router.rs`: byte-for-byte pass-through, unhandled echo when the keyboard is absent, the link-drop race, reply integrity.
- CI matrix: two new check/clippy rows and one test row (`dongle,vial,…`). All existing dongle/vial rows pass unchanged (472/494/498 tests).
- Real firmware: the nRF54LM20 dongle example builds with `vial` added (verified locally, example left untouched).

## Known boundary

A Vial dongle bonded to a Rynk keyboard (or vice versa) types fine but its config channel silently does nothing — a deployment mismatch, deliberately not detected in firmware.

Not yet tested on hardware end-to-end (Vial GUI → dongle → keyboard).