### PR TITLE
Add the default morse profile and flow-tap window in Rynk

### DIFF
--- a/rmk-types/src/morse.rs
+++ b/rmk-types/src/morse.rs
@@ -104,7 +104,8 @@ impl MorseProfile {
         )
     }
 
-    /// Per-profile override for flow tap. `None` inherits the global morse setting.
+    /// Per-profile override for flow tap. `None` falls back to the default
+    /// profile's bit, then the config-level `enable_flow_tap` switch.
     pub fn enable_flow_tap(self) -> Option<bool> {
         match (self.0 & FLOW_TAP_MASK) >> 13 {
             3 => Some(true),

--- a/rmk-types/src/protocol/rynk/payload/system.rs
+++ b/rmk-types/src/protocol/rynk/payload/system.rs
@@ -6,6 +6,8 @@ use heapless::{String, Vec};
 use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
 
+use crate::morse::MorseProfile;
+
 /// Maximum byte length of each `DeviceInfo` string field.
 pub const DEVICE_INFO_STRING_SIZE: usize = 32;
 
@@ -155,6 +157,10 @@ pub struct BehaviorConfig {
     pub oneshot_timeout_ms: u16,
     pub tap_interval_ms: u16,
     pub tap_capslock_interval_ms: u16,
+    /// Default profile for morse/tap-hold keys; per-key profiles override it.
+    pub morse_default_profile: MorseProfile,
+    /// Flow-tap window: a tap within this time of the previous key forces a tap.
+    pub morse_prior_idle_time_ms: u16,
 }
 
 #[cfg(test)]
@@ -287,6 +293,14 @@ mod tests {
             oneshot_timeout_ms: 500,
             tap_interval_ms: 200,
             tap_capslock_interval_ms: 20,
+            morse_default_profile: MorseProfile::new(
+                Some(true),
+                Some(crate::morse::MorseMode::PermissiveHold),
+                Some(260),
+                Some(180),
+            )
+            .with_quick_tap_timeout_ms(Some(120)),
+            morse_prior_idle_time_ms: 130,
         });
     }
 }

--- a/rmk-types/src/protocol/rynk/payload/system.rs
+++ b/rmk-types/src/protocol/rynk/payload/system.rs
@@ -302,5 +302,25 @@ mod tests {
             .with_quick_tap_timeout_ms(Some(120)),
             morse_prior_idle_time_ms: 130,
         });
+
+        // Max-width case: every profile field at its widest so the packed u64's
+        // varint encoding is as long as it gets vs the derived `MaxSize`.
+        let cfg = BehaviorConfig {
+            combo_timeout_ms: u16::MAX,
+            oneshot_timeout_ms: u16::MAX,
+            tap_interval_ms: u16::MAX,
+            tap_capslock_interval_ms: u16::MAX,
+            morse_default_profile: MorseProfile::new(
+                Some(true),
+                Some(crate::morse::MorseMode::Normal),
+                Some(8191),
+                Some(8191),
+            )
+            .with_enable_flow_tap(Some(true))
+            .with_quick_tap_timeout_ms(Some(8191)),
+            morse_prior_idle_time_ms: u16::MAX,
+        };
+        round_trip(&cfg);
+        assert_max_size_bound(&cfg);
     }
 }

--- a/rmk-types/src/protocol/rynk/payload/system.rs
+++ b/rmk-types/src/protocol/rynk/payload/system.rs
@@ -158,6 +158,8 @@ pub struct BehaviorConfig {
     pub tap_interval_ms: u16,
     pub tap_capslock_interval_ms: u16,
     /// Default profile for morse/tap-hold keys; per-key profiles override it.
+    /// A `None` field falls back to a firmware default the host can't read back —
+    /// for `enable_flow_tap`, the compiled `[behavior.morse]` switch.
     pub morse_default_profile: MorseProfile,
     /// Flow-tap window: a morse key pressed within this time of the previous
     /// key press is forced to its tap action.
@@ -304,21 +306,15 @@ mod tests {
             morse_prior_idle_time_ms: 130,
         });
 
-        // Max-width case: every profile field at its widest so the packed u64's
-        // varint encoding is as long as it gets vs the derived `MaxSize`.
+        // Max-width case. The profile's setters top out at bit 45, so it is built
+        // from raw bits: a host decodes `MorseProfile` from a bare u64, and only
+        // the reserved high bits reach the 10-byte varint `MaxSize` counts.
         let cfg = BehaviorConfig {
             combo_timeout_ms: u16::MAX,
             oneshot_timeout_ms: u16::MAX,
             tap_interval_ms: u16::MAX,
             tap_capslock_interval_ms: u16::MAX,
-            morse_default_profile: MorseProfile::new(
-                Some(true),
-                Some(crate::morse::MorseMode::Normal),
-                Some(8191),
-                Some(8191),
-            )
-            .with_enable_flow_tap(Some(true))
-            .with_quick_tap_timeout_ms(Some(8191)),
+            morse_default_profile: MorseProfile::from(u64::MAX),
             morse_prior_idle_time_ms: u16::MAX,
         };
         round_trip(&cfg);

