### PR TITLE
fix(via): return persisted layout options from GetKeyboardValue

### DIFF
--- a/rmk/src/host/context.rs
+++ b/rmk/src/host/context.rs
@@ -280,10 +280,13 @@ impl<'a> KeyboardContext<'a> {
     }
 
     pub async fn set_layout_options(&self, opts: u32) {
+        self.keymap.set_layout_option(opts);
         #[cfg(feature = "storage")]
         FLASH_CHANNEL.send(FlashOperationMessage::LayoutOptions(opts)).await;
-        #[cfg(not(feature = "storage"))]
-        let _ = opts;
+    }
+
+    pub fn layout_options(&self) -> u32 {
+        self.keymap.layout_option()
     }
 
     pub async fn reset_storage(&self) {

--- a/rmk/src/host/storage.rs
+++ b/rmk/src/host/storage.rs
@@ -107,6 +107,8 @@ impl<F: AsyncNorFlash, const ROW: usize, const COL: usize, const NUM_LAYER: usiz
                 (StorageKey::LayoutConfig, StorageData::LayoutConfig(config)) => {
                     // Restore the default (base) layer set via a `PDF` key
                     behavior.default_layer = config.default_layer;
+                    // Restore the VIA/Vial layout options selection
+                    data.layout_option = config.layout_option;
                 }
                 _ => continue,
             }

--- a/rmk/src/host/via/mod.rs
+++ b/rmk/src/host/via/mod.rs
@@ -55,8 +55,7 @@ impl<'a> VialService<'a> {
                             BigEndian::write_u32(&mut report.input_data[2..6], value);
                         }
                         ViaKeyboardInfo::LayoutOptions => {
-                            // TODO: retrieve layout option from storage
-                            let layout_option: u32 = 0;
+                            let layout_option = self.ctx.layout_options();
                             BigEndian::write_u32(&mut report.input_data[2..6], layout_option);
                         }
                         #[cfg(not(feature = "host_lock"))]
@@ -323,6 +322,35 @@ mod tests {
             let mut report = macro_set_buffer_report(29);
             block_on(service.process_via_packet(&mut report));
             assert_eq!(report.input_data[0], 0xFF);
+        });
+    }
+
+    /// A `GetKeyboardValue(LayoutOptions)` (0x02 0x02) or
+    /// `SetKeyboardValue(LayoutOptions)` (0x03 0x02) report carrying `value`
+    /// as the big-endian payload.
+    fn layout_options_report(command_id: u8, value: u32) -> ViaReport {
+        let mut output_data = [0u8; 32];
+        output_data[0] = command_id;
+        output_data[1] = 0x02; // ViaKeyboardInfo::LayoutOptions
+        BigEndian::write_u32(&mut output_data[2..6], value);
+        ViaReport {
+            input_data: output_data,
+            output_data,
+        }
+    }
+
+    // GetKeyboardValue(LayoutOptions) must return the value written by
+    // SetKeyboardValue(LayoutOptions) instead of a hardcoded 0, so the Vial
+    // GUI shows the user's selection again after a reconnect.
+    #[test]
+    fn layout_options_set_then_get_roundtrip() {
+        with_service(|service| {
+            let mut set = layout_options_report(0x03, 0x00C0_FFEE);
+            block_on(service.process_via_packet(&mut set));
+
+            let mut get = layout_options_report(0x02, 0);
+            block_on(service.process_via_packet(&mut get));
+            assert_eq!(BigEndian::read_u32(&get.input_data[2..6]), 0x00C0_FFEE);
         });
     }
 }

--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -33,6 +33,8 @@ pub struct KeymapData<const ROW: usize, const COL: usize, const NUM_LAYER: usize
     layer_cache: [[u8; COL]; ROW],
     /// Layer cache for encoder directions
     encoder_layer_cache: [[u8; 2]; NUM_ENCODER],
+    /// VIA/Vial layout options; persisted via `LayoutConfig`
+    pub(crate) layout_option: u32,
 }
 
 impl<const ROW: usize, const COL: usize, const NUM_LAYER: usize> KeymapData<ROW, COL, NUM_LAYER, 0> {
@@ -44,6 +46,7 @@ impl<const ROW: usize, const COL: usize, const NUM_LAYER: usize> KeymapData<ROW,
             layer_state: [false; NUM_LAYER],
             layer_cache: [[0; COL]; ROW],
             encoder_layer_cache: [],
+            layout_option: 0,
         }
     }
 }
@@ -62,6 +65,7 @@ impl<const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_ENCOD
             layer_state: [false; NUM_LAYER],
             layer_cache: [[0; COL]; ROW],
             encoder_layer_cache: [[0u8; 2]; NUM_ENCODER],
+            layout_option: 0,
         }
     }
 }
@@ -102,6 +106,8 @@ struct KeyMapInner<'a> {
     hand: &'a [Hand],
     /// Mouse button state
     mouse_buttons: u8,
+    /// VIA/Vial layout options; persisted via `LayoutConfig`
+    layout_option: u32,
     /// Matrix state for vial lock
     #[cfg(feature = "host_lock")]
     matrix_state: MatrixState,
