### PR TITLE
fix(dongle): don't hardcode trouble's notification MTU

### DIFF
--- a/rmk/src/dongle/mod.rs
+++ b/rmk/src/dongle/mod.rs
@@ -414,6 +414,9 @@ where
 
     /// Relay both directions for as long as this future is polled: notifications
     /// out to USB/router, LED state and router frames back to the keyboard.
+    ///
+    /// `NOTIF_MTU` is trouble's notification buffer size, inferred from the
+    /// listener; restating the constant would pin RMK to one trouble build.
     async fn relay<const NOTIF_MTU: usize>(
         &self,
         #[cfg(not(feature = "vial"))] conn: &Connection<'_, DefaultPacketPool>,

--- a/rmk/src/dongle/mod.rs
+++ b/rmk/src/dongle/mod.rs
@@ -414,11 +414,11 @@ where
 
     /// Relay both directions for as long as this future is polled: notifications
     /// out to USB/router, LED state and router frames back to the keyboard.
-    async fn relay(
+    async fn relay<const NOTIF_MTU: usize>(
         &self,
         #[cfg(not(feature = "vial"))] conn: &Connection<'_, DefaultPacketPool>,
         client: &Client<'_, C>,
-        listener: &mut NotificationListener<'_, 512>,
+        listener: &mut NotificationListener<'_, NOTIF_MTU>,
         chars: &KeyboardCharacteristics,
     ) {
         // Largest single write chunk on the Rynk characteristic: ATT MTU minus the


### PR DESCRIPTION
`DongleCentral::relay` takes `&mut NotificationListener<'_, 512>`. That 512 is not RMK's to choose — it is trouble's, and the listener only ever comes from `client.listen_all()`, so RMK never constructs one. Restating the constant just pins RMK to one particular trouble build.

That matters because upstream's 512 is a placeholder, not a considered value. trouble's GATT-client queue stores a fixed-size `Notification<512>` per slot regardless of the negotiated MTU:

```rust
notifications: PubSubChannel<NoopRawMutex, Notification<512>, NOTIF_QSIZE, MAX_NOTIF, 1>,
// TODO: Wait for something like min_generic_const_args ... to allow using P::MTU
```

`dongle` asks for 8 slots, so that is 4 KB of RAM, MTU-independent. On a small part it has to come down — an nRF52820 has 32 KB total — but lowering it in trouble makes RMK stop compiling, over a constant RMK does not use.

## Change

Make `relay` generic over the MTU and let it be inferred:

```rust
async fn relay<const NOTIF_MTU: usize>(
    …
    listener: &mut NotificationListener<'_, NOTIF_MTU>,
```

No behaviour change on stock trouble — 512 is still what gets inferred. RMK simply stops caring what trouble picked.

## Not included

`split::ble::central` still spells out `NotificationListener<'b, 512>`, but there it is a struct field and would need a const parameter threaded through the type. Left alone: split runs on parts where 4 KB is affordable, and the dongle path is the one that actually blocks a build.

## Verification

`cargo check -p rmk` with `nrf52840_ble,storage,dongle` and with `…,vial`, on `thumbv7em-none-eabihf`.

End to end: with this plus #1049 and #1050, an nRF52820 dongle firmware builds against **unmodified RMK** — previously it needed a three-file RMK fork. 197,344 B flash (77.7% of 256 KB) and 22,276 B static RAM (68.0% of 32 KB), leaving 10.5 KB of stack. The only patch still needed there is trouble's own notification MTU, which is what the TODO above is about.

Stacked on #1050 → #1049 → #1047.