### PR TITLE
feat(dongle): relay Rynk and Vial keyboards from one firmware

### DIFF
--- a/examples/use_rust/nrf_dongle/README.md
+++ b/examples/use_rust/nrf_dongle/README.md
@@ -32,6 +32,8 @@ for a new one whenever the bonded keyboard stops answering, so the replacement
 just has to be seeking — no host involvement, and no reflashing.
 
 The dongle relays whichever host protocol its keyboard speaks. This example is
-Rynk; swapping `rynk` for `vial` on the central and adding `vial` to the dongle
-crate yields a Vial dongle instead, whose USB side is the standard Vial HID
-interface.
+Rynk; adding `vial` to the dongle crate grows the Vial relay beside the Rynk
+one — the dongle then serves both USB interfaces (the vendor one and the
+standard Vial HID one) and discovers at connection time which protocol its
+keyboard speaks. A `vial` central (swap `rynk` for `vial` there) and a `rynk`
+central then work on the same dongle firmware.

--- a/examples/use_rust/nrf_dongle/dongle/src/main.rs
+++ b/examples/use_rust/nrf_dongle/dongle/src/main.rs
@@ -174,7 +174,7 @@ async fn main(spawner: Spawner) {
     // Shared by the two tasks that relay: the dongle's BLE link and the USB host sessions.
     let router = DongleRouter::new();
     let mut dongle = Dongle::new(sdc, ble_addr(), &router);
-    let mut usb_transport = UsbTransport::new(driver, device_config).with_dongle_router(&router);
+    let mut usb_transport = UsbTransport::new_dongle(driver, device_config, &router);
 
     run_all!(usb_transport, dongle, storage).await;
 }

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -140,7 +140,8 @@ rynk = ["host", "host_lock", "rmk-types/rynk"]
 ## Enable dongle support. Both sides of a dongle setup enable it: the keyboard
 ## gets a bond slot of its own for the dongle plus the `SwitchToDongle` key, the
 ## dongle binary gets `rmk::dongle`. The dongle relays the keyboard's host