@@ -370,6 +376,7 @@ impl<'a> KeyMap<'a> {
                 behavior,
                 hand,
                 mouse_buttons: 0,
+                layout_option: data.layout_option,
                 #[cfg(feature = "host_lock")]
                 matrix_state: MatrixState::new(ROW, COL),
             }),
@@ -530,6 +537,14 @@ impl<'a> KeyMap<'a> {
 
     pub(crate) fn set_default_layer(&self, layer_num: u8) {
         self.inner.borrow_mut().set_default_layer(layer_num);
+    }
+
+    pub(crate) fn layout_option(&self) -> u32 {
+        self.inner.borrow().layout_option
+    }
+
+    pub(crate) fn set_layout_option(&self, layout_option: u32) {
+        self.inner.borrow_mut().layout_option = layout_option;
     }
 
     pub(crate) fn update_fn_layer_state(&self) {

--- a/rmk/src/storage/mod.rs
+++ b/rmk/src/storage/mod.rs
@@ -294,7 +294,7 @@ pub(crate) struct LocalStorageConfig {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct LayoutConfig {
     pub(crate) default_layer: u8,
-    layout_option: u32,
+    pub(crate) layout_option: u32,
 }
 
 #[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize, MaxSize)]
@@ -1062,6 +1062,76 @@ mod tests {
                     build_hash: BUILD_HASH,
                 })
             ));
+        });
+    }
+
+    // A stored LayoutConfig must reach the Vial GUI again after a power
+    // cycle: read_keymap restores layout_option into KeymapData and
+    // KeyMap::build copies it into the runtime state that
+    // GetKeyboardValue(LayoutOptions) answers from (the GET wiring itself is
+    // covered by host::via::tests::layout_options_set_then_get_roundtrip).
+    // Deleting the restore in read_keymap (or the copy in KeyMap::build)
+    // leaves the runtime value at 0 and fails this test.
+    #[cfg(feature = "vial")]
+    #[test]
+    fn layout_option_restored_from_storage() {
+        use crate::config::BehaviorConfig;
+        use crate::keymap::{KeyMap, KeymapData};
+
+        block_on(async {
+            type Flash = TestFlash<16_384, 4_096, 1>;
+
+            let storage_range = (16_384 - 2 * 4_096) as u32..16_384u32;
+            let mut map =
+                MapStorage::<StorageKey, _, _>::new(Flash::new(), MapConfig::new(storage_range), Cache::new_uncached());
+            let mut buffer = [0u8; 256];
+
+            // A matching build hash keeps the stored records across the boot.
+            map.store_item(
+                &mut buffer,
+                &StorageKey::StorageConfig,
+                &StorageData::StorageConfig(LocalStorageConfig {
+                    enable: true,
+                    build_hash: BUILD_HASH,
+                }),
+            )
+            .await
+            .unwrap();
+            map.store_item(
+                &mut buffer,
+                &StorageKey::LayoutConfig,
+                &StorageData::LayoutConfig(LayoutConfig {
+                    default_layer: 0,
+                    layout_option: 42,
+                }),
+            )
+            .await
+            .unwrap();
+
+            let (flash, _) = map.destroy();
+            let keymap_init = [[[KeyAction::No; 1]; 1]; 1];
+            let encoder_map_init: Option<&mut [[EncoderAction; 0]; 1]> = None;
+
+            let mut storage = Storage::<Flash, 1, 1, 1, 0>::new(
+                flash,
+                &keymap_init,
+                &encoder_map_init,
+                &RuntimeStorageConfig::default(),
+                &RuntimeBehaviorConfig::default(),
+            )
+            .await;
+
+            // Boot-time restore path: storage -> KeymapData -> KeyMap::build.
+            let mut data = KeymapData::new([[[KeyAction::No]]]);
+            let mut behavior = BehaviorConfig::default();
+            storage.read_keymap(&mut data, &mut behavior).await.unwrap();
+
+            let positional = crate::config::PositionalConfig::<1, 1>::default();
+            let keymap = KeyMap::new(&mut data, &mut behavior, &positional).await;
+
+            // The freshly built keymap exposes the stored value to the via
+            // GET handler.
+            assert_eq!(keymap.layout_option(), 42);
         });
     }
 }


### PR DESCRIPTION
Fixes #1058

`SetKeyboardValue(LayoutOptions)` persists the selection, but `GetKeyboardValue(LayoutOptions)` returned a hardcoded `0` (TODO) and the boot path restored only `default_layer` from `LayoutConfig`, so the Vial GUI reverts to option 0 on every reconnect.

As discussed in #1058, this restores the persisted `layout_option` and returns it through `GetKeyboardValue(LayoutOptions)`:

- Keep the layout option as `KeyMap` runtime state (same pattern as `mouse_buttons`; no public config API change)
- `read_keymap` restores `layout_option` from the stored `LayoutConfig` alongside `default_layer`
- `HostContext::set_layout_options` updates the RAM state first and still forwards to flash under the `storage` feature; without `storage` the value now lasts for the session instead of always reading 0
- Two regression tests: a set→get roundtrip through the via handler, and a storage restore test that fails if `read_keymap` stops restoring `layout_option` (or `KeyMap::build` stops copying it)

Testing: `cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble` (496 passed), `bash scripts/test_all.sh` (all rows green), nightly `cargo fmt --check` (no diffs).