### PR TITLE
fix(ble): keep the dongle link at 2M PHY under `use_1m_phy`

### DIFF
--- a/docs/docs/main/docs/configuration/wireless.md
+++ b/docs/docs/main/docs/configuration/wireless.md
@@ -34,6 +34,7 @@ passkey_entry_timeout = 120
 ```
 
 Some legacy BLE adapters cannot connect to devices using 2M PHY at all. For those hosts, enable the `use_1m_phy` Cargo feature of the `rmk` crate, which makes the keyboard use 1M PHY for the host connection.
+This only affects host connections. The dongle link and the split link between the halves always run at 2M PHY, so a keyboard built with both `dongle` and `use_1m_phy` keeps those links fast and still connects to a legacy adapter on its other BLE profiles.
 
 ### Passkey entry
 

--- a/rmk/Cargo.toml
+++ b/rmk/Cargo.toml
@@ -223,8 +223,8 @@ st7796 = ["lcd_async"]
 ## Enable async matrix scanning
 async_matrix = []
 
-## Use 1M PHY.
-## Some legacy adapters cannot connect to devices using 2M PHY. 
+## Use 1M PHY toward the host.
+## The dongle link and the split link are unaffected: they always run at 2M.
 use_1m_phy = []
 
 ## Enable split keyboard support.

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -760,7 +760,13 @@ async fn serve_keyboard_connection<
         }
     }
 
-    let host_phy = if cfg!(feature = "use_1m_phy") {
+    // `use_1m_phy` exists for legacy host adapters that cannot do 2M.
+    // Always use 2M for the dongle link.
+    #[cfg(feature = "dongle")]
+    let dongle_link = crate::state::current_profile() == crate::ble::profile::DONGLE_PROFILE;
+    #[cfg(not(feature = "dongle"))]
+    let dongle_link = false;
+    let host_phy = if cfg!(feature = "use_1m_phy") && !dongle_link {
         PhyKind::Le1M
     } else {
         PhyKind::Le2M


### PR DESCRIPTION
## Problem

`use_1m_phy` is meant for legacy host adapters that cannot do 2M PHY. But `serve_keyboard_connection` applied it to *every* connection it serves, and on a keyboard the dongle is just another bond slot (`DONGLE_PROFILE`) served by that same function — so the dongle link got 1M too.

That is not a harmless preference either: `Connection::set_phy` sets a single-PHY preference for both TX and RX, so the keyboard pinning 1M defeats the `PhyKind::Le2M` the dongle central asks for in `discover_and_relay`. The result was an all-or-nothing choice — 2M everywhere (unusable on a legacy adapter) or 1M everywhere (a needlessly slow dongle link, on hardware we control on both ends).

## Change

Pick the PHY per connection: the dongle slot always gets 2M, `use_1m_phy` applies only to real host links. Behaviour is unchanged for every build that does not combine `dongle` with `use_1m_phy`.

Also fixes the feature doc comment in `rmk/Cargo.toml` and the wireless docs page to say so.

## Testing

`cargo clippy -- -D warnings` clean on `vial,_ble,storage`, `dongle,vial,_ble,storage`, `dongle,vial,_ble,storage,use_1m_phy`, `vial,_ble,storage,use_1m_phy` and `dongle,rynk,split,_ble,storage,use_1m_phy` (`use_1m_phy` is not in `RMK_FEATURESETS`, so the combination is not covered by CI today).