-## protocol: Rynk by default, or Vial when both binaries also enable `vial`.
+## protocol: Rynk, plus Vial when the dongle binary also enables `vial` — which
+## of the two a keyboard speaks is discovered when it connects.
 dongle = [
     "storage",
     # In the default Rynk setup both sides speak Rynk on the wire — the keyboard

--- a/rmk/src/dongle/mod.rs
+++ b/rmk/src/dongle/mod.rs
@@ -2,19 +2,20 @@
 //! RMK keyboard to a USB host.
 //!
 //! It is a HID-over-GATT client toward the keyboard and a relay for everything
-//! else — the keyboard's host protocol (Rynk frames, or Vial reports with the
-//! `vial` feature) passes through unparsed in both directions, so the dongle
-//! answers no command of its own and never tracks the protocol. Keymaps and
-//! storage stay on the keyboard; the dongle persists one bond.
+//! else — the keyboard's host protocol passes through unparsed in both
+//! directions, so the dongle answers no command of its own and never tracks the
+//! protocol. That protocol is Rynk frames; with the `vial` feature the dongle
+//! also carries Vial reports, and discovery picks per keyboard which relay the
+//! connection feeds (`Protocol`). Keymaps and storage stay on the keyboard;
+//! the dongle persists one bond.
 //!
 //! Task layout (both joined by [`Dongle::run`]):
 //! - `ble_task`: trouble runner with the seeking-advertisement scan handler;
 //! - [`DongleCentral::run`]: find a keyboard, connect, secure, relay, repeat.
 
-#[cfg(not(feature = "vial"))]
-mod router;
+pub(crate) mod router;
 #[cfg(feature = "vial")]
-mod vial_router;
+pub(crate) mod vial_router;
 use core::cell::Cell;
 
 use bt_hci::cmd::le::{LeReadLocalSupportedFeatures, LeSetPhy, LeSetScanParams};
@@ -25,15 +26,13 @@ use embassy_futures::select::{Either, select, select3};
 use embassy_sync::blocking_mutex::Mutex as BlockingMutex;
 use embassy_sync::signal::Signal;
 use embassy_time::{Duration, Instant, Timer, with_deadline, with_timeout};
-#[cfg(not(feature = "vial"))]
 use rmk_types::protocol::rynk::{RYNK_BLE_CHUNK_SIZE, RYNK_INPUT_CHAR_UUID, RYNK_OUTPUT_CHAR_UUID, RYNK_SERVICE_UUID};
+#[cfg(not(feature = "vial"))]
 pub use router::DongleRouter;
-#[cfg(feature = "vial")]
-use router::VialReport;
 use trouble_host::prelude::*;
 use usbd_hid::descriptor::{MediaKeyboardReport, MouseReport, SystemControlReport};
 #[cfg(feature = "vial")]
-use vial_router as router;
+use vial_router::VialReport;
 
 use crate::ble::adv::Adv;
 use crate::ble::profile::{ProfileInfo, ProfileManager};
@@ -57,6 +56,53 @@ type DongleBleResources = HostResources<DefaultPacketPool, DONGLE_CONNECTIONS_MA
 type Client<'a, C> = GattClient<'a, C, DefaultPacketPool, 3>;
 
 const BOND_SLOT: u8 = 0;
+
+/// Which host protocol the connected keyboard serves, decided by discovery:
+/// the Rynk custom service names Rynk — a Rynk keyboard carries a second HID
+/// service too (its WebHID lane), so that extra 0x1812 alone proves nothing —
+/// and a keyboard without it serves Vial there.
+#[cfg(feature = "vial")]
+#[derive(Clone, Copy, PartialEq)]
+enum Protocol {
+    Rynk,
+    Vial,
+}
+
+/// Both relays side by side. Discovery picks per connection which one the BLE
+/// link feeds ([`Protocol`]); USB serves both interfaces throughout, and the
+/// idle relay answers its interface as if no keyboard were connected.
+#[cfg(feature = "vial")]
+pub struct DongleRouter {
+    /// The Rynk byte relay behind the vendor bulk interface.
+    pub(crate) rynk: router::DongleRouter,
+    /// The Vial report relay behind the Vial HID interface.
+    pub(crate) vial: vial_router::DongleRouter,
+}
+
+#[cfg(feature = "vial")]
+impl DongleRouter {
+    pub const fn new() -> Self {
+        Self {
+            rynk: router::DongleRouter::new(),
+            vial: vial_router::DongleRouter::new(),
+        }
+    }
+
+    /// Close both halves. Only one was up at most, but a spare `link_down` on
+    /// an idle relay is already the norm: `run_connection` fires it even when
+    /// discovery never brought a link up.
+    fn link_down(&self) {
+        self.rynk.link_down();
+        self.vial.link_down();
+    }
+}
+
+#[cfg(feature = "vial")]
+impl Default for DongleRouter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Which keyboard a connection is to, which decides whether it pairs or
 /// encrypts, and whether a refused key means the stored bond is dead.
@@ -390,16 +436,15 @@ where
         // One catch-all listener for every subscription — one queue, routed by handle.
         let mut listener = client.listen_all().ok()?;
 
+        #[cfg(not(feature = "vial"))]
         self.router.link_up();
+        #[cfg(feature = "vial")]
+        match chars.protocol {
+            Protocol::Rynk => self.router.rynk.link_up(),
+            Protocol::Vial => self.router.vial.link_up(),
+        }
         info!("[dongle] relaying");
-        self.relay(
-            #[cfg(not(feature = "vial"))]
-            conn,
-            client,
-            &mut listener,
-            &chars,
-        )
-        .await;
+        self.relay(conn, client, &mut listener, &chars).await;
         Some(())
     }
 
