### PR TITLE
 chore: ignore direnv state and add Nix build dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ pkg
 *.uf2
 
 .idea
+.direnv/
 
 # ignore Cargo.lock of library, but keep it for binaries
 rmk/Cargo.lock

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
           "thumbv8m.main-none-eabihf"
           "riscv32imc-unknown-none-elf"
           "riscv32imac-unknown-none-elf"
+          "wasm32-unknown-unknown"
         ];
 
         stableToolchain = fenixPkgs.combine (
@@ -144,11 +145,16 @@
           pkgs.cargo-expand
           pkgs.cargo-make
           pkgs.cargo-nextest
+          pkgs.dbus
           pkgs.espflash
           pkgs.espup
           pkgs.flip-link
           pkgs.just
+          pkgs.llvmPackages.libclang
+          pkgs.nodejs
+          pkgs.pkg-config
           pkgs.probe-rs-tools
+          pkgs.wasm-pack
         ];
       in {
         formatter = pkgs.alejandra;
@@ -170,6 +176,7 @@
 
           env = {
             CARGO_NET_GIT_FETCH_WITH_CLI = "true";
+            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
             RUST_MIN_STACK = "67108864";
             RUST_SRC_PATH = "${stableToolchain}/lib/rustlib/src/rust/library";
           };


### PR DESCRIPTION
## Summary

- Ignore generated `.direnv/` state in Git.
- Complete the Nix development shell dependencies for RMK and Rynk:
  - Add the `wasm32-unknown-unknown` Rust target.
  - Add `libclang` and configure `LIBCLANG_PATH` for nRF-SDC bindgen builds.
  - Add the dependencies required by Rynk host and WASM checks:
    `dbus`, `pkg-config`, `nodejs`, and `wasm-pack`.

## Validation

- `nix flake check --no-update-lock-file`
- `nix develop --ignore-environment --command bash -lc 'cd examples/use_rust/nrf52832_ble && cargo build --release'`
- `nix develop --ignore-environment --command bash -lc 'bash .github/ci/host.sh'`

The host checks now pass in a pure Nix development shell.