### PR TITLE
fix: seed the default morse profile's flow-tap bit; Vial reads tap_capslock_interval

### DIFF
--- a/rmk-config/src/resolved/behavior.rs
+++ b/rmk-config/src/resolved/behavior.rs
@@ -181,8 +181,10 @@ impl crate::KeyboardTomlConfig {
                 })
                 .unwrap_or_default();
 
+            // Seeded rather than left `None` so the switch is stored and read
+            // back over Rynk like the profile's other fields.
             let default_profile = MorseProfile {
-                enable_flow_tap: None,
+                enable_flow_tap: Some(m.enable_flow_tap.unwrap_or(false)),
                 unilateral_tap: m.unilateral_tap,
                 permissive_hold: m.permissive_hold,
                 hold_on_other_press: m.hold_on_other_press,
@@ -334,7 +336,7 @@ hold_timeout = "200ms"
         let behavior = config.behavior().unwrap();
         let morse = behavior.morse.unwrap();
         assert!(morse.enable_flow_tap);
-        assert_eq!(morse.default_profile.enable_flow_tap, None);
+        assert_eq!(morse.default_profile.enable_flow_tap, Some(true));
         assert_eq!(morse.profiles["flow_on"].enable_flow_tap, Some(true));
         assert_eq!(morse.profiles["flow_off"].enable_flow_tap, Some(false));
         assert_eq!(morse.profiles["inherit"].enable_flow_tap, None);

--- a/rmk-types/src/protocol/rynk/payload/system.rs
+++ b/rmk-types/src/protocol/rynk/payload/system.rs
@@ -158,8 +158,8 @@ pub struct BehaviorConfig {
     pub tap_interval_ms: u16,
     pub tap_capslock_interval_ms: u16,
     /// Default profile for morse/tap-hold keys; per-key profiles override it.
-    /// A `None` field falls back to a firmware default the host can't read back —
-    /// for `enable_flow_tap`, the compiled `[behavior.morse]` switch.
+    /// `keyboard.toml` seeds `enable_flow_tap` and both timeouts, so a read
+    /// returns them; a `None` field falls back to the firmware default.
     pub morse_default_profile: MorseProfile,
     /// Flow-tap window: a morse key pressed within this time of the previous
     /// key press is forced to its tap action.

--- a/rmk/src/host/via/vial.rs
+++ b/rmk/src/host/via/vial.rs
@@ -134,8 +134,8 @@ pub(crate) async fn process_vial<'a>(
                     LittleEndian::write_u16(&mut report.input_data[1..3], tap_interval);
                 }
                 SettingKey::TapCapslockInterval => {
-                    let tap_interval = ctx.tap_interval();
-                    LittleEndian::write_u16(&mut report.input_data[1..3], tap_interval);
+                    let tap_capslock_interval = ctx.tap_capslock_interval();
+                    LittleEndian::write_u16(&mut report.input_data[1..3], tap_capslock_interval);
                 }
                 SettingKey::PermissiveHold => {
                     if let Some(m) = ctx.morse_default_profile().mode()

--- a/rmk/tests/integration/vial.rs
+++ b/rmk/tests/integration/vial.rs
@@ -155,6 +155,22 @@ fn combo_and_behavior_writes_change_the_chord() {
 }
 
 #[test]
+fn tap_capslock_interval_reads_back_its_own_value() {
+    test_block_on(async {
+        let mut keyboard = SimKeyboard::builder([[[k!(A)]]]).build().await;
+        keyboard.set_behavior(SettingKey::TapInterval, 180);
+        keyboard.set_behavior(SettingKey::TapCapslockInterval, 240);
+        let mut request = vial(VialCommand::GetBehaviorSetting);
+        request[2..4].copy_from_slice(&(SettingKey::TapCapslockInterval as u16).to_le_bytes());
+        let mut reply = [0xFF; REPORT];
+        reply[0] = 0;
+        reply[1..3].copy_from_slice(&240u16.to_le_bytes());
+        keyboard.host_exchange(request, reply);
+        keyboard.run().await;
+    });
+}
+
+#[test]
 fn morse_write_changes_the_tap() {
     test_block_on(async {
         let mut keyboard = SimKeyboard::builder([[[rmk::td!(0)]]]).build().await;


### PR DESCRIPTION
Follow-up to #1054.

## Flow tap in the default morse profile

`[behavior.morse] enable_flow_tap` lived only in the compiled `MorsesConfig` bool, so the default profile always carried `None` on the wire: a Rynk host read `null` on a board where flow tap is on, and the switch was the one behavior setting that never went through storage.

Seeding the bit at `rmk-config` resolve time (`Some(m.enable_flow_tap.unwrap_or(false))`) makes it behave like the profile's other fields:

- first boot / `clear_storage` / build-hash change → the `keyboard.toml` value is written to flash with the rest of `BehaviorConfig`
- otherwise boot reads flash; `GetBehaviorConfig` returns what's stored
- a host write wins until storage is cleared

`is_flow_tap_enabled`'s chain, the handlers, wire layout and snapshots are unchanged; a host that writes `None` still falls back to the compiled switch (kept for use_rust users who only set `MorsesConfig::enable_flow_tap`).

## Vial `TapCapslockInterval`

`GetBehaviorSetting` answered `TapCapslockInterval` with `tap_interval`, so Vial and Rynk reported different values for the same field and a Vial read-modify-write copied `tap_interval` over `tap_capslock_interval`. Now reads `tap_capslock_interval()`; `tap_capslock_interval_reads_back_its_own_value` fails before the fix (reads 180, expects 240).

## Tests

- `rmk-config` cargo test
- `rmk` nextest, `rynk,_ble,split,async_matrix,storage` row: 550 passed
- `rmk` nextest, `vial,host_lock,_no_usb,steno,passkey_entry` row: 505 passed
- `rmk-macro` cargo test

https://claude.ai/code/session_01FnxjaFoT6KTZUkPrtEXAGP