@@ -407,14 +452,20 @@ where
     /// out to USB/router, LED state and router frames back to the keyboard.
     async fn relay(
         &self,
-        #[cfg(not(feature = "vial"))] conn: &Connection<'_, DefaultPacketPool>,
+        conn: &Connection<'_, DefaultPacketPool>,
         client: &Client<'_, C>,
         listener: &mut NotificationListener<'_, 512>,
         chars: &KeyboardCharacteristics,
     ) {
+        // The connection's relay: the Rynk half of the router, unless discovery
+        // picked Vial — those arms bail out before the shared Rynk path below.
+        #[cfg(not(feature = "vial"))]
+        let rynk = self.router;
+        #[cfg(feature = "vial")]
+        let rynk = &self.router.rynk;
+
         // Largest single write chunk on the Rynk characteristic: ATT MTU minus the
         // 3-byte write header. Vial reports are 32 bytes and cross whole.
-        #[cfg(not(feature = "vial"))]
         let chunk_size = RYNK_BLE_CHUNK_SIZE
             .min((conn.att_mtu() as usize).saturating_sub(3))
             .max(1);
@@ -425,25 +476,27 @@ where
                 let (handle, data) = (notification.handle(), notification.as_ref());
                 // Only the config stream is opaque, and it goes straight to the host.
                 if handle == chars.config_input.handle {
+                    // Reports are atomic: a dropped one costs its reply, nothing else.
+                    #[cfg(feature = "vial")]
+                    if chars.protocol == Protocol::Vial {
+                        match VialReport::try_from(data) {
+                            Ok(report) => {
+                                if self.router.vial.to_host.try_send(report).is_err() {
+                                    warn!("[dongle] host reply queue full, dropping a reply");
+                                }
+                            }
+                            Err(_) => warn!("[dongle] non-report-size vial notify dropped"),
+                        }
+                        continue;
+                    }
                     // A full pipe is usually a host a moment behind, so wait for 20ms at most.
-                    #[cfg(not(feature = "vial"))]
-                    if with_timeout(Duration::from_millis(20), self.router.to_host.write_all(data))
+                    if with_timeout(Duration::from_millis(20), rynk.to_host.write_all(data))
                         .await
                         .is_err()
                     {
                         // Try to send a delimeter and drop the bytes which cannot be written in 20ms.
-                        let _ = self.router.to_host.try_write(&[0]);
+                        let _ = rynk.to_host.try_write(&[0]);
                         warn!("[dongle] host config stream overflow, dropping bytes");
-                    }
-                    // Reports are atomic: a dropped one costs its reply, nothing else.
-                    #[cfg(feature = "vial")]
-                    match VialReport::try_from(data) {
-                        Ok(report) => {
-                            if self.router.to_host.try_send(report).is_err() {
-                                warn!("[dongle] host reply queue full, dropping a reply");
-                            }
-                        }
-                        Err(_) => warn!("[dongle] non-report-size vial notify dropped"),
                     }
                 } else if let Some(report) = chars.report(handle, data) {
                     send_hid_report(report).await;
@@ -464,24 +517,21 @@ where
         // One characteristic write per pass. Rynk takes a write's worth out of the
         // byte stream — the read itself is the chunker — while Vial takes one whole
         // report, because a report can't be split.
-        #[cfg(not(feature = "vial"))]
         let mut request = [0u8; RYNK_BLE_CHUNK_SIZE];
         let request_to_keyboard = async {
             loop {
-                #[cfg(not(feature = "vial"))]
-                {
-                    let n = self.router.to_keyboard.read(&mut request[..chunk_size]).await;
-                    let _ = client
-                        .write_characteristic_without_response(&chars.config_output, &request[..n])
-                        .await;
-                }
                 #[cfg(feature = "vial")]
-                {
-                    let report = self.router.to_keyboard.receive().await;
+                if chars.protocol == Protocol::Vial {
+                    let report = self.router.vial.to_keyboard.receive().await;
                     let _ = client
                         .write_characteristic_without_response(&chars.config_output, &report)
                         .await;
+                    continue;
                 }
+                let n = rynk.to_keyboard.read(&mut request[..chunk_size]).await;
+                let _ = client
+                    .write_characteristic_without_response(&chars.config_output, &request[..n])
+                    .await;
             }
         };
 
@@ -517,6 +567,10 @@ struct KeyboardCharacteristics {
     /// pair of vial's own HID service.
     config_input: Characteristic<[u8]>,
     config_output: Characteristic<[u8]>,
+    /// Which relay the pair belongs to, and so which router half this
+    /// connection feeds.
+    #[cfg(feature = "vial")]
+    protocol: Protocol,
 }
 
 impl KeyboardCharacteristics {
@@ -545,15 +599,22 @@ impl KeyboardCharacteristics {
         let media = reports.next()?;
         let system = reports.next()?;
 
-        #[cfg(not(feature = "vial"))]
-        let (config_input, config_output) = {
-            let rynk = client
-                .services_by_uuid(&RYNK_SERVICE_UUID.into())
-                .await
-                .ok()?
-                .into_iter()
-                .next()?;
-            (
+        // An absent Rynk service ends the search with an empty list, not an
+        // error, so `ok()?` only fails the discovery on a real ATT error.
+        let rynk_service = client
+            .services_by_uuid(&RYNK_SERVICE_UUID.into())
+            .await
+            .ok()?
+            .into_iter()
+            .next();
+        #[cfg(feature = "vial")]
+        let protocol = match rynk_service {
+            Some(_) => Protocol::Rynk,
+            None => Protocol::Vial,
+        };
+
+        let (config_input, config_output) = match rynk_service {
+            Some(rynk) => (
                 client
                     .characteristic_by_uuid::<[u8]>(&rynk, &RYNK_INPUT_CHAR_UUID.into())
                     .await
@@ -562,19 +623,24 @@ impl KeyboardCharacteristics {
                     .characteristic_by_uuid::<[u8]>(&rynk, &RYNK_OUTPUT_CHAR_UUID.into())
                     .await
                     .ok()?,
-            )
-        };
-        // Vial rides the second HID service instance: input notify, then output write.
-        #[cfg(feature = "vial")]
-        let (config_input, config_output) = {
-            let vial = hid_services.next()?;
-            let mut reports = client
-                .characteristics::<9>(&vial)
-                .await
-                .ok()?
-                .into_iter()
-                .filter(|c| c.uuid == report_uuid);
-            (reports.next()?, reports.next()?)
+            ),
+            // No Rynk service names the keyboard a Vial one (see `Protocol`):
+            // its pair rides the second HID service instance — input notify,
+            // then output write.
+            #[cfg(feature = "vial")]
+            None => {
+                let vial = hid_services.next()?;
+                let mut reports = client
+                    .characteristics::<9>(&vial)
+                    .await
+                    .ok()?
+                    .into_iter()
+                    .filter(|c| c.uuid == report_uuid);
+                (reports.next()?, reports.next()?)
+            }
+            // Without the Vial relay there is nothing else to look for.
+            #[cfg(not(feature = "vial"))]
+            None => return None,
         };
 
         Some(Self {
@@ -585,6 +651,8 @@ impl KeyboardCharacteristics {
             system,
             config_input,
             config_output,
+            #[cfg(feature = "vial")]
+            protocol,
         })
     }
 
@@ -633,6 +701,42 @@ impl KeyboardCharacteristics {
         } else {
             None
         }
+    }
+}
+
+#[cfg(all(test, feature = "vial"))]
+mod tests {
+    use rmk_types::protocol::vial::VIAL_EP_SIZE;
+
+    use super::*;
+
+    /// The central's `link_down` is protocol-blind — it must reach both halves,
+    /// so whichever one was relaying drops its queue like a lone router would.
+    #[test]
+    fn link_down_reaches_both_halves() {
+        let router = DongleRouter::new();
+        router.rynk.link_up();
+        router.vial.link_up();
+        router.rynk.to_keyboard.try_write(&[1, 2, 3]).unwrap();
+        router.vial.to_keyboard.try_send([7u8; VIAL_EP_SIZE]).unwrap();
+
+        router.link_down();
+
+        let mut buf = [0u8; 8];
+        assert!(
+            router.rynk.to_keyboard.try_read(&mut buf).is_err(),
+            "no stale rynk request is parked for the next keyboard"
+        );
+        assert!(
+            router.vial.to_keyboard.try_receive().is_err(),
+            "no stale vial request is parked for the next keyboard"
+        );
+        let n = router
+            .rynk
+            .to_host
+            .try_read(&mut buf)
+            .expect("rynk stream is closed off");
+        assert_eq!(&buf[..n], &[0], "with the delimiter that voids a partial frame");
     }
 }
 

--- a/rmk/src/usb/mod.rs
+++ b/rmk/src/usb/mod.rs
@@ -24,15 +24,17 @@ use crate::light::UsbLedReader;
 use crate::state::{current_usb_state, set_usb_state};
 
 // The Rynk vendor interface serves the keyboard's Rynk session and the dongle's router.
-#[cfg(any(feature = "rynk", all(feature = "dongle", not(feature = "vial"))))]
+#[cfg(any(feature = "rynk", feature = "dongle"))]
 pub(crate) mod rynk;
 #[cfg(feature = "vial")]
 pub(crate) mod vial;
 
-// A build has at most one host interface — Vial's HID report pair or the Rynk
-// vendor bulk pair, and the protocols are mutually exclusive. A dongle relays
-// its keyboard's protocol: Rynk unless `vial` says otherwise. The two modules
-// expose the same names, so the rest of the file only talks to `host_usb`.
+// A keyboard build has one host interface — Vial's HID report pair or the Rynk
+// vendor bulk pair, the protocols being mutually exclusive — and `host_usb` is
+// whichever it is. The two modules expose the same names, so the rest of the
+// file only talks to `host_usb`. A dongle+vial build alone carries both, ready
+// for either kind of keyboard: the Vial pair rides `host_usb`, the Rynk pair
+// its own `rynk_*` fields.
 #[cfg(any(feature = "rynk", all(feature = "dongle", not(feature = "vial"))))]
 use rynk as host_usb;
 #[cfg(feature = "vial")]
@@ -160,22 +162,34 @@ impl<'d, D: Driver<'d>> HidWriterTrait for UsbKeyboardWriter<'_, 'd, D> {
     }
 }
 
-pub(crate) fn new_usb_builder<'d, D: Driver<'d>>(driver: D, keyboard_config: DeviceConfig<'d>) -> Builder<'d, D> {
+/// `rynk_magic` prefixes the serial with the Rynk discovery tag; it follows the
+/// role, not the feature set — the keyboard binary of a dongle setup carries
+/// the `dongle` feature too, but must not look like a Rynk device.
+pub(crate) fn new_usb_builder<'d, D: Driver<'d>>(
+    driver: D,
+    keyboard_config: DeviceConfig<'d>,
+    rynk_magic: bool,
+) -> Builder<'d, D> {
     let mut usb_config = embassy_usb::Config::new(keyboard_config.vid, keyboard_config.pid);
     usb_config.manufacturer = Some(keyboard_config.manufacturer);
     usb_config.product = Some(keyboard_config.product_name);
     // Informational tag (visible in `lsusb` & co); host discovery keys on the
     // Rynk vendor interface triple, not the serial.
-    #[cfg(any(feature = "rynk", all(feature = "dongle", not(feature = "vial"))))]
-    let serial_number = {
+    #[cfg(any(feature = "rynk", feature = "dongle"))]
+    let serial_number = if rynk_magic {
         static SERIAL: StaticCell<heapless::String<64>> = StaticCell::new();
         let s = SERIAL.init(heapless::String::new());
         let _ = s.push_str(rmk_types::protocol::rynk::RYNK_MAGIC);
         let _ = s.push_str(keyboard_config.serial_number);
         s.as_str()
+    } else {
+        keyboard_config.serial_number
     };
-    #[cfg(not(any(feature = "rynk", all(feature = "dongle", not(feature = "vial")))))]
-    let serial_number = keyboard_config.serial_number;
+    #[cfg(not(any(feature = "rynk", feature = "dongle")))]
+    let serial_number = {
+        let _ = rynk_magic;
+        keyboard_config.serial_number
+    };
     usb_config.serial_number = Some(serial_number);
     usb_config.max_power = 450;
     usb_config.supports_remote_wakeup = true;
@@ -193,7 +207,7 @@ pub(crate) fn new_usb_builder<'d, D: Driver<'d>>(driver: D, keyboard_config: Dev
         feature = "steno",
         feature = "dfu",
         feature = "rynk",
-        all(feature = "dongle", not(feature = "vial"))
+        feature = "dongle"
     ));
     const USB_BUF_SIZE: usize = if EXTRA_INTERFACES { 256 } else { 128 };
 
@@ -205,7 +219,7 @@ pub(crate) fn new_usb_builder<'d, D: Driver<'d>>(driver: D, keyboard_config: Dev
 
     // The rynk MS OS 2.0 descriptor set (WinUSB binding) takes ~178 bytes, and
     // its BOS platform capability another 28 on top of the 5-byte BOS header.
-    const RYNK_INTERFACE: bool = cfg!(any(feature = "rynk", all(feature = "dongle", not(feature = "vial"))));
+    const RYNK_INTERFACE: bool = cfg!(any(feature = "rynk", feature = "dongle"));
     const BOS_BUF_SIZE: usize = if RYNK_INTERFACE { 64 } else { 16 };
     const MSOS_BUF_SIZE: usize = if RYNK_INTERFACE { 256 } else { 16 };
 
@@ -249,12 +263,49 @@ pub struct UsbTransport<'a, D: Driver<'static>, S = ()> {
     host_reader: host_usb::HostUsbReader<D>,
     #[cfg(any(feature = "host", feature = "dongle"))]
     host_writer: host_usb::HostUsbWriter<D>,
+    /// The dual dongle's second host interface: `host_usb` carries the Vial
+    /// pair, this the Rynk pair. Only [`Self::new_dongle`] builds it — the
+    /// keyboard binary of a dongle setup shares the feature set, but must not
+    /// grow the interface.
+    #[cfg(all(feature = "dongle", feature = "vial"))]
+    rynk_io: Option<(rynk::HostUsbReader<D>, rynk::HostUsbWriter<D>)>,
+    /// The Rynk half of the dongle's router, concretely typed — the one build
+    /// shape with two interfaces has exactly one router for them.
+    #[cfg(all(feature = "dongle", feature = "vial"))]
+    rynk_router: Option<&'a crate::dongle::router::DongleRouter>,
     /// Serves the host interface; `&()` until a binary attaches its own.
     session: &'a S,
 }
 
 impl<'a, D: Driver<'static>> UsbTransport<'a, D> {
     pub fn new(driver: D, device_config: DeviceConfig<'static>) -> Self {
+        Self::build(driver, device_config, false)
+    }
+
+    /// The dongle role's transport, serving the host interface with the same
+    /// router [`crate::dongle::Dongle`] relays through. It carries the keyboard
+    /// interface set plus — with `vial` — the Rynk vendor interface beside the
+    /// Vial one, because which protocol the bonded keyboard speaks is only
+    /// known once it connects.
+    #[cfg(feature = "dongle")]
+    pub fn new_dongle(
+        driver: D,
+        device_config: DeviceConfig<'static>,
+        router: &'a crate::dongle::DongleRouter,
+    ) -> UsbTransport<'a, D, crate::dongle::DongleRouter> {
+        let this = Self::build(driver, device_config, true);
+        #[cfg(feature = "vial")]
+        let this = UsbTransport {
+            rynk_router: Some(&router.rynk),
+            ..this
+        };
+        this.serving(router)
+    }
+
+    /// `dongle_role` picks what features alone cannot: both binaries of a
+    /// dongle setup share a feature set, but only the dongle itself presents
+    /// the Rynk interface and its magic serial.
+    fn build(driver: D, device_config: DeviceConfig<'static>, dongle_role: bool) -> Self {
         // nRF chips don't have a stable USB serial number unless one is derived
         // from the FICR. Override here so user code doesn't have to know.
         #[cfg(feature = "_nrf_ble")]
@@ -263,7 +314,8 @@ impl<'a, D: Driver<'static>> UsbTransport<'a, D> {
             device_config.serial_number = crate::ble::nrf::get_serial_number();
             device_config
         };
-        let mut builder: Builder<'static, D> = new_usb_builder(driver, device_config);
+        let mut builder: Builder<'static, D> =
+            new_usb_builder(driver, device_config, cfg!(feature = "rynk") || dongle_role);
         // Linux's usbhid driver auto-enables power/wakeup when it probes a
         // boot-protocol keyboard, so advertise Boot/Keyboard on the primary
         // HID interface.
@@ -295,6 +347,8 @@ impl<'a, D: Driver<'static>> UsbTransport<'a, D> {
 
         #[cfg(any(feature = "host", feature = "dongle"))]
         let (host_reader, host_writer) = host_usb::build_host_usb(&mut builder);
+        #[cfg(all(feature = "dongle", feature = "vial"))]
+        let rynk_io = dongle_role.then(|| rynk::build_host_usb(&mut builder));
 
         let (keyboard_reader, keyboard_writer) = keyboard_rw.split();
         let device = builder.build();
@@ -312,6 +366,10 @@ impl<'a, D: Driver<'static>> UsbTransport<'a, D> {
             host_reader,
             #[cfg(any(feature = "host", feature = "dongle"))]
             host_writer,
+            #[cfg(all(feature = "dongle", feature = "vial"))]
+            rynk_io,
+            #[cfg(all(feature = "dongle", feature = "vial"))]
+            rynk_router: None,
             session: &(),
         }
     }
@@ -325,16 +383,6 @@ impl<'a, D: Driver<'static>, S> UsbTransport<'a, D, S> {
         service: &'a crate::host::HostService<'a>,
     ) -> UsbTransport<'a, D, crate::host::HostService<'a>> {
         self.serving(service)
-    }
-
-    /// Attach the dongle's router — this is what makes a binary a dongle. The
-    /// same router goes to [`crate::dongle::Dongle`], which relays through it.
-    #[cfg(feature = "dongle")]
-    pub fn with_dongle_router(
-        self,
-        router: &'a crate::dongle::DongleRouter,
-    ) -> UsbTransport<'a, D, crate::dongle::DongleRouter> {
-        self.serving(router)
     }
 
     /// Rebuild around the session that answers the host interface.
@@ -352,6 +400,10 @@ impl<'a, D: Driver<'static>, S> UsbTransport<'a, D, S> {
             host_reader: self.host_reader,
             #[cfg(any(feature = "host", feature = "dongle"))]
             host_writer: self.host_writer,
+            #[cfg(all(feature = "dongle", feature = "vial"))]
+            rynk_io: self.rynk_io,
+            #[cfg(all(feature = "dongle", feature = "vial"))]
+            rynk_router: self.rynk_router,
             session,
         }
     }
