### PR TITLE
fix(dongle): don't hijack the keyboard's host profiles

### DIFF
--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -301,6 +301,15 @@ where
                         disconnect(&conn).await;
                         continue;
                     }
+                    // The bonded dongle belongs to its own slot, whatever it connects on.
+                    #[cfg(feature = "dongle")]
+                    if crate::state::current_profile() != crate::ble::profile::DONGLE_PROFILE
+                        && profile_manager.is_bonded_dongle(&conn.raw().peer_identity())
+                    {
+                        warn!("[ble] the bonded dongle connected on a host profile, disconnecting");
+                        disconnect(&conn).await;
+                        continue;
+                    }
                     if let Either::Second(_) = select(
                         serve_keyboard_connection(
                             server,

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -301,12 +301,12 @@ where
                         disconnect(&conn).await;
                         continue;
                     }
-                    // The bonded dongle belongs to its own slot, whatever it connects on.
+                    // When connecting to BLE host, check the connected peer is not a dongle.
                     #[cfg(feature = "dongle")]
                     if crate::state::current_profile() != crate::ble::profile::DONGLE_PROFILE
                         && profile_manager.is_bonded_dongle(&conn.raw().peer_identity())
                     {
-                        warn!("[ble] the bonded dongle connected on a host profile, disconnecting");
+                        warn!("[ble] the bonded dongle connected on a host BLE profile, disconnecting");
                         disconnect(&conn).await;
                         continue;
                     }

--- a/rmk/src/ble/profile.rs
+++ b/rmk/src/ble/profile.rs
@@ -168,6 +168,17 @@ where
             .cloned()
     }
 
+    /// Is `identity` the dongle this keyboard is bonded to? Host profiles turn it
+    /// away: an empty slot would otherwise pair the dongle into a host's slot.
+    #[cfg(feature = "dongle")]
+    pub(crate) fn is_bonded_dongle(&self, identity: &Identity) -> bool {
+        self.bonded_devices.iter().any(|bond_info| {
+            !bond_info.removed
+                && bond_info.slot_num == DONGLE_PROFILE
+                && bond_info.info.identity.match_identity(identity)
+        })
+    }
+
     /// Update bonding information in the stack according to the current active profile
     pub(crate) fn update_stack_bonds(&self) {
         // Drain one at a time rather than collecting: the stack holds bonds this

--- a/rmk/src/ble/profile.rs
+++ b/rmk/src/ble/profile.rs
@@ -168,8 +168,10 @@ where
             .cloned()
     }
 
