### PR TITLE
[Docs] Update FAQ with instructions for getting ZMK working again after flashing RMK

### DIFF
--- a/docs/docs/main/docs/getting_started/faq.md
+++ b/docs/docs/main/docs/getting_started/faq.md
@@ -188,7 +188,7 @@ If you have more sectors available in your internal flash, you can increase `num
 ### ZMK no longer works after flashing RMK
 
 ::: info
-Generally, the behavior you'll see is that ZMK is not outputting any keys or broadcasting a bluetooth connection. If you have other symptoms, something else is likely wrong.
+Generally, the behavior you'll see is that ZMK is not outputting any keys or and isn't broadcasting a bluetooth connection. If you have other symptoms, something else is likely wrong.
 :::
 
 For nRF boards (i.e. the `nice!nano` or `XIAO BLE`), ZMK uses a legacy SoftDevice Bluetooth stack. RMK uses a more recent version which is not compatible. To get ZMK working again, you must disable SoftDevice in the firmware; see below. All future firmwares for the ZMK board should be built with SoftDevice disabled.

--- a/docs/docs/main/docs/getting_started/faq.md
+++ b/docs/docs/main/docs/getting_started/faq.md
@@ -185,6 +185,39 @@ ERROR Keymap reading aborted!
 
 If you have more sectors available in your internal flash, you can increase `num_sectors` in `[storage]` section of your `keyboard.toml`, or change `storage_config` in your [`RmkConfig`](https://docs.rs/rmk/latest/rmk/config/struct.RmkConfig.html) if you're using Rust API. When using DFU (`dfu_rp` / `dfu_nrf`), the storage partition is placed after the DFU slot (via `rmk-memory.x`) and the 8-sector default matches its 32 KB size.
 
+### ZMK no longer works after flashing RMK
+
+::: info
+Generally, the behavior you'll see is that ZMK is not outputting any keys or broadcasting a bluetooth connection. If you have other symptoms, something else is likely wrong.
+:::
+
+For nRF boards (i.e. the `nice!nano` or `XIAO BLE`), ZMK uses a legacy SoftDevice Bluetooth stack. RMK uses a more recent version which is not compatible. To get ZMK working again, you must disable SoftDevice in the firmware; see below. All future firmwares for the ZMK board should be built with SoftDevice disabled.
+
+A more permanent solution would be to re-flash the bootloader with SoftDevice support. Unfortunately, the stock `XIAO BLE` bootloader does not seem to be published anywhere, so this is not an easy option.
+
+#### Disable SoftDevice for a cloud build
+Add the `nrf52840-nosd` (for the nRF82840) or `nrf52833-nosd` (for the nRF52833) snippet to your `build.yaml`, i.e.
+
+```yaml
+  - board: xiao_ble//zmk
+    snippet: nrf52840-nosd
+    shield: <your_keyboard>
+```
+
+You may also need to perform a [settings reset](https://zmk.dev/docs/troubleshooting/connection-issues#building-a-reset-firmware) to clear the Bluetooth settings so the board can re-pair:
+
+```yaml
+  - board: xiao_ble//zmk
+    snippet: nrf52840-nosd
+    shield: settings_reset
+```
+
+#### Disable SoftDevice for a local build
+
+Build with the `nrf52840-nosd` or `rnf52833-nosd` snippet (depending on your chip) by adding `--snippet nrf52840-nosd` (or `--snippet rnf52833-nosd`) to the `west build` command.
+
+If you need to perform a settings reset, you can change the board type (i.e. `-b settings_reset`).
+
 ### OUTDATED: panicked at embassy-executor: task arena is full.
 
 ::: info


### PR DESCRIPTION
Per [this discussion](https://github.com/rmk-rs/rmk/discussions/1062) I added a section to the FAQ that explains how to get ZMK working again after you flash RMK. Feel free to change anything!

I chose not to add anything to the [migration guide](https://rmk.rs/docs/migration/v06_v07#nrf-ble-stack-migration) since that's just for RMK upgrades, so having something about ZMK seems weird.

I'll open then answer an issue in ZMK's GitHub pointing to the new file so it's easier for people to find this info.

Thanks!