@@ -372,6 +424,10 @@ impl<D: Driver<'static>, S: HostSession> Runnable for UsbTransport<'_, D, S> {
             host_reader,
             #[cfg(any(feature = "host", feature = "dongle"))]
             host_writer,
+            #[cfg(all(feature = "dongle", feature = "vial"))]
+            rynk_io,
+            #[cfg(all(feature = "dongle", feature = "vial"))]
+            rynk_router,
             session,
         } = self;
 
@@ -409,6 +465,15 @@ impl<D: Driver<'static>, S: HostSession> Runnable for UsbTransport<'_, D, S> {
             let _ = session;
             core::future::pending::<()>()
         };
+        // The dual dongle's Rynk interface runs beside the Vial one; a keyboard
+        // build never built the interface and idles here.
+        #[cfg(all(feature = "dongle", feature = "vial"))]
+        let host_task = embassy_futures::join::join(host_task, async {
+            match (rynk_io, rynk_router) {
+                (Some((reader, writer)), Some(router)) => rynk::run_host_usb(reader, writer, *router).await,
+                _ => core::future::pending().await,
+            }
+        });
 
         #[cfg(feature = "usb_log")]
         let logger_task = run_usb_logger(logger.take().expect("UsbTransport::run called twice"));
@@ -435,7 +500,7 @@ async fn run_usb_logger<D: Driver<'static>>(logger_class: CdcAcmClass<'static, D
 
 #[cfg(any(feature = "usb_log", feature = "dfu_nrf", feature = "dfu_rp"))]
 pub async fn run_peripheral_usb<D: Driver<'static>>(driver: D, config: DeviceConfig<'static>) {
-    let mut builder = new_usb_builder(driver, config);
+    let mut builder = new_usb_builder(driver, config, cfg!(feature = "rynk"));
 
     #[cfg(feature = "usb_log")]
     let logger_fut = run_usb_logger(add_usb_logger!(&mut builder));

--- a/rmk/src/usb/rynk.rs
+++ b/rmk/src/usb/rynk.rs
@@ -14,8 +14,10 @@ impl HostSession for crate::host::rynk::RynkService<'_> {
     }
 }
 