-    /// Is `identity` the dongle this keyboard is bonded to? Host profiles turn it
-    /// away: an empty slot would otherwise pair the dongle into a host's slot.
+    /// Check if the `identity` is the bonded dongle's identity.
+    ///
+    /// This function is used when searching for BLE host,
+    /// the connected dongle(in the DONGLE_PROFILE) should be excluded.
     #[cfg(feature = "dongle")]
     pub(crate) fn is_bonded_dongle(&self, identity: &Identity) -> bool {
         self.bonded_devices.iter().any(|bond_info| {

--- a/rmk/src/ble/scan.rs
+++ b/rmk/src/ble/scan.rs
@@ -27,9 +27,6 @@ pub(crate) fn scan_config(window: Duration) -> ScanConfig<'static> {
 /// Start a scan, retrying while the controller refuses one — it does until a
 /// previous connect's initiator has stopped.
 ///
-/// A non-empty `filter_accept_list` drops everyone else's reports at the
-/// controller; `&[]` scans unfiltered.
-///
 /// End the session with [`ScanSession::stop`], which waits for the controller to
 /// confirm. Dropping it only signals the cancel, and the controller refuses an
 /// initiator until the runner has issued the stop.

--- a/rmk/src/ble/scan.rs
+++ b/rmk/src/ble/scan.rs
@@ -27,16 +27,24 @@ pub(crate) fn scan_config(window: Duration) -> ScanConfig<'static> {
 /// Start a scan, retrying while the controller refuses one — it does until a
 /// previous connect's initiator has stopped.
 ///
+/// A non-empty `filter_accept_list` drops everyone else's reports at the
+/// controller; `&[]` scans unfiltered.
+///
 /// End the session with [`ScanSession::stop`], which waits for the controller to
 /// confirm. Dropping it only signals the cancel, and the controller refuses an
 /// initiator until the runner has issued the stop.
 pub(crate) async fn start_scan<'a, C: Controller + ControllerCmdSync<LeSetScanParams>>(
     stack: &'a Stack<'_, C, DefaultPacketPool>,
     window: Duration,
+    filter_accept_list: &[Address],
 ) -> ScanSession<'a, false> {
+    let config = ScanConfig {
+        filter_accept_list,
+        ..scan_config(window)
+    };
     loop {
         let mut central = stack.central();
-        match Scanner::new(&mut central).scan(&scan_config(window)).await {
+        match Scanner::new(&mut central).scan(&config).await {
             Ok(session) => return session,
             Err(_) => Timer::after_millis(500).await,
         }

--- a/rmk/src/dongle/mod.rs
+++ b/rmk/src/dongle/mod.rs
@@ -1,14 +1,14 @@
 //! Dongle firmware (`dongle` feature): a BLE central that relays one bonded
 //! RMK keyboard to a USB host.
 //!
-//! It is a HID-over-GATT client toward the keyboard and a relay for everything
-//! else — the keyboard's host protocol (Rynk frames, or Vial reports with the
+//! Toward the keyboard it is a HID-over-GATT client; for everything else it is
+//! a relay. The keyboard's host protocol (Rynk frames, or Vial reports with the
 //! `vial` feature) passes through unparsed in both directions, so the dongle
 //! answers no command of its own and never tracks the protocol. Keymaps and
-//! storage stay on the keyboard; the dongle persists one bond.
+//! storage stay on the keyboard; the dongle stores only one bond.
 //!
-//! Task layout (both joined by [`Dongle::run`]):
-//! - `ble_task`: trouble runner with the seeking-advertisement scan handler;
+//! Two tasks, joined by [`Dongle::run`]:
+//! - `ble_task`: the trouble runner, with the scan handler below;
 //! - [`DongleCentral::run`]: find a keyboard, connect, secure, relay, repeat.
 
 #[cfg(not(feature = "vial"))]
@@ -45,30 +45,26 @@ use crate::event::{EventSubscriber, LedIndicatorEvent, SubscribableEvent};
 use crate::hid::{KeyboardReport, Report};
 use crate::{DONGLE_PAIRING_WINDOW_SECS, RawMutex};
 
-/// One keyboard link, and no more: the dongle relays exactly one keyboard.
+/// The dongle relays exactly one keyboard.
 const DONGLE_CONNECTIONS_MAX: usize = 1;
 
-/// trouble's `CHANNELS` counts only dynamic L2CAP channels; the fixed ones
-/// (signalling, ATT, SMP) never take a slot. A dongle talks pure GATT over ATT
-/// and opens no CoC, so zero.
+/// trouble's `CHANNELS` counts only dynamic L2CAP channels (fixed
+/// signalling/ATT/SMP are free); the dongle only talks GATT, so zero.
 const DONGLE_L2CAP_CHANNELS_MAX: usize = 0;
 
-/// BLE resources sized for the dongle role; owned by [`Dongle::run`].
-///
-/// The trailing `1, 2` are `ADV_SETS` (its default) and `BONDS`. The dongle
-/// keeps one bond, but [`ProfileManager::update_stack_bonds`] prunes only after
-/// a new pairing lands, so adopting a replacement keyboard briefly holds two —
-/// with a single slot, `add_bond` fails and the new bond is lost on reboot.
+/// The trailing `1, 2` are `ADV_SETS` (its default) and `BONDS`: the old bond
+/// is pruned only after a new pairing succeeds, so replacing the keyboard
+/// briefly holds two — one slot would lose the new bond on reboot.
 type DongleBleResources = HostResources<DefaultPacketPool, DONGLE_CONNECTIONS_MAX, DONGLE_L2CAP_CHANNELS_MAX, 1, 2>;
 
-/// The services discovery keeps: 0x1812 matches both the report service and the
-/// host-protocol HID service (rynk or vial), plus rynk's custom service.
+/// What the 3 covers: the 0x1812 query matches both the report service and the
+/// host-protocol HID service (rynk's or vial's), plus rynk's custom service.
 type Client<'a, C> = GattClient<'a, C, DefaultPacketPool, 3>;
 
 const BOND_SLOT: u8 = 0;
 
-/// Which keyboard a connection is to, which decides whether it pairs or
-/// encrypts, and whether a refused key means the stored bond is dead.
+/// Which keyboard a connection is to. Decides whether the link pairs or
+/// encrypts, and whether a rejected key means the stored bond is dead.
 #[derive(Clone, Copy, PartialEq)]
 enum Peer {
     /// The keyboard this dongle already holds a bond for.
@@ -77,21 +73,20 @@ enum Peer {
     New,
 }
 
-/// What the scan handler tells [`DongleCentral`]. It runs inside the BLE runner,
-/// where it can reach neither the profile manager nor the stack's bond list, so
-/// it only reports what it sees; the dongle task acts on it.
+/// What the scan handler tells [`DongleCentral`]. Inside the BLE runner it has
+/// no access to bonds or profiles, so it only reports; the dongle task decides.
 struct ScanHandler {
-    /// Whose return to report, mirrored by [`DongleCentral::run`] every time it
-    /// re-reads the bond — the one thing the task tells the handler.
+    /// The bonded keyboard's address to watch; [`DongleCentral::run`] updates it
+    /// whenever it re-reads the bond.
     bonded_addr: BlockingMutex<RawMutex, Cell<Option<BdAddr>>>,
-    /// The latest keyboard sighted seeking a dongle, and how strong its signal was.
+    /// The most recent keyboard seen seeking a dongle, and its RSSI.
     seeking_keyboard: Signal<RawMutex, ((AddrKind, BdAddr), i8)>,
-    /// The bonded keyboard was sighted at all — alive, on any profile. This
-    /// vetoes adopting a replacement; it never licenses a connect.
+    /// The bonded keyboard was seen advertising (anything but seeking). This
+    /// blocks adopting a replacement; it never triggers a connect.
     bonded_seen: Signal<RawMutex, ()>,
-    /// The bonded keyboard asked for a dongle: a directed advertisement, or
-    /// seeking anew after dropping its bond. The only license to connect.
-    bonded_sought: Signal<RawMutex, ()>,
+    /// The bonded keyboard asked for the dongle: a directed advertisement, or
+    /// seeking again after clearing its bond. Only this triggers a connect.
+    bonded_asked: Signal<RawMutex, ()>,
 }
 
 impl ScanHandler {
@@ -100,12 +95,11 @@ impl ScanHandler {
             bonded_addr: BlockingMutex::new(Cell::new(None)),
             seeking_keyboard: Signal::new(),
             bonded_seen: Signal::new(),
-            bonded_sought: Signal::new(),
+            bonded_asked: Signal::new(),
         }
     }
 }
 
-/// Runner event handler: surface seeking keyboards, and the bonded one's sightings and calls.
 impl EventHandler for ScanHandler {
     fn on_adv_reports(&self, mut it: LeAdvReportsIter<'_>) {
         while let Some(Ok(report)) = it.next() {
@@ -114,24 +108,24 @@ impl EventHandler for ScanHandler {
                 debug!("[dongle] seeking keyboard {:?} rssi {}", report.addr, report.rssi);
                 self.seeking_keyboard
                     .signal(((report.addr_kind, report.addr), report.rssi));
-                // Seeking anew means it cleared its bond; reconnecting re-pairs it.
+                // Seeking again means it cleared its bond; the reconnect will re-pair.
                 if bonded {
-                    self.bonded_sought.signal(());
+                    self.bonded_asked.signal(());
                 }
             } else if bonded {
                 self.bonded_seen.signal(());
                 // Directed advertisements are only reported to their target: us.
                 if report.event_kind == LeAdvEventKind::AdvDirectInd {
-                    self.bonded_sought.signal(());
+                    self.bonded_asked.signal(());
                 }
             }
         }
     }
 }
 
-/// The dongle runnable. Owns and sizes its own BLE stack — the keyboard role's
-/// [`crate::ble::BleTransport`] is not involved, so one build can carry both
-/// kinds of binaries. The USB side is a stock [`crate::usb::UsbTransport`]
+/// The dongle runnable. It owns and sizes its own BLE stack — the keyboard
+/// side's [`crate::ble::BleTransport`] is not involved, so one build can carry
+/// both kinds of binaries. The USB side is a normal [`crate::usb::UsbTransport`]
 /// serving the same [`DongleRouter`].
 pub struct Dongle<'a, C> {
     /// Taken by `run`, which owns the stack and its resources.
@@ -141,8 +135,7 @@ pub struct Dongle<'a, C> {
 }
 
 impl<'a, C> Dongle<'a, C> {
-    /// `router` is the one this binary's [`crate::usb::UsbTransport`] serves:
-    /// the dongle task relays through it, the USB sessions fill it.
+    /// `router` must be the one this binary's [`crate::usb::UsbTransport`] serves.
     pub fn new(controller: C, address: [u8; 6], router: &'a DongleRouter) -> Self {
         Self {
             controller: Some(controller),
@@ -179,8 +172,8 @@ where
     }
 }
 
-/// The dongle's BLE central: what it holds for longer than one connection. Per-connection
-/// state — the link, its GATT client — stays in the signatures.
+/// The dongle's BLE central: the state that outlives one connection.
+/// Per-connection state — the link, its GATT client — is passed as arguments.
 struct DongleCentral<'b, 's: 'b, C: Controller + ControllerCmdAsync<LeSetPhy>> {
     stack: &'b Stack<'s, C, DefaultPacketPool>,
     scan: &'b ScanHandler,
@@ -202,6 +195,8 @@ where
 
         let bonded = self.profiles.active_bond_info().map(|b| b.info.identity.addr);
         self.scan.bonded_addr.lock(|a| a.set(bonded.map(|addr| addr.addr)));
+        // The only chance to pair while a bond exists: one window at boot, so a
+        // keyboard the user already set seeking can replace the bonded one.
         if bonded.is_some()
             && let Some((kind, addr)) = self.run_pairing_window().await
             && let Some(conn) = self.connect(Address { kind, addr }).await
@@ -214,11 +209,11 @@ where
             self.scan.bonded_addr.lock(|a| a.set(bonded.map(|addr| addr.addr)));
 
             if let Some(addr) = bonded {
-                // Initiate only once the keyboard asks for a dongle; its bare address
-                // would answer its host advertising too. Accept list drops ambient traffic.
-                self.scan.bonded_sought.reset();
+                // Connect only once the keyboard asks for the dongle; its bare address
+                // would match its host advertising too. The accept list drops other traffic.
+                self.scan.bonded_asked.reset();
                 let session = start_scan(self.stack, DONGLE_SCAN_WINDOW, &[addr]).await;
-                self.scan.bonded_sought.wait().await;
+                self.scan.bonded_asked.wait().await;
                 session.stop().await;
                 if let Some(conn) = self.connect(addr).await {
                     self.run_connection(conn, Peer::Bonded).await;
@@ -236,9 +231,8 @@ where
         let mut central = self.stack.central();
 
         let config = ConnectConfig {
-            // The relaying interval from the start, but no latency and a longer
-            // supervision timeout: pairing and discovery run on this link before
-            // it is tuned down.
+            // Relay interval, but zero latency and a longer supervision timeout
+            // while pairing and discovery run; the relay settings come after.
             connect_params: RequestedConnParams {
                 max_latency: 0,
                 supervision_timeout: Duration::from_secs(30),
@@ -249,7 +243,7 @@ where
                 ..scan_config(DONGLE_SCAN_WINDOW)
             },
         };
-        // An absent keyboard times out the attempt; the caller's loop retries.
+        // If the keyboard is absent the attempt times out; the caller's loop retries.
         match with_timeout(Duration::from_secs(15), central.connect(&config)).await {
             Ok(Ok(conn)) => Some(conn),
             Ok(Err(e)) => {
@@ -262,10 +256,10 @@ where
         }
     }
 
-    /// Scan for keyboards seeking a dongle, returning the strongest sighted within
-    /// 2s of the first. First evidence wins: sighting the bonded keyboard ends the
-    /// window with `None`; a seeker sighted while it is silent was staged by hand
-    /// before the (re)plug, which outranks an automatic reconnect.
+    /// Scan for keyboards seeking a dongle; return the strongest seen within 2s
+    /// of the first. Whichever shows up first wins: the bonded keyboard ends the
+    /// window with `None`, while a seeker seen before it was set seeking by the
+    /// user before the (re)plug — that beats the automatic reconnect.
     async fn run_pairing_window(&self) -> Option<(AddrKind, BdAddr)> {
         info!("[dongle] pairing window open for {}s", DONGLE_PAIRING_WINDOW_SECS);
         self.scan.seeking_keyboard.reset();
@@ -274,7 +268,7 @@ where
 
         let pick = async {
             let (mut best_addr, mut best_rssi) = self.scan.seeking_keyboard.wait().await;
-            // Don't sit out the whole window: gather 2s past the first sighting.
+            // Don't wait out the whole window: collect for 2s after the first one.
             let gather = Instant::now() + Duration::from_secs(2);
             while let Ok((addr, rssi)) = with_deadline(gather, self.scan.seeking_keyboard.wait()).await {
                 if rssi > best_rssi {
@@ -302,20 +296,19 @@ where
                 None
             }
         };
-        // The connect that follows is refused an initiator until the controller has
-        // actually stopped scanning.
+        // The connect that follows fails unless the controller has fully stopped scanning.
         session.stop().await;
         found
     }
 
-    /// One connection's whole life: secure it, relay over it, and leave the host
-    /// holding nothing once it drops.
+    /// One connection from start to end: secure it, relay over it, and release
+    /// everything still held on the host when it drops.
     async fn run_connection(&mut self, conn: Connection<'b, DefaultPacketPool>, peer: Peer) {
         if !self.secure_connection(&conn, peer).await {
             info!("[dongle] securing failed");
         } else if let Ok(client) = Client::new(self.stack, &conn).await {
-            // The client task pumps notifications and the watcher pumps connection
-            // events; the relay runs beside them and ends when either one does.
+            // The client task receives notifications and the watcher drains connection
+            // events; the relay runs beside them and ends when either one ends.
             select3(
                 client.task(),
                 self.watch_connection(&conn),
@@ -330,8 +323,8 @@ where
         conn.disconnect();
     }
 
-    /// Consume connection events for the connection's whole life: a full queue
-    /// drops what is posted next, including the disconnect this returns on.
+    /// Keep draining connection events for the connection's whole life: a full
+    /// queue drops new events, including the disconnect this returns on.
     async fn watch_connection(&self, conn: &Connection<'_, DefaultPacketPool>) {
         loop {
             match conn.next().await {
@@ -351,8 +344,8 @@ where
     /// Pair (a new keyboard) or encrypt (the bonded one), then wait for the link
     /// to report it is secure.
     async fn secure_connection(&mut self, conn: &Connection<'_, DefaultPacketPool>, peer: Peer) -> bool {
-        // Both sides must be bondable or neither is handed bond information, and the
-        // keyboard would re-pair on every reconnect. Must precede `request_security`.
+        // Both sides must be bondable, or neither side gets the bond data and the
+        // keyboard would re-pair on every reconnect. Must come before `request_security`.
         if let Err(e) = conn.set_bondable(true) {
             warn!("[dongle] set_bondable error: {:?}", e);
             return false;
@@ -363,10 +356,8 @@ where
         }
         loop {
             match with_timeout(Duration::from_secs(30), conn.next()).await {
-                // Persist what the pairing produced. This covers the fresh pairing,
-                // and equally a keyboard that dropped its side and re-paired over a
-                // reconnect, which would otherwise leave the stored key one that no
-                // keyboard will ever accept again.
+                // Save the new bond — also when the bonded keyboard cleared its side
+                // and re-paired, otherwise we keep an old key nothing accepts anymore.
                 Ok(ConnectionEvent::PairingComplete { bond: Some(bond), .. }) => {
                     self.profiles
                         .add_profile_info(ProfileInfo {
@@ -386,10 +377,9 @@ where
                     }
                     return false;
                 }
-                // A keyboard that has cleared its side refuses our key at the link
-                // layer, so the refusal arrives here and not as `PairingFailed`.
-                // Both mean the stored key can never work again (design §2.5): drop
-                // it, and the next loop reopens for a fresh pairing.
+                // A keyboard that cleared its side rejects our key at the link layer,
+                // so the rejection arrives here, not as `PairingFailed`. The stored
+                // key is dead either way: drop it, and the next loop opens a pairing window.
                 Ok(ConnectionEvent::Disconnected { reason }) => {
                     if peer == Peer::Bonded && reason == Status::AUTHENTICATION_FAILURE {
                         warn!("[dongle] bonded keyboard refused our key, dropping the bond");
@@ -398,16 +388,15 @@ where
                     return false;
                 }
                 Err(_) => return false,
-                // Securing owns the event queue until it returns, so it answers these itself.
+                // Securing is the only event reader until it returns, so answer these here.
                 Ok(ConnectionEvent::RequestConnectionParams(req)) => self.accept_conn_params(req).await,
                 Ok(_) => {}
             }
         }
     }
 
-    /// Everything that runs beside the GATT client task: tune the link, discover
-    /// and subscribe, then relay. `None` if the setup failed, which ends the
-    /// connection.
+    /// Tune the link, discover and subscribe, then relay. `None` means setup
+    /// failed, which ends the connection.
     async fn discover_and_relay(&self, conn: &Connection<'_, DefaultPacketPool>, client: &Client<'_, C>) -> Option<()> {
         // Same latency setup as a split link: 2M PHY + 7.5 ms interval.
         update_ble_phy(self.stack, conn, PhyKind::Le2M).await;
@@ -431,11 +420,9 @@ where
         Some(())
     }
 
-    /// Relay both directions for as long as this future is polled: notifications
-    /// out to USB/router, LED state and router frames back to the keyboard.
-    ///
-    /// `NOTIF_MTU` is trouble's notification buffer size, inferred from the
-    /// listener; restating the constant would pin RMK to one trouble build.
+    /// Relay both directions until this future is dropped. `NOTIF_MTU` is
+    /// trouble's notification buffer size, taken from the listener type;
+    /// writing the number out here would tie RMK to one trouble build.
     async fn relay<const NOTIF_MTU: usize>(
         &self,
         #[cfg(not(feature = "vial"))] conn: &Connection<'_, DefaultPacketPool>,
@@ -443,8 +430,8 @@ where
         listener: &mut NotificationListener<'_, NOTIF_MTU>,
         chars: &KeyboardCharacteristics,
     ) {
-        // Largest single write chunk on the Rynk characteristic: ATT MTU minus the
-        // 3-byte write header. Vial reports are 32 bytes and cross whole.
+        // Largest single write to the Rynk characteristic: ATT MTU minus the
+        // 3-byte write header. Vial reports are 32 bytes and are sent whole.
         #[cfg(not(feature = "vial"))]
         let chunk_size = RYNK_BLE_CHUNK_SIZE
             .min((conn.att_mtu() as usize).saturating_sub(3))
@@ -454,19 +441,19 @@ where
             loop {
                 let notification = listener.next().await;
                 let (handle, data) = (notification.handle(), notification.as_ref());
-                // Only the config stream is opaque, and it goes straight to the host.
+                // The config stream is the only one not parsed; it goes straight to the host.
                 if handle == chars.config_input.handle {
-                    // A full pipe is usually a host a moment behind, so wait for 20ms at most.
+                    // A full pipe usually means the host is a moment behind, so wait 20ms at most.
                     #[cfg(not(feature = "vial"))]
                     if with_timeout(Duration::from_millis(20), self.router.to_host.write_all(data))
                         .await
                         .is_err()
                     {
-                        // Try to send a delimeter and drop the bytes which cannot be written in 20ms.
+                        // Send a frame delimiter so the host drops the cut-off frame and resyncs.
                         let _ = self.router.to_host.try_write(&[0]);
                         warn!("[dongle] host config stream overflow, dropping bytes");
                     }
-                    // Reports are atomic: a dropped one costs its reply, nothing else.
+                    // Each report stands alone: dropping one loses that reply, nothing else.
                     #[cfg(feature = "vial")]
                     match VialReport::try_from(data) {
                         Ok(report) => {
@@ -492,9 +479,8 @@ where
             }
         };
 
-        // One characteristic write per pass. Rynk takes a write's worth out of the
-        // byte stream — the read itself is the chunker — while Vial takes one whole
-        // report, because a report can't be split.
+        // One characteristic write per loop turn: Rynk reads one write's worth of
+        // bytes (the read does the chunking); Vial takes one unsplittable report.
         #[cfg(not(feature = "vial"))]
         let mut request = [0u8; RYNK_BLE_CHUNK_SIZE];
         let request_to_keyboard = async {
@@ -516,17 +502,16 @@ where
             }
         };
 
-        // Three independent errands, not one interleaved loop: an LED update must
-        // not wait behind a config write, nor the other way round.
+        // Three independent loops, not one combined one: an LED update must not
+        // wait behind a config write, or the other way around.
         select3(keyboard_to_host, led_to_keyboard, request_to_keyboard).await;
     }
 }
 
-/// Parameters for the link once it relays: 7.5 ms interval — the same latency
-/// budget as a split link. The generous supervision timeout trades reconnect
-/// latency after a dongle power-cycle (rare) for radio-interference tolerance
-/// during normal use: the keyboard only starts its directed reconnect
-/// advertising once this timer expires.
+/// Link parameters while relaying: 7.5 ms interval, the same latency budget as
+/// a split link. The long supervision timeout favors surviving radio noise over
+/// a fast reconnect after a dongle power-cycle (rare): the keyboard starts its
+/// directed reconnect advertising only after this timeout runs out.
 fn relay_conn_params() -> RequestedConnParams {
     RequestedConnParams {
         min_connection_interval: Duration::from_micros(7500),
@@ -544,17 +529,16 @@ struct KeyboardCharacteristics {
     mouse: Characteristic<[u8]>,
     media: Characteristic<[u8]>,
     system: Characteristic<[u8]>,
-    /// The host-protocol pair: rynk's custom service, or the 32-byte report
-    /// pair of vial's own HID service.
+    /// The host-protocol pair: from rynk's custom service, or the two 32-byte
+    /// report characteristics of vial's own HID service.
     config_input: Characteristic<[u8]>,
     config_output: Characteristic<[u8]>,
 }
 
 impl KeyboardCharacteristics {
-    /// Discover the HID and host-protocol services. The report characteristics
-    /// share UUID 0x2A4D; both ends are RMK, so service and declaration order
-    /// are fixed: the report service comes first with keyboard input, keyboard
-    /// output, mouse, media, system.
+    /// Discover the HID and host-protocol services. Report characteristics all
+    /// share UUID 0x2A4D, but both ends are RMK, so the declaration order below
+    /// is fixed and identifies them.
     async fn discover<C: Controller>(client: &Client<'_, C>) -> Option<Self> {
         let mut hid_services = client
             .services_by_uuid(&Uuid::new_short(0x1812))
@@ -563,7 +547,7 @@ impl KeyboardCharacteristics {
             .into_iter();
         let hid = hid_services.next()?;
         let report_uuid = Uuid::new_short(0x2A4D);
-        // Discovery fails unless every characteristic `HidService` declares fits.
+        // The 9 must fit every characteristic `HidService` declares, or discovery fails.
         let mut reports = client
             .characteristics::<9>(&hid)
             .await
@@ -595,7 +579,7 @@ impl KeyboardCharacteristics {
                     .ok()?,
             )
         };
-        // Vial rides the second HID service instance: input notify, then output write.
+        // Vial uses the second HID service: input (notify) first, then output (write).
         #[cfg(feature = "vial")]
         let (config_input, config_output) = {
             let vial = hid_services.next()?;
@@ -619,8 +603,7 @@ impl KeyboardCharacteristics {
         })
     }
 
-    /// Subscribe to everything the keyboard notifies on, by writing each CCCD
-    /// once. The notifications themselves arrive on one catch-all listener.
+    /// Subscribe to everything the keyboard notifies on by writing each CCCD once.
     async fn subscribe<C: Controller>(&self, client: &Client<'_, C>) -> Option<()> {
         for ch in [
             &self.keyboard_input,
@@ -636,9 +619,8 @@ impl KeyboardCharacteristics {
         Some(())
     }
 
-    /// The HID report a notification carries, or `None` when the handle is not
-    /// a report characteristic or the payload is short. The BLE boot report and
-    /// the USB one carry the same bytes, so the handle alone identifies it.
+    /// The HID report a notification carries, or `None`. BLE report bytes match
+    /// the USB layout, so the handle alone tells the report type.
     fn report(&self, handle: u16, data: &[u8]) -> Option<Report> {
         if handle == self.keyboard_input.handle && data.len() >= 8 {
             Some(Report::KeyboardReport(KeyboardReport {
@@ -724,28 +706,28 @@ mod tests {
     }
 
     #[test]
-    fn a_host_advertisement_vetoes_adoption_but_never_licenses_a_connect() {
+    fn a_host_advertisement_blocks_adoption_but_never_triggers_a_connect() {
         let handler = bonded_handler();
         report(&handler, ADV_IND, BONDED, HOST_DATA);
         assert!(handler.bonded_seen.signaled());
-        assert!(!handler.bonded_sought.signaled());
+        assert!(!handler.bonded_asked.signaled());
     }
 
     #[test]
-    fn a_directed_advertisement_licenses_the_connect() {
+    fn a_directed_advertisement_triggers_the_connect() {
         let handler = bonded_handler();
         report(&handler, ADV_DIRECT_IND, BONDED, &[]);
-        assert!(handler.bonded_sought.signaled());
+        assert!(handler.bonded_asked.signaled());
         assert!(handler.bonded_seen.signaled());
     }
 
     #[test]
-    fn the_bonded_keyboard_seeking_anew_licenses_the_connect() {
+    fn the_bonded_keyboard_seeking_again_triggers_the_connect() {
         let handler = bonded_handler();
         report(&handler, ADV_IND, BONDED, SEEKING_DATA);
         assert!(handler.seeking_keyboard.signaled());
-        assert!(handler.bonded_sought.signaled());
-        // Seeking stays out of the veto: it competes in the window's RSSI pick instead.
+        assert!(handler.bonded_asked.signaled());
+        // Seeking does not count as "seen": it competes in the window's RSSI pick instead.
         assert!(!handler.bonded_seen.signaled());
     }
 
@@ -756,6 +738,6 @@ mod tests {
         report(&handler, ADV_DIRECT_IND, OTHER, &[]);
         assert!(handler.seeking_keyboard.signaled());
         assert!(!handler.bonded_seen.signaled());
-        assert!(!handler.bonded_sought.signaled());
+        assert!(!handler.bonded_asked.signaled());
     }
 }

--- a/rmk/src/dongle/mod.rs
+++ b/rmk/src/dongle/mod.rs
@@ -19,7 +19,7 @@ use core::cell::Cell;
 
 use bt_hci::cmd::le::{LeReadLocalSupportedFeatures, LeSetPhy, LeSetScanParams};
 use bt_hci::controller::{ControllerCmdAsync, ControllerCmdSync};
-use bt_hci::param::{AddrKind, BdAddr, Status};
+use bt_hci::param::{AddrKind, BdAddr, LeAdvEventKind, Status};
 use embassy_futures::join::join;
 use embassy_futures::select::{Either, select, select3};
 use embassy_sync::blocking_mutex::Mutex as BlockingMutex;
@@ -86,8 +86,12 @@ struct ScanHandler {
     bonded_addr: BlockingMutex<RawMutex, Cell<Option<BdAddr>>>,
     /// The latest keyboard sighted seeking a dongle, and how strong its signal was.
     seeking_keyboard: Signal<RawMutex, ((AddrKind, BdAddr), i8)>,
-    /// The bonded keyboard turned up, so the pairing window can stand down.
+    /// The bonded keyboard was sighted at all — alive, on any profile. This
+    /// vetoes adopting a replacement; it never licenses a connect.
     bonded_seen: Signal<RawMutex, ()>,
+    /// The bonded keyboard asked for a dongle: a directed advertisement, or
+    /// seeking anew after dropping its bond. The only license to connect.
+    bonded_sought: Signal<RawMutex, ()>,
 }
 
 impl ScanHandler {
@@ -96,20 +100,30 @@ impl ScanHandler {
             bonded_addr: BlockingMutex::new(Cell::new(None)),
             seeking_keyboard: Signal::new(),
             bonded_seen: Signal::new(),
+            bonded_sought: Signal::new(),
         }
     }
 }
 
-/// Runner event handler: surface seeking keyboards, and the bonded one's return.
+/// Runner event handler: surface seeking keyboards, and the bonded one's sightings and calls.
 impl EventHandler for ScanHandler {
     fn on_adv_reports(&self, mut it: LeAdvReportsIter<'_>) {
         while let Some(Ok(report)) = it.next() {
+            let bonded = self.bonded_addr.lock(|addr| addr.get()) == Some(report.addr);
             if Adv::decode(report.data) == Some(Adv::DongleSeeking) {
                 debug!("[dongle] seeking keyboard {:?} rssi {}", report.addr, report.rssi);
                 self.seeking_keyboard
                     .signal(((report.addr_kind, report.addr), report.rssi));
-            } else if self.bonded_addr.lock(|addr| addr.get()) == Some(report.addr) {
+                // Seeking anew means it cleared its bond; reconnecting re-pairs it.
+                if bonded {
+                    self.bonded_sought.signal(());
+                }
+            } else if bonded {
                 self.bonded_seen.signal(());
+                // Directed advertisements are only reported to their target: us.
+                if report.event_kind == LeAdvEventKind::AdvDirectInd {
+                    self.bonded_sought.signal(());
+                }
             }
         }
     }
@@ -200,7 +214,12 @@ where
             self.scan.bonded_addr.lock(|a| a.set(bonded.map(|addr| addr.addr)));
 
             if let Some(addr) = bonded {
-                // If there is bonded keyboard, repeatly connect to that keyboard.
+                // Initiate only once the keyboard asks for a dongle; its bare address
+                // would answer its host advertising too. Accept list drops ambient traffic.
+                self.scan.bonded_sought.reset();
+                let session = start_scan(self.stack, DONGLE_SCAN_WINDOW, &[addr]).await;
+                self.scan.bonded_sought.wait().await;
+                session.stop().await;
                 if let Some(conn) = self.connect(addr).await {
                     self.run_connection(conn, Peer::Bonded).await;
                 }
@@ -243,10 +262,10 @@ where
         }
     }
 
-    /// Scan for keyboards seeking a dongle, returning the strongest sighted
-    /// within 2s of the first. Ends early with `None` when the bonded keyboard
-    /// turns up, so the power-on window with the keyboard present skips
-    /// straight to reconnecting.
+    /// Scan for keyboards seeking a dongle, returning the strongest sighted within
+    /// 2s of the first. First evidence wins: sighting the bonded keyboard ends the
+    /// window with `None`; a seeker sighted while it is silent was staged by hand
+    /// before the (re)plug, which outranks an automatic reconnect.
     async fn run_pairing_window(&self) -> Option<(AddrKind, BdAddr)> {
         info!("[dongle] pairing window open for {}s", DONGLE_PAIRING_WINDOW_SECS);
         self.scan.seeking_keyboard.reset();
@@ -265,7 +284,7 @@ where
             (best_addr, best_rssi)
         };
 
-        let Ok(session) = with_deadline(deadline, start_scan(self.stack, DONGLE_SCAN_WINDOW)).await else {
+        let Ok(session) = with_deadline(deadline, start_scan(self.stack, DONGLE_SCAN_WINDOW, &[])).await else {
             info!("[dongle] pairing window closed, the scanner never started");
             return None;
         };
@@ -275,7 +294,7 @@ where
                 Some(addr)
             }
             Ok(Either::Second(())) => {
-                debug!("[dongle] bonded keyboard is back, closing the pairing window");
+                debug!("[dongle] bonded keyboard is alive, closing the pairing window");
                 None
             }
             Err(_) => {
@@ -664,5 +683,79 @@ async fn release_held_keys() {
         Report::SystemControlReport(SystemControlReport { usage_id: 0 }),
     ] {
         send_hid_report(report).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bt_hci::FromHciBytes;
+    use bt_hci::param::LeAdvReports;
+
+    use super::*;
+
+    const BONDED: [u8; 6] = [1, 2, 3, 4, 5, 6];
+    const OTHER: [u8; 6] = [7, 8, 9, 10, 11, 12];
+
+    const ADV_IND: u8 = 0;
+    const ADV_DIRECT_IND: u8 = 1;
+
+    /// Flags + manufacturer-specific data naming a dongle-seeking advertisement (see `Adv::build`).
+    const SEEKING_DATA: &[u8] = &[0x02, 0x01, 0x04, 0x04, 0xFF, 0x53, 0x52, 0x01];
+    /// A host advertisement carries no RMK payload; flags alone stand in for it.
+    const HOST_DATA: &[u8] = &[0x02, 0x01, 0x06];
+
+    /// One legacy advertising report as the controller lays it out:
+    /// count, kind, address kind, address, data length, data, rssi.
+    fn report(handler: &ScanHandler, event_kind: u8, addr: [u8; 6], data: &[u8]) {
+        let mut bytes: heapless::Vec<u8, 64> = heapless::Vec::new();
+        bytes.extend_from_slice(&[1, event_kind, 1]).unwrap();
+        bytes.extend_from_slice(&addr).unwrap();
+        bytes.push(data.len() as u8).unwrap();
+        bytes.extend_from_slice(data).unwrap();
+        bytes.push(0xC0).unwrap(); // rssi
+        let (reports, _) = LeAdvReports::from_hci_bytes(&bytes).unwrap();
+        handler.on_adv_reports(reports.iter());
+    }
+
+    fn bonded_handler() -> ScanHandler {
+        let handler = ScanHandler::new();
+        handler.bonded_addr.lock(|a| a.set(Some(BdAddr::new(BONDED))));
+        handler
+    }
+
+    #[test]
+    fn a_host_advertisement_vetoes_adoption_but_never_licenses_a_connect() {
+        let handler = bonded_handler();
+        report(&handler, ADV_IND, BONDED, HOST_DATA);
+        assert!(handler.bonded_seen.signaled());
+        assert!(!handler.bonded_sought.signaled());
+    }
+
+    #[test]
+    fn a_directed_advertisement_licenses_the_connect() {
+        let handler = bonded_handler();
+        report(&handler, ADV_DIRECT_IND, BONDED, &[]);
+        assert!(handler.bonded_sought.signaled());
+        assert!(handler.bonded_seen.signaled());
+    }
+
+    #[test]
+    fn the_bonded_keyboard_seeking_anew_licenses_the_connect() {
+        let handler = bonded_handler();
+        report(&handler, ADV_IND, BONDED, SEEKING_DATA);
+        assert!(handler.seeking_keyboard.signaled());
+        assert!(handler.bonded_sought.signaled());
+        // Seeking stays out of the veto: it competes in the window's RSSI pick instead.
+        assert!(!handler.bonded_seen.signaled());
+    }
+
+    #[test]
+    fn another_keyboard_is_a_pairing_candidate_and_nothing_more() {
+        let handler = bonded_handler();
+        report(&handler, ADV_IND, OTHER, SEEKING_DATA);
+        report(&handler, ADV_DIRECT_IND, OTHER, &[]);
+        assert!(handler.seeking_keyboard.signaled());
+        assert!(!handler.bonded_seen.signaled());
+        assert!(!handler.bonded_sought.signaled());
     }
 }

--- a/rmk/src/split/ble/central.rs
+++ b/rmk/src/split/ble/central.rs
@@ -121,7 +121,7 @@ pub(crate) async fn scan_and_connect_peripherals<'a, C: Controller + ControllerC
         } else if peripheral_slots.iter().any(|s| matches!(s, SlotState::NoAddr)) {
             // No `Disconnected` peripherals, check `NoAddr` peripheral slot and scan new peripherals
             info!("Start scanning peripherals");
-            let session = start_scan(stack, SPLIT_CENTRAL_SCAN_WINDOW).await;
+            let session = start_scan(stack, SPLIT_CENTRAL_SCAN_WINDOW, &[]).await;
             let event = select(PERIPHERAL_FOUND.wait(), ended.ready_to_receive()).await;
             // Wait until the controller has confirmed the stop: it refuses an
             // initiator until then.


### PR DESCRIPTION
## Problem

A bonded dongle reconnects by initiating on the keyboard's address alone (`filter_accept_list`), without looking at what the keyboard is advertising. The keyboard uses one static address for every profile, so when the user switches it to a BLE host profile, the dongle answers its plain HID advertising:

- **Target profile empty** (user wants to pair a phone): the dongle wins the connect race, trouble falls back to fresh pairing after its stale-key encryption is refused, the keyboard stores the dongle's bond **into that host profile's slot**, and keys keep flowing out of the dongle's USB host. The phone never gets a chance.
- **Target profile bonded** (e.g. a laptop): the keyboard's identity check disconnects the dongle, but it retries every 500 ms — a connect storm the real host can rarely beat.

## Fix

**Dongle side** — the scan handler distinguishes two signals:

- `bonded_seen`: the bonded keyboard was sighted at all, on any profile. Stands the pairing window down to protect the bond; never licenses a connect.
- `bonded_sought`: the keyboard asked for a dongle — a directed advertisement, or seeking anew after clearing its bond (reconnecting re-pairs it, so the hold-to-forget flow keeps working). This is the only license to initiate.

While standing by, the scan puts the bonded address on the controller's filter accept list, so ambient traffic is dropped at the link layer instead of being sifted per report on the host.

**Keyboard side** — every host profile turns the bonded dongle away by identity (`is_bonded_dongle`). An empty slot previously had no bond to mismatch against, and serving the dongle paired it into the slot the user keeps for a host. This also closes the race where the user switches profiles between the dongle's sighting and its connect, and defends against dongles running older firmware.

The pairing window keeps its first-evidence-wins semantics: a sighting of the bonded keyboard closes it, while a seeker sighted while the keyboard is silent is adopted — the seeker was staged by hand before the dongle was plugged in, and that pair of gestures outranks an automatic reconnect. Replacing a keyboard while the old one is mid-relay keeps working through exactly this path.

## Testing

- 4 new unit tests pin the scan-handler semantics (`cargo nextest run --lib --no-default-features --features=dongle,_ble`, 250 passed)
- `cargo check` on `dongle,_ble` / `dongle,vial,_ble` / `split,vial,storage,async_matrix,_ble`
- Behavioral suite row: 494/494
- Firmware examples build: `nrf_dongle/dongle` (nRF54LM20) and `nrf_dongle/central` (nRF52833, split + dongle)

Hardware checks still pending: dongle stays quiet while the keyboard is on a host profile, reconnect latency on switching back, hold-to-forget re-pairing, and keyboard replacement during the supervision-timeout window.