### PR TITLE
fix(pointing): stop polling once the sensor init has permanently failed

### DIFF
--- a/rmk/src/input_device/pointing.rs
+++ b/rmk/src/input_device/pointing.rs
@@ -210,6 +210,13 @@ impl<S: PointingDriver> PointingDevice<S> {
         }
 
         loop {
+            // A sensor that used up its init retries never reports again, and an
+            // unpopulated motion pin can sit low — `wait_for_low` would then return
+            // instantly and spin this loop at full speed, starving the executor.
+            if self.init_state == InitState::Failed {
+                pending::<()>().await;
+            }
+
             let poll_wait = async {
                 if let Some(gpio) = self.sensor.motion_gpio() {
                     let _ = gpio.wait_for_low().await;


### PR DESCRIPTION
## Problem

`PointingDevice::read_pointing_event` keeps looping after `try_init` has exhausted `MAX_INIT_RETRIES` and latched `InitState::Failed`. In that state `try_init` returns `false` immediately, without awaiting anything, so the only thing that can yield is `poll_wait`.

With a motion pin configured, `poll_wait` is `gpio.wait_for_low()` — and embassy documents that it returns immediately when the pin is already low:

```rust
/// Wait until the pin is low. If it is already low, return immediately.
pub async fn wait_for_low(&mut self) { ... }
```

`report_wait` is `pending()` while nothing is accumulated, so it cannot break the tie either. The loop then spins at full speed for a sensor that can never report again, starving the executor and taking the rest of the keyboard down with it — no keys, no BLE, no USB.

An unpopulated pointing header makes this easy to hit: the motion line is held only by the internal pull-up, so a single low reading is enough to wedge the board. I ran into it on a board whose PMW3610 connector was left empty — init failed three times with `InvalidProductId(0)`, and everything else stopped from that point on.

## Fix

A sensor that used up its retries is not coming back, so park the loop rather than letting it spin:

```rust
loop {
    if self.init_state == InitState::Failed {
        pending::<()>().await;
    }
    ...
}
```

The check has to be inside the loop: init is lazy, so `InitState::Failed` only appears after `poll_once` has burned through the retries.

This also removes the wasted wakeups in the polling configuration (`motion_gpio: None`), where the loop was still waking every `poll_interval` to call a `poll_once` that returns immediately.

## Testing

`cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble` — 496 passed, 0 skipped.