+// The concrete Rynk relay: the public `DongleRouter` itself without `vial`, the
+// `rynk` half of it with — either way what serves this interface.
 #[cfg(feature = "dongle")]
-impl HostSession for crate::dongle::DongleRouter {
+impl HostSession for crate::dongle::router::DongleRouter {
     async fn serve<R: Read, W: Write>(&self, rx: &mut R, tx: &mut W) {
         self.run_session(rx, tx).await
     }

--- a/rmk/src/usb/vial.rs
+++ b/rmk/src/usb/vial.rs
@@ -28,10 +28,12 @@ impl super::HostSession for VialService<'_> {
     }
 }
 
+// A dongle with `vial` is the dual-protocol shape: the generic session is the
+// whole router, and this interface is its Vial half's.
 #[cfg(feature = "dongle")]
 impl super::HostSession for crate::dongle::DongleRouter {
     async fn serve<R: Read, W: Write>(&self, rx: &mut R, tx: &mut W) {
-        self.run_session(rx, tx).await
+        self.vial.run_session(rx, tx).await
     }
 }
 


### PR DESCRIPTION
Stacked on #1047.

A `dongle`+`vial` build no longer swaps the Rynk relay for the Vial one — it carries both, and picks per keyboard at connection time. One dongle firmware now serves whichever keyboard it bonds.

