### PR TITLE
feat(nrf): add an nrf52820_ble chip feature

### DIFF
--- a/docs/docs/main/docs/features/wireless.md
+++ b/docs/docs/main/docs/features/wireless.md
@@ -25,6 +25,7 @@ The following is the list of available feature gates (i.e., supported BLE chips)
 - nrf52840_ble
 - nrf52833_ble
 - nrf52832_ble
+- nrf52820_ble
 - nrf52811_ble
 - nrf52810_ble
 - esp32c3_ble

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -269,6 +269,10 @@ _no_usb = []
 ## Internal marker for 480 Mbps USB chips; activates 512-byte bulk packets.
 _usb_high_speed = []
 
+## Internal feature that indicates the chip has no SAADC, auto-activated by the
+## chip features that need it (see `nrf52820_ble`). Compiles out `NrfAdc`.
+_no_saadc = []
+
 #! ### BLE feature flags
 #!
 #! ⚠️ Due to the limitation of docs.rs, functions gated by BLE features won't show in docs.rs. You have to head to [`examples`](https://github.com/rmk-rs/rmk/tree/main/examples) folder of RMK repo for their usages.
@@ -280,6 +284,9 @@ nrf54l15_ble = ["_nrf_ble", "_no_usb"]
 nrf52840_ble = ["_nrf_ble"]
 ## Enable feature if you want to use nRF52833 with BLE.
 nrf52833_ble = ["_nrf_ble"]
+## Enable feature if you want to use nRF52820 with BLE.
+## The nRF52820 has no SAADC, so `NrfAdc` is compiled out via `_no_saadc`.
+nrf52820_ble = ["_nrf_ble", "_no_saadc"]
 ## Enable feature if you want to use nRF52832 with BLE.
 nrf52832_ble = ["_nrf_ble", "_no_usb"]
 ## Enable feature if you want to use nRF52811 with BLE.

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -269,8 +269,7 @@ _no_usb = []
 ## Internal marker for 480 Mbps USB chips; activates 512-byte bulk packets.
 _usb_high_speed = []
 
-## Internal feature that indicates the chip has no SAADC, auto-activated by the
-## chip features that need it (see `nrf52820_ble`). Compiles out `NrfAdc`.
+## Internal marker for chips without SAADC; compiles out `NrfAdc`.
 _no_saadc = []
 
 #! ### BLE feature flags
@@ -284,8 +283,7 @@ nrf54l15_ble = ["_nrf_ble", "_no_usb"]
 nrf52840_ble = ["_nrf_ble"]
 ## Enable feature if you want to use nRF52833 with BLE.
 nrf52833_ble = ["_nrf_ble"]
-## Enable feature if you want to use nRF52820 with BLE.
-## The nRF52820 has no SAADC, so `NrfAdc` is compiled out via `_no_saadc`.
+## Enable feature if you want to use nRF52820 with BLE. The chip has no SAADC, so `NrfAdc` is unavailable.
 nrf52820_ble = ["_nrf_ble", "_no_saadc"]
 ## Enable feature if you want to use nRF52832 with BLE.
 nrf52832_ble = ["_nrf_ble", "_no_usb"]

--- a/rmk/src/input_device/adc/mod.rs
+++ b/rmk/src/input_device/adc/mod.rs
@@ -1,7 +1,5 @@
-// `NrfAdc` is built on `embassy_nrf::saadc`, which embassy-nrf compiles out for
-// parts that have no SAADC (nRF52820, nRF5340-net, nRF51). Gating only on
-// `_nrf_ble` therefore makes RMK itself fail to build for those chips;
-// `_no_saadc` (set by `nrf52820_ble`) opts them out.
+// embassy-nrf compiles `saadc` out for parts that lack it (nRF52820, nRF5340-net,
+// nRF51), so this module can't build on `_no_saadc` chips.
 #[cfg(all(feature = "_nrf_ble", not(feature = "_no_saadc")))]
 pub mod nrf;
 

--- a/rmk/src/input_device/adc/mod.rs
+++ b/rmk/src/input_device/adc/mod.rs
@@ -1,7 +1,11 @@
-#[cfg(feature = "_nrf_ble")]
+// `NrfAdc` is built on `embassy_nrf::saadc`, which embassy-nrf compiles out for
+// parts that have no SAADC (nRF52820, nRF5340-net, nRF51). Gating only on
+// `_nrf_ble` therefore makes RMK itself fail to build for those chips;
+// `_no_saadc` (set by `nrf52820_ble`) opts them out.
+#[cfg(all(feature = "_nrf_ble", not(feature = "_no_saadc")))]
 pub mod nrf;
 
-#[cfg(feature = "_nrf_ble")]
+#[cfg(all(feature = "_nrf_ble", not(feature = "_no_saadc")))]
 pub use nrf::*;
 
 pub enum AnalogEventType {


### PR DESCRIPTION
## Problem

RMK cannot be built for the nRF52820 at all today. The chip has no SAADC, and embassy-nrf compiles `embassy_nrf::saadc` out for such parts, but `input_device::adc::nrf` imports it unconditionally behind `_nrf_ble` alone:

```
error[E0432]: unresolved import `embassy_nrf::saadc`
note: found an item that was configured out
   --> embassy-nrf-0.11.0/src/lib.rs:187:9
186 | #[cfg(not(any(feature = "_nrf51", feature = "nrf52820", feature = "_nrf5340-net")))]
187 |     pub mod saadc;
```

So there is no `nrf52820_ble` alongside the other `nrf52*_ble` features.

## Change

Three small pieces:

- `_no_saadc` — a new internal feature that gates out `input_device::adc::nrf`.
- `nrf52820_ble = ["_nrf_ble", "_no_saadc"]` — the chip feature.
- The chip added to the supported-BLE-chips list in the wireless docs.

`_no_saadc` is deliberately its own flag rather than `cfg(feature = "nrf52820_ble")` inline: nRF5340-net and nRF51 are configured out by embassy-nrf for the same reason and would reuse it as-is.

## Why the chip is worth supporting

The nRF52820 is a natural dongle part — native USB, 256 KB flash / 32 KB RAM — and with `nrf-sdc`'s central-only role (which links `libsoftdevice_controller_central.a` instead of the multirole archive, worth ~144 KB) a `rmk::dongle` pass-through relay fits with room to spare. Measured on a real image: 197 KB flash (77.7%), 23.5 KB static RAM (71.7%). A dongle has no ADC input, so compiling `NrfAdc` out costs it nothing.

## Verification

- `nrf52820_ble` now builds: `cargo check -p rmk --no-default-features --features nrf52820_ble,storage,dongle,embassy-nrf/nrf52820 --target thumbv7em-none-eabi` ✅
- No regression for parts that do have a SAADC: `nrf52833_ble,storage,split,vial` on `thumbv7em-none-eabihf` ✅ — it does not set `_no_saadc`, so `NrfAdc` compiles exactly as before.
- Beyond the check, this exact patch has been carrying a working nRF52820 dongle firmware build.

Not tested on nRF52820 hardware yet — the claim here is that RMK compiles for the chip, which it previously could not.