### PR TITLE
fix(dongle): size HostResources to what the dongle actually uses

### DIFF
--- a/rmk/src/dongle/mod.rs
+++ b/rmk/src/dongle/mod.rs
@@ -48,27 +48,17 @@ use crate::{DONGLE_PAIRING_WINDOW_SECS, RawMutex};
 /// One keyboard link, and no more: the dongle relays exactly one keyboard.
 const DONGLE_CONNECTIONS_MAX: usize = 1;
 
-/// trouble's `CHANNELS` sizes the pool of **dynamic L2CAP connection-oriented
-/// channels** — the ones `ChannelManager::alloc` hands out for `l2cap` create /
-/// accept, on CIDs at or above `L2CAP_CID_DYN_START`. The fixed channels
-/// (signalling, ATT, SMP) are dispatched by CID in `BleHost` and never take a
-/// slot, so they do not belong in this count. A dongle talks pure GATT — HID,
-/// and the relayed host protocol (rynk or vial), all over ATT — and opens no
-/// CoC at all.
+/// trouble's `CHANNELS` counts only dynamic L2CAP channels; the fixed ones
+/// (signalling, ATT, SMP) never take a slot. A dongle talks pure GATT over ATT
+/// and opens no CoC, so zero.
 const DONGLE_L2CAP_CHANNELS_MAX: usize = 0;
 
 /// BLE resources sized for the dongle role; owned by [`Dongle::run`].
 ///
-/// The trailing `1, 2` are `ADV_SETS` and `BONDS`, whose defaults are 1 and 10.
-/// A dongle never advertises, so `ADV_SETS` keeps the default.
-///
-/// `BONDS` is 2 rather than 1 even though a dongle keeps exactly one bond
-/// (`BOND_SLOT`, and its [`ProfileManager`] is `SLOTS = 1`): the stack holds two
-/// for a moment. [`ProfileManager::update_stack_bonds`] prunes *after* the fact
-/// — "a fresh pairing lands there before we prune" — so adopting a replacement
-/// keyboard while the old bond is still loaded needs the second slot. With one,
-/// `add_bond` pushes to a full `Vec` and returns `OutOfMemory`, dropping the new
-/// bond on the floor.
+/// The trailing `1, 2` are `ADV_SETS` (its default) and `BONDS`. The dongle
+/// keeps one bond, but [`ProfileManager::update_stack_bonds`] prunes only after
+/// a new pairing lands, so adopting a replacement keyboard briefly holds two —
+/// with a single slot, `add_bond` fails and the new bond is lost on reboot.
 type DongleBleResources = HostResources<DefaultPacketPool, DONGLE_CONNECTIONS_MAX, DONGLE_L2CAP_CHANNELS_MAX, 1, 2>;
 
 /// The services discovery keeps: 0x1812 matches both the report service and the

--- a/rmk/src/dongle/mod.rs
+++ b/rmk/src/dongle/mod.rs
@@ -47,10 +47,29 @@ use crate::{DONGLE_PAIRING_WINDOW_SECS, RawMutex};
 
 /// One keyboard link, and no more: the dongle relays exactly one keyboard.
 const DONGLE_CONNECTIONS_MAX: usize = 1;
-const DONGLE_L2CAP_CHANNELS_MAX: usize = DONGLE_CONNECTIONS_MAX * 4; // Signal + att + smp + hid
+
+/// trouble's `CHANNELS` sizes the pool of **dynamic L2CAP connection-oriented
+/// channels** — the ones `ChannelManager::alloc` hands out for `l2cap` create /
+/// accept, on CIDs at or above `L2CAP_CID_DYN_START`. The fixed channels
+/// (signalling, ATT, SMP) are dispatched by CID in `BleHost` and never take a
+/// slot, so they do not belong in this count. A dongle talks pure GATT — HID,
+/// and the relayed host protocol (rynk or vial), all over ATT — and opens no
+/// CoC at all.
+const DONGLE_L2CAP_CHANNELS_MAX: usize = 0;
 
 /// BLE resources sized for the dongle role; owned by [`Dongle::run`].