--- a/rmk-types/src/protocol/rynk/payload/system.rs
+++ b/rmk-types/src/protocol/rynk/payload/system.rs
@@ -159,7 +159,8 @@ pub struct BehaviorConfig {
     pub tap_capslock_interval_ms: u16,
     /// Default profile for morse/tap-hold keys; per-key profiles override it.
     pub morse_default_profile: MorseProfile,
-    /// Flow-tap window: a tap within this time of the previous key forces a tap.
+    /// Flow-tap window: a morse key pressed within this time of the previous
+    /// key press is forced to its tap action.
     pub morse_prior_idle_time_ms: u16,
 }
 

--- a/rmk-types/src/protocol/rynk/snapshots/wire_frames.snap
+++ b/rmk-types/src/protocol/rynk/snapshots/wire_frames.snap
@@ -15,7 +15,7 @@ ClearBleProfile request 1                                                       
 ConnectionChange topic ConnectionStatus{Configured,{1,Adv},Ble}                 03 03 80 03 02 01 02 01 00
 GetBatteryStatus reply Ok(Available{Discharging,85})                            04 03 08 01 05 01 01 01 55 00
 GetBatteryStatus request ()                                                     04 03 08 01 00
-GetBehaviorConfig reply Ok(BehaviorConfig{50,500,200,20})                       04 01 06 01 07 32 f4 03 c8 01 14 00
+GetBehaviorConfig reply Ok(BehaviorConfig{50..120})                             04 01 06 01 0d 32 3c 46 50 da 80 a6 86 e8 8d 08 78 00
 GetBehaviorConfig request ()                                                    04 01 06 01 00
 GetBleStatus reply Ok(BleStatus{1,Advertising})                                 04 03 07 01 02 01 01 00
 GetBleStatus request ()                                                         04 03 07 01 00
@@ -66,7 +66,7 @@ Lock request ()                                                                 
 Reboot reply Ok(())                                                             02 03 02 01 01 00
 Reboot request ()                                                               02 03 02 01 00
 SetBehaviorConfig reply Ok(())                                                  04 02 06 01 01 00
-SetBehaviorConfig request BehaviorConfig{50,500,200,20}                         0a 02 06 01 32 f4 03 c8 01 14 00
+SetBehaviorConfig request BehaviorConfig{50..120}                               10 02 06 01 32 3c 46 50 da 80 a6 86 e8 8d 08 78 00
 SetCombo reply Ok(())                                                           04 02 03 01 01 00
 SetCombo request SetComboRequest{3,combo}                                       08 02 03 01 03 01 02 01 06 04 05 01 01 02 00
 SetDefaultLayer reply Ok(())                                                    04 04 01 01 01 00

--- a/rmk-types/src/protocol/rynk/snapshots/wire_values.snap
+++ b/rmk-types/src/protocol/rynk/snapshots/wire_values.snap
@@ -28,7 +28,7 @@ Action::TriggerMacro(7)                   0c 07
 Action::User(9)                           13 09
 BatteryStatus::Available{Discharging,85}  01 01 01 55
 BatteryStatus::Unavailable                00
-BehaviorConfig{50,500,200,20}             32 f4 03 c8 01 14
+BehaviorConfig{50..120}                   32 3c 46 50 da 80 a6 86 e8 8d 08 78
 BleState::Advertising                     00
 BleState::Connected                       01
 BleState::Inactive                        02

--- a/rmk-types/src/protocol/rynk/tests.rs
+++ b/rmk-types/src/protocol/rynk/tests.rs
@@ -261,11 +261,16 @@ fn exemplars() -> Exemplars {
         product_name: heapless::String::try_from("RMK Keyboard").unwrap(),
         serial_number: heapless::String::try_from("rynk:0001").unwrap(),
     };