## How the protocol is chosen

Discovery probes the Rynk custom GATT service first; only its absence names the keyboard a Vial one, whose config pair rides the second HID service instance. The extra 0x1812 alone proves nothing — a Rynk keyboard also exposes a second HID service (its WebHID lane). trouble-host returns an empty list (not an error) for an absent service, so the probe distinguishes "not there" from a real ATT failure. The existing `Client<3>` service budget already covers the worst case (report + second HID + custom).

## Interface set follows the role, not the feature set

Both binaries of a dongle setup enable `dongle`, so feature gates alone would have grown a dead Rynk vendor interface (and the RYNK_MAGIC serial) on the *keyboard* binary of a vial setup — rmk-gui would discover it and hang. `UsbTransport::new_dongle(driver, config, &router)` replaces `new(...).with_dongle_router(...)` and is the one place the second interface and magic serial come from; `new()` keeps the keyboard shape. The nrf_dongle example is updated.

## Shape

- `dongle` without `vial`: unchanged — Rynk-only relay, same image.
- `dongle`+`vial`: public `DongleRouter` is now both relays side by side (`rynk` + `vial` halves); the BLE task feeds the discovered half, USB runs both sessions (`host_usb` carries the Vial pair, a concrete second lane the Rynk pair). `link_down` closes both halves — a spare `link_down` on an idle relay was already the norm.
- The keyboard binary of a vial dongle setup pays ~420 B of statically sized descriptor buffers it never fills (BOS/MSOS/config sizing is per feature set, the interface build is per role).

## Tested

- `cargo check` on all 7 dongle/rynk/vial CI feature rows, plus clippy on both dongle rows: clean.
- `cargo nextest` on `dongle,vial,_ble,storage` (504 passed, incl. new `link_down_reaches_both_halves`) and `dongle,_ble,storage` (473 passed).
- nrf_dongle example builds for nRF54LM20 as-is (Rynk mode) and with `vial` added (dual mode).