-type DongleBleResources = HostResources<DefaultPacketPool, DONGLE_CONNECTIONS_MAX, DONGLE_L2CAP_CHANNELS_MAX>;
+///
+/// The trailing `1, 2` are `ADV_SETS` and `BONDS`, whose defaults are 1 and 10.
+/// A dongle never advertises, so `ADV_SETS` keeps the default.
+///
+/// `BONDS` is 2 rather than 1 even though a dongle keeps exactly one bond
+/// (`BOND_SLOT`, and its [`ProfileManager`] is `SLOTS = 1`): the stack holds two
+/// for a moment. [`ProfileManager::update_stack_bonds`] prunes *after* the fact
+/// — "a fresh pairing lands there before we prune" — so adopting a replacement
+/// keyboard while the old bond is still loaded needs the second slot. With one,
+/// `add_bond` pushes to a full `Vec` and returns `OutOfMemory`, dropping the new
+/// bond on the floor.
+type DongleBleResources = HostResources<DefaultPacketPool, DONGLE_CONNECTIONS_MAX, DONGLE_L2CAP_CHANNELS_MAX, 1, 2>;
 
 /// The services discovery keeps: 0x1812 matches both the report service and the
 /// host-protocol HID service (rynk or vial), plus rynk's custom service.


### PR DESCRIPTION
Two corrections to `DongleBleResources` in `rmk/src/dongle/mod.rs`. One is a live bug.

## `BONDS`: 10 → 2 (bug fix)

The default is 10. The obvious reading is that a dongle needs 1 — it keeps exactly one bond, and its `ProfileManager` is already `SLOTS = 1`. But 1 is wrong, because the stack transiently holds two.

`ProfileManager::update_stack_bonds` prunes *after* the fact, as its own comment says:

```rust
// Drain one at a time rather than collecting: the stack holds bonds this
// manager has no slot for — a fresh pairing lands there before we prune —
// and a `heapless::Vec` collect panics on the overflow.
```

So on the adopt-a-replacement-keyboard path — which #1044 made reachable at power-on while bonded — the sequence is:

1. `update_stack_bonds()` loads the existing bond → list is 1/1.
2. The pairing window finds a *different* keyboard, SMP completes.
3. `add_bond` finds no matching identity and pushes to a full `Vec`:

```rust
} else {
    bond.push(bond_information).map_err(|_| Error::OutOfMemory)?;
}
```

The new bond is silently dropped. The dongle appears to pair and relays fine on that connection, but nothing was persisted — it comes back after a reboot with the old bond, or none.

Two is the floor. The remaining eight slots were dead weight.

## `CHANNELS`: `CONNECTIONS_MAX * 4` → 0

`HostResources`' `CHANNELS` sizes `channels: [ChannelStorage<P::Packet>; CHANNELS]`, which is the pool of **dynamic L2CAP connection-oriented channels** — what `ChannelManager::alloc` hands out for l2cap create/accept, on CIDs at or above `L2CAP_CID_DYN_START`. All three `alloc` call sites are CoC paths (`spsm`, `mps`, `LeCreditConnResultCode`).

The fixed channels are dispatched by CID in `BleHost` and never take a slot:

```rust
if header.channel < L2CAP_CID_DYN_START
    && !(&[L2CAP_CID_LE_U_SIGNAL, L2CAP_CID_ATT, L2CAP_CID_LE_U_SECURITY_MANAGER]…
```

So the old `* 4  // Signal + att + smp + hid` was counting something this parameter does not size — and HID-over-GATT is ATT traffic, never a channel of its own. A dongle is a pure GATT client (HID over ATT, Rynk over ATT) and opens no CoC, so the correct count is 0.

## Effect

Measured on an nRF52820 dongle image: **336 B of RAM back**, and the `OutOfMemory` path gone. Flash −200 B.

Verified with `cargo check -p rmk --no-default-features --features nrf52840_ble,storage,dongle,embassy-nrf/nrf52840 --target thumbv7em-none-eabihf`, and by building a real nRF52820 dongle firmware against it.

The `BONDS` reasoning is from reading `update_stack_bonds` and `add_bond`, not from observing the failure on hardware — the re-pair path has not been exercised on a device here. Worth a second opinion on whether 2 is enough, or whether the prune should instead happen before the pairing completes.

Independent of #1049; touches a different file.