+    // Quick-tap sits in the u64's high bits, so the profile also exercises a
+    // long-varint encoding.
     let behavior = BehaviorConfig {
         combo_timeout_ms: 50,
-        oneshot_timeout_ms: 500,
-        tap_interval_ms: 200,
-        tap_capslock_interval_ms: 20,
+        oneshot_timeout_ms: 60,
+        tap_interval_ms: 70,
+        tap_capslock_interval_ms: 80,
+        morse_default_profile: MorseProfile::new(Some(true), Some(MorseMode::HoldOnOtherPress), Some(90), Some(100))
+            .with_quick_tap_timeout_ms(Some(110)),
+        morse_prior_idle_time_ms: 120,
     };
     let connection = ConnectionStatus {
         usb: UsbState::Configured,
@@ -483,7 +488,7 @@ fn wire_values_locked() {
         ("MatrixState{[0x05,0x00,0x20]}", encode(&ex.matrix)),
         ("DeviceCapabilities{1..16}", encode(&ex.capabilities)),
         ("DeviceInfo{1.2.3,4,5,RMK,..}", encode(&ex.device_info)),
-        ("BehaviorConfig{50,500,200,20}", encode(&ex.behavior)),
+        ("BehaviorConfig{50..120}", encode(&ex.behavior)),
         ("ConnectionStatus{Configured,{1,Adv},Ble}", encode(&ex.connection)),
         ("ProtocolVersion{1,0}", encode(&ProtocolVersion { major: 1, minor: 0 })),
         ("ProtocolVersion::CURRENT", encode(&ProtocolVersion::CURRENT)),
@@ -859,7 +864,7 @@ fn wire_frames_locked() {
             encode_frame(Cmd::GetBehaviorConfig, SEQ, &())
         ),
         (
-            "GetBehaviorConfig reply Ok(BehaviorConfig{50,500,200,20})",
+            "GetBehaviorConfig reply Ok(BehaviorConfig{50..120})",
             encode_frame(
                 Cmd::GetBehaviorConfig,
                 SEQ,
@@ -867,7 +872,7 @@ fn wire_frames_locked() {
             ),
         ),
         (
-            "SetBehaviorConfig request BehaviorConfig{50,500,200,20}",
+            "SetBehaviorConfig request BehaviorConfig{50..120}",
             encode_frame(Cmd::SetBehaviorConfig, SEQ, &ex.behavior)
         ),
         (

--- a/rmk/src/host/context.rs
+++ b/rmk/src/host/context.rs
@@ -9,6 +9,8 @@ use rmk_types::connection::{ConnectionStatus, ConnectionType};
 use rmk_types::fork::Fork;
 use rmk_types::led_indicator::LedIndicator;
 use rmk_types::morse::{Morse, MorseProfile};
+#[cfg(feature = "rynk")]
+use rmk_types::protocol::rynk::BehaviorConfig;
 
 use crate::event::KeyboardEventPos;
 use crate::keyboard::combo::Combo;
@@ -277,6 +279,32 @@ impl<'a> KeyboardContext<'a> {
         self.keymap.set_morse_prior_idle_time(Duration::from_millis(ms as u64));
         #[cfg(feature = "storage")]
         FLASH_CHANNEL.send(FlashOperationMessage::PriorIdleTime(ms)).await;
+    }
+
+    // Whole-struct write for Rynk's SetBehaviorConfig: one flash message instead
+    // of six read-modify-write cycles of the same storage item.
+    #[cfg(feature = "rynk")]
+    pub async fn set_behavior_config(&self, cfg: BehaviorConfig) {
+        self.keymap
+            .set_combo_timeout(Duration::from_millis(cfg.combo_timeout_ms as u64));
+        self.keymap
+            .set_one_shot_timeout(Duration::from_millis(cfg.oneshot_timeout_ms as u64));
+        self.keymap.set_tap_interval(cfg.tap_interval_ms);
+        self.keymap.set_tap_capslock_interval(cfg.tap_capslock_interval_ms);
+        self.keymap.set_morse_default_profile(cfg.morse_default_profile);
+        self.keymap
+            .set_morse_prior_idle_time(Duration::from_millis(cfg.morse_prior_idle_time_ms as u64));
+        #[cfg(feature = "storage")]
+        FLASH_CHANNEL
+            .send(FlashOperationMessage::BehaviorConfig(crate::storage::BehaviorConfig {
+                prior_idle_time: cfg.morse_prior_idle_time_ms,
+                morse_default_profile: cfg.morse_default_profile,
+                combo_timeout: cfg.combo_timeout_ms,
+                one_shot_timeout: cfg.oneshot_timeout_ms,
+                tap_interval: cfg.tap_interval_ms,
+                tap_capslock_interval: cfg.tap_capslock_interval_ms,
+            }))
+            .await;
     }
 
     pub async fn set_layout_options(&self, opts: u32) {

--- a/rmk/src/host/rynk/handlers/behavior.rs
+++ b/rmk/src/host/rynk/handlers/behavior.rs
@@ -22,12 +22,7 @@ impl Handle<GetBehaviorConfig> for RynkService<'_> {
 
 impl Handle<SetBehaviorConfig> for RynkService<'_> {
     async fn handle(&self, cfg: BehaviorConfig) -> Result<(), RynkError> {
-        self.ctx.set_combo_timeout(cfg.combo_timeout_ms).await;
-        self.ctx.set_one_shot_timeout(cfg.oneshot_timeout_ms).await;
-        self.ctx.set_tap_interval(cfg.tap_interval_ms).await;
-        self.ctx.set_tap_capslock_interval(cfg.tap_capslock_interval_ms).await;
-        self.ctx.set_morse_default_profile(cfg.morse_default_profile).await;
-        self.ctx.set_morse_prior_idle_time(cfg.morse_prior_idle_time_ms).await;
+        self.ctx.set_behavior_config(cfg).await;
         Ok(())
     }
 }

--- a/rmk/src/host/rynk/handlers/behavior.rs
+++ b/rmk/src/host/rynk/handlers/behavior.rs
@@ -1,4 +1,5 @@
-//! Behavior-config handlers (combo timeout, one-shot timeout, tap intervals).
+//! Behavior-config handlers (combo timeout, one-shot timeout, tap intervals,
+//! default morse profile, flow-tap window).
 
 use rmk_types::protocol::rynk::command::{GetBehaviorConfig, SetBehaviorConfig};
 use rmk_types::protocol::rynk::{BehaviorConfig, RynkError};
@@ -13,6 +14,8 @@ impl Handle<GetBehaviorConfig> for RynkService<'_> {
             oneshot_timeout_ms: self.ctx.one_shot_timeout().as_millis() as u16,
             tap_interval_ms: self.ctx.tap_interval(),
             tap_capslock_interval_ms: self.ctx.tap_capslock_interval(),
+            morse_default_profile: self.ctx.morse_default_profile(),
+            morse_prior_idle_time_ms: self.ctx.morse_prior_idle_time().as_millis() as u16,
         })
     }
 }
@@ -23,6 +26,8 @@ impl Handle<SetBehaviorConfig> for RynkService<'_> {
         self.ctx.set_one_shot_timeout(cfg.oneshot_timeout_ms).await;
         self.ctx.set_tap_interval(cfg.tap_interval_ms).await;
         self.ctx.set_tap_capslock_interval(cfg.tap_capslock_interval_ms).await;
+        self.ctx.set_morse_default_profile(cfg.morse_default_profile).await;
+        self.ctx.set_morse_prior_idle_time(cfg.morse_prior_idle_time_ms).await;
         Ok(())
     }
 }

--- a/rmk/src/keyboard/morse.rs
+++ b/rmk/src/keyboard/morse.rs
@@ -412,7 +412,7 @@ impl<'a> Keyboard<'a> {
         };
         per_key
             .or_else(|| keymap.morse_default_profile().enable_flow_tap())
-            .unwrap_or(false)
+            .unwrap_or_else(|| keymap.morse_enable_flow_tap())
     }
 
     /// Checks if the given pattern can fire its action early even though longer

--- a/rmk/src/keyboard/morse.rs
+++ b/rmk/src/keyboard/morse.rs
@@ -403,17 +403,16 @@ impl<'a> Keyboard<'a> {
     }
 
     pub fn is_flow_tap_enabled(keymap: &KeyMap, key_action: &KeyAction) -> bool {
-        match key_action {
-            KeyAction::TapHold(_, _, idx) => keymap
-                .morse_profile(*idx)
-                .enable_flow_tap()
-                .unwrap_or_else(|| keymap.morse_enable_flow_tap()),
+        let per_key = match key_action {
+            KeyAction::TapHold(_, _, idx) => keymap.morse_profile(*idx).enable_flow_tap(),
             KeyAction::Morse(index) => keymap
                 .get_morse(*index as usize)
-                .and_then(|morse| morse.profile.enable_flow_tap())
-                .unwrap_or_else(|| keymap.morse_enable_flow_tap()),
-            _ => keymap.morse_enable_flow_tap(),
-        }
+                .and_then(|morse| morse.profile.enable_flow_tap()),
+            _ => None,
+        };
+        per_key
+            .or_else(|| keymap.morse_default_profile().enable_flow_tap())
+            .unwrap_or(false)
     }
 
     /// Checks if the given pattern can fire its action early even though longer

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -345,6 +345,13 @@ impl<'a> KeyMap<'a> {
         behavior: &'a mut BehaviorConfig,
         positional_config: &'a PositionalConfig<ROW, COL>,
     ) -> Self {
+        // The default profile heads every per-field fallback chain, so fold the
+        // config-level flow-tap switch in; an unset bit has nowhere left to fall.
+        let morse = &mut behavior.morse;
+        if morse.default_profile.enable_flow_tap().is_none() {
+            morse.default_profile = morse.default_profile.with_enable_flow_tap(Some(morse.enable_flow_tap));
+        }
+
         let layers = data.keymap.as_mut_slice().as_flattened_mut().as_flattened_mut();
         let encoders = if NUM_ENCODER > 0 {
             Some(data.encoder_map.as_mut_slice().as_flattened_mut())
@@ -574,10 +581,6 @@ impl<'a> KeyMap<'a> {
         self.inner.borrow().behavior.tap.tap_capslock_interval
     }
 
-    pub(crate) fn morse_enable_flow_tap(&self) -> bool {
-        self.inner.borrow().behavior.morse.enable_flow_tap
-    }
-
     pub(crate) fn morse_prior_idle_time(&self) -> Duration {
         self.inner.borrow().behavior.morse.prior_idle_time
     }
@@ -629,7 +632,15 @@ impl<'a> KeyMap<'a> {
     }
 
     pub(crate) fn set_morse_default_profile(&self, profile: MorseProfile) {
-        self.inner.borrow_mut().behavior.morse.default_profile = profile;
+        let mut inner = self.inner.borrow_mut();
+        let morse = &mut inner.behavior.morse;
+        // Same fold as `build`: keep the top of the fallback chain concrete
+        // so a host write can't silently drop the config-level switch.
+        morse.default_profile = if profile.enable_flow_tap().is_none() {
+            profile.with_enable_flow_tap(Some(morse.enable_flow_tap))
+        } else {
+            profile
+        };
     }
 
     pub(crate) fn set_morse_prior_idle_time(&self, time: Duration) {

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -345,13 +345,6 @@ impl<'a> KeyMap<'a> {
         behavior: &'a mut BehaviorConfig,
         positional_config: &'a PositionalConfig<ROW, COL>,
     ) -> Self {
-        // The default profile heads every per-field fallback chain, so fold the
-        // config-level flow-tap switch in; an unset bit has nowhere left to fall.
-        let morse = &mut behavior.morse;
-        if morse.default_profile.enable_flow_tap().is_none() {
-            morse.default_profile = morse.default_profile.with_enable_flow_tap(Some(morse.enable_flow_tap));
-        }
-
         let layers = data.keymap.as_mut_slice().as_flattened_mut().as_flattened_mut();
         let encoders = if NUM_ENCODER > 0 {
             Some(data.encoder_map.as_mut_slice().as_flattened_mut())
@@ -581,6 +574,10 @@ impl<'a> KeyMap<'a> {
         self.inner.borrow().behavior.tap.tap_capslock_interval
     }
 
+    pub(crate) fn morse_enable_flow_tap(&self) -> bool {
+        self.inner.borrow().behavior.morse.enable_flow_tap
+    }
+
     pub(crate) fn morse_prior_idle_time(&self) -> Duration {
         self.inner.borrow().behavior.morse.prior_idle_time
     }
@@ -632,15 +629,7 @@ impl<'a> KeyMap<'a> {
     }
 
     pub(crate) fn set_morse_default_profile(&self, profile: MorseProfile) {
-        let mut inner = self.inner.borrow_mut();
-        let morse = &mut inner.behavior.morse;
-        // Same fold as `build`: keep the top of the fallback chain concrete
-        // so a host write can't silently drop the config-level switch.
-        morse.default_profile = if profile.enable_flow_tap().is_none() {
-            profile.with_enable_flow_tap(Some(morse.enable_flow_tap))
-        } else {
-            profile
-        };
+        self.inner.borrow_mut().behavior.morse.default_profile = profile;
     }
 
     pub(crate) fn set_morse_prior_idle_time(&self, time: Duration) {

--- a/rmk/src/storage/mod.rs
+++ b/rmk/src/storage/mod.rs
@@ -152,6 +152,10 @@ pub(crate) enum FlashOperationMessage {
     PriorIdleTime(u16),
     // Default morse profile containing all morse/tap-hold settings (mode, timeouts, unilateral_tap)
     MorseDefaultProfile(MorseProfile),
+    #[cfg(feature = "rynk")]
+    // The whole behavior config in one message (Rynk's SetBehaviorConfig carries
+    // every field, so one store beats six read-modify-write cycles)
+    BehaviorConfig(BehaviorConfig),
     #[cfg(feature = "_ble")]
     // Read bond info for the given slot; storage task replies via `BOND_INFO_RESPONSE`.
     ReadBleBondInfo(u8),
@@ -806,6 +810,14 @@ impl<F: AsyncNorFlash, const ROW: usize, const COL: usize, const NUM_LAYER: usiz
                 }
                 FlashOperationMessage::MorseDefaultProfile(morse_default_profile) => {
                     update_storage_field!(&mut self.flash, &mut self.buffer, BehaviorConfig, morse_default_profile)
+                }
+                #[cfg(feature = "rynk")]
+                FlashOperationMessage::BehaviorConfig(behavior_config) => {
+                    self.store_data(
+                        StorageKey::BehaviorConfig,
+                        &StorageData::BehaviorConfig(behavior_config),
+                    )
+                    .await
                 }
             };
 

--- a/rmk/tests/scenarios/rynk_behavior.toml
+++ b/rmk/tests/scenarios/rynk_behavior.toml
@@ -13,7 +13,8 @@ map = """
 [[keymap.layer]]
 keys = "A  B  TD(0)"
 
-# Overwritten over the wire below; present so `TD(0)` resolves.
+# Lets `TD(0)` resolve. Most cases overwrite it over the wire, but the flow-tap
+# case asserts `X`/`Y` directly, so renaming them breaks it.
 [[behavior.morse.morses]]
 tap = "X"
 hold = "Y"

--- a/rmk/tests/scenarios/rynk_behavior.toml
+++ b/rmk/tests/scenarios/rynk_behavior.toml
@@ -91,19 +91,20 @@ steps = [
 ]
 expect = [["C"], [], ["A"], ["A", "B"], ["B"], []]
 
-# The written profile leaves flow-tap unset; the read returns it folded to the
-# config-level switch (false here) — the default profile never reads back with
-# a hole at the top of the fallback chain.
+# The written profile leaves flow-tap unset and the read returns it unchanged:
+# the profile stores exactly what the host wrote, and an unset bit keeps
+# inheriting the config-level switch at use time.
 [[test]]
 name = "behavior_config_read_returns_what_was_written"
 steps = [
   { rynk = { cmd = "SetBehaviorConfig", payload = { combo_timeout_ms = 42, oneshot_timeout_ms = 900, tap_interval_ms = 180, tap_capslock_interval_ms = 240, morse_default_profile = { unilateral_tap = true, mode = "PermissiveHold", hold_timeout_ms = 210, gap_timeout_ms = 160, quick_tap_timeout_ms = 110 }, morse_prior_idle_time_ms = 95 } } },
-  { rynk = { cmd = "GetBehaviorConfig", reply = { combo_timeout_ms = 42, oneshot_timeout_ms = 900, tap_interval_ms = 180, tap_capslock_interval_ms = 240, morse_default_profile = { unilateral_tap = true, enable_flow_tap = false, mode = "PermissiveHold", hold_timeout_ms = 210, gap_timeout_ms = 160, quick_tap_timeout_ms = 110 }, morse_prior_idle_time_ms = 95 } } },
+  { rynk = { cmd = "GetBehaviorConfig", reply = { combo_timeout_ms = 42, oneshot_timeout_ms = 900, tap_interval_ms = 180, tap_capslock_interval_ms = 240, morse_default_profile = { unilateral_tap = true, mode = "PermissiveHold", hold_timeout_ms = 210, gap_timeout_ms = 160, quick_tap_timeout_ms = 110 }, morse_prior_idle_time_ms = 95 } } },
 ]
 
 # Flow tap resolves through the default profile, so turning it on over the wire
 # reaches morse-table keys too: a long press right after another key is forced
-# to its tap action instead of resolving as a hold.
+# to its tap action instead of resolving as a hold. Writing the bit back unset
+# reverts to the config-level switch (off here): the same gesture holds again.
 [[test]]
 name = "flow_tap_written_to_the_default_profile_forces_a_tap"
 steps = [
@@ -112,8 +113,13 @@ steps = [
   { tap = { pos = [0, 0], duration = 30 } },
   { delay = 50 },
   { tap = { pos = [0, 2], duration = 400 } },
+  { rynk = { cmd = "SetBehaviorConfig", payload = { combo_timeout_ms = 50, oneshot_timeout_ms = 1000, tap_interval_ms = 200, tap_capslock_interval_ms = 250, morse_default_profile = {}, morse_prior_idle_time_ms = 120 } } },
+  { delay = 200 },
+  { tap = { pos = [0, 0], duration = 30 } },
+  { delay = 50 },
+  { tap = { pos = [0, 2], duration = 400 } },
 ]
-expect = [["A"], [], ["X"], []]
+expect = [["A"], [], ["X"], [], ["A"], [], ["Y"], []]
 
 # `actions` is a pattern-to-action map: 2 = tap, 3 = hold, 4 = double tap,
 # 5 = hold after tap.

--- a/rmk/tests/scenarios/rynk_behavior.toml
+++ b/rmk/tests/scenarios/rynk_behavior.toml
@@ -91,12 +91,29 @@ steps = [
 ]
 expect = [["C"], [], ["A"], ["A", "B"], ["B"], []]
 
+# The written profile leaves flow-tap unset; the read returns it folded to the
+# config-level switch (false here) — the default profile never reads back with
+# a hole at the top of the fallback chain.
 [[test]]
 name = "behavior_config_read_returns_what_was_written"
 steps = [
   { rynk = { cmd = "SetBehaviorConfig", payload = { combo_timeout_ms = 42, oneshot_timeout_ms = 900, tap_interval_ms = 180, tap_capslock_interval_ms = 240, morse_default_profile = { unilateral_tap = true, mode = "PermissiveHold", hold_timeout_ms = 210, gap_timeout_ms = 160, quick_tap_timeout_ms = 110 }, morse_prior_idle_time_ms = 95 } } },
-  { rynk = { cmd = "GetBehaviorConfig", reply = { combo_timeout_ms = 42, oneshot_timeout_ms = 900, tap_interval_ms = 180, tap_capslock_interval_ms = 240, morse_default_profile = { unilateral_tap = true, mode = "PermissiveHold", hold_timeout_ms = 210, gap_timeout_ms = 160, quick_tap_timeout_ms = 110 }, morse_prior_idle_time_ms = 95 } } },
+  { rynk = { cmd = "GetBehaviorConfig", reply = { combo_timeout_ms = 42, oneshot_timeout_ms = 900, tap_interval_ms = 180, tap_capslock_interval_ms = 240, morse_default_profile = { unilateral_tap = true, enable_flow_tap = false, mode = "PermissiveHold", hold_timeout_ms = 210, gap_timeout_ms = 160, quick_tap_timeout_ms = 110 }, morse_prior_idle_time_ms = 95 } } },
 ]
+
+# Flow tap resolves through the default profile, so turning it on over the wire
+# reaches morse-table keys too: a long press right after another key is forced
+# to its tap action instead of resolving as a hold.
+[[test]]
+name = "flow_tap_written_to_the_default_profile_forces_a_tap"
+steps = [
+  { rynk = { cmd = "SetBehaviorConfig", payload = { combo_timeout_ms = 50, oneshot_timeout_ms = 1000, tap_interval_ms = 200, tap_capslock_interval_ms = 250, morse_default_profile = { enable_flow_tap = true }, morse_prior_idle_time_ms = 120 } } },
+  { delay = 200 },
+  { tap = { pos = [0, 0], duration = 30 } },
+  { delay = 50 },
+  { tap = { pos = [0, 2], duration = 400 } },
+]
+expect = [["A"], [], ["X"], []]
 
 # `actions` is a pattern-to-action map: 2 = tap, 3 = hold, 4 = double tap,
 # 5 = hold after tap.

--- a/rmk/tests/scenarios/rynk_behavior.toml
+++ b/rmk/tests/scenarios/rynk_behavior.toml
@@ -25,7 +25,7 @@ steps = [
     { Single = { Key = { Hid = "A" } } },
     { Single = { Key = { Hid = "B" } } },
   ], output = { Single = { Key = { Hid = "C" } } } } } } },
-  { rynk = { cmd = "SetBehaviorConfig", payload = { combo_timeout_ms = 80, oneshot_timeout_ms = 1000, tap_interval_ms = 200, tap_capslock_interval_ms = 250 } } },
+  { rynk = { cmd = "SetBehaviorConfig", payload = { combo_timeout_ms = 80, oneshot_timeout_ms = 1000, tap_interval_ms = 200, tap_capslock_interval_ms = 250, morse_default_profile = {}, morse_prior_idle_time_ms = 120 } } },
   # One combo key alone stays silent until the written timeout expires, which is
   # what proves the timeout came from the wire and not the compiled default.
   { press = [0, 0] },
@@ -94,8 +94,8 @@ expect = [["C"], [], ["A"], ["A", "B"], ["B"], []]
 [[test]]
 name = "behavior_config_read_returns_what_was_written"
 steps = [
-  { rynk = { cmd = "SetBehaviorConfig", payload = { combo_timeout_ms = 42, oneshot_timeout_ms = 900, tap_interval_ms = 180, tap_capslock_interval_ms = 240 } } },
-  { rynk = { cmd = "GetBehaviorConfig", reply = { combo_timeout_ms = 42, oneshot_timeout_ms = 900, tap_interval_ms = 180, tap_capslock_interval_ms = 240 } } },
+  { rynk = { cmd = "SetBehaviorConfig", payload = { combo_timeout_ms = 42, oneshot_timeout_ms = 900, tap_interval_ms = 180, tap_capslock_interval_ms = 240, morse_default_profile = { unilateral_tap = true, mode = "PermissiveHold", hold_timeout_ms = 210, gap_timeout_ms = 160, quick_tap_timeout_ms = 110 }, morse_prior_idle_time_ms = 95 } } },
+  { rynk = { cmd = "GetBehaviorConfig", reply = { combo_timeout_ms = 42, oneshot_timeout_ms = 900, tap_interval_ms = 180, tap_capslock_interval_ms = 240, morse_default_profile = { unilateral_tap = true, mode = "PermissiveHold", hold_timeout_ms = 210, gap_timeout_ms = 160, quick_tap_timeout_ms = 110 }, morse_prior_idle_time_ms = 95 } } },
 ]
 
 # `actions` is a pattern-to-action map: 2 = tap, 3 = hold, 4 = double tap,

--- a/rynk/tests/loopback.rs
+++ b/rynk/tests/loopback.rs
@@ -150,8 +150,11 @@ async fn client_against_run_session() {
         let mut beh = client.get_behavior().await.unwrap();
         beh.combo_timeout_ms = beh.combo_timeout_ms.wrapping_add(7);
         beh.tap_interval_ms = beh.tap_interval_ms.wrapping_add(3);
+        // Flow-tap set explicitly: an unset bit reads back folded to the
+        // config-level switch, which would break the exact-equality check.
         beh.morse_default_profile =
-            MorseProfile::new(Some(true), Some(MorseMode::PermissiveHold), Some(230), Some(140));
+            MorseProfile::new(Some(true), Some(MorseMode::PermissiveHold), Some(230), Some(140))
+                .with_enable_flow_tap(Some(true));
         beh.morse_prior_idle_time_ms = beh.morse_prior_idle_time_ms.wrapping_add(5);
         client.set_behavior(beh).await.unwrap();
         assert_eq!(client.get_behavior().await.unwrap(), beh);

--- a/rynk/tests/loopback.rs
+++ b/rynk/tests/loopback.rs
@@ -150,8 +150,6 @@ async fn client_against_run_session() {
         let mut beh = client.get_behavior().await.unwrap();
         beh.combo_timeout_ms = beh.combo_timeout_ms.wrapping_add(7);
         beh.tap_interval_ms = beh.tap_interval_ms.wrapping_add(3);
-        // Flow-tap set explicitly: an unset bit reads back folded to the
-        // config-level switch, which would break the exact-equality check.
         beh.morse_default_profile =
             MorseProfile::new(Some(true), Some(MorseMode::PermissiveHold), Some(230), Some(140))
                 .with_enable_flow_tap(Some(true));

--- a/rynk/tests/loopback.rs
+++ b/rynk/tests/loopback.rs
@@ -20,7 +20,6 @@ use rmk::keymap::{KeyMap, KeymapData};
 use rmk_types::action::KeyAction;
 use rmk_types::combo::Combo;
 use rmk_types::constants::{MACRO_DATA_SIZE, RYNK_BUFFER_SIZE};
-use rmk_types::morse::{MorseMode, MorseProfile};
 use rmk_types::protocol::rynk::{MacroData, ProtocolVersion, RYNK_MAX_PAYLOAD_SIZE, RynkError, StorageResetMode};
 use rynk::layout::{Key, Rect, Variant};
 use rynk::{Client, LayoutInfo, RynkDevice, RynkHostError, TopicEvent};
@@ -150,9 +149,7 @@ async fn client_against_run_session() {
         let mut beh = client.get_behavior().await.unwrap();
         beh.combo_timeout_ms = beh.combo_timeout_ms.wrapping_add(7);
         beh.tap_interval_ms = beh.tap_interval_ms.wrapping_add(3);
-        beh.morse_default_profile =
-            MorseProfile::new(Some(true), Some(MorseMode::PermissiveHold), Some(230), Some(140))
-                .with_enable_flow_tap(Some(true));
+        beh.morse_default_profile = beh.morse_default_profile.with_enable_flow_tap(Some(true));
         beh.morse_prior_idle_time_ms = beh.morse_prior_idle_time_ms.wrapping_add(5);
         client.set_behavior(beh).await.unwrap();
         assert_eq!(client.get_behavior().await.unwrap(), beh);

--- a/rynk/tests/loopback.rs
+++ b/rynk/tests/loopback.rs
@@ -20,6 +20,7 @@ use rmk::keymap::{KeyMap, KeymapData};
 use rmk_types::action::KeyAction;
 use rmk_types::combo::Combo;
 use rmk_types::constants::{MACRO_DATA_SIZE, RYNK_BUFFER_SIZE};
+use rmk_types::morse::{MorseMode, MorseProfile};
 use rmk_types::protocol::rynk::{MacroData, ProtocolVersion, RYNK_MAX_PAYLOAD_SIZE, RynkError, StorageResetMode};
 use rynk::layout::{Key, Rect, Variant};
 use rynk::{Client, LayoutInfo, RynkDevice, RynkHostError, TopicEvent};
@@ -149,6 +150,9 @@ async fn client_against_run_session() {
         let mut beh = client.get_behavior().await.unwrap();
         beh.combo_timeout_ms = beh.combo_timeout_ms.wrapping_add(7);
         beh.tap_interval_ms = beh.tap_interval_ms.wrapping_add(3);
+        beh.morse_default_profile =
+            MorseProfile::new(Some(true), Some(MorseMode::PermissiveHold), Some(230), Some(140));
+        beh.morse_prior_idle_time_ms = beh.morse_prior_idle_time_ms.wrapping_add(5);
         client.set_behavior(beh).await.unwrap();
         assert_eq!(client.get_behavior().await.unwrap(), beh);
 


### PR DESCRIPTION
## Summary

`Get/SetBehaviorConfig` now carry the default `MorseProfile` and the flow-tap prior-idle window, reaching parity with Vial's behavior settings (morse timeout, permissive hold / hold-on-other-press, quick tap, unilateral tap, prior idle time) — plus gap timeout and flow-tap enable, which the packed profile carries for free. The protocol version stays v0.1 while it is pre-release; the wire snapshots are regenerated.

The second commit makes the new surface fully effective: flow-tap was the one profile field whose runtime fallback skipped the default profile and read a separate config-level bool, so a host write couldn't reach morse-table keys and hosts couldn't see the real switch. The config-level `enable_flow_tap` is now folded into the default profile at keymap build and on host writes, and the runtime chain is per-key profile → default profile like every other field. The keyboard.toml surface is unchanged.

## Tests

- `rynk_behavior.toml`: full read-back round-trip for the new fields; a new scenario proves a wire-written default-profile flow-tap forces a tap on a morse-table key (verified to fail without the resolution fix)
- `rynk/tests/loopback.rs`: end-to-end client↔firmware round-trip extended to the new fields
- All five CI feature rows green; wire snapshots regenerated via `UPDATE_SNAPSHOTS=1`