### PR TITLE
refactor(ble): Improve power consumption, code structure and documentation of subrating config

### DIFF
--- a/docs/docs/main/docs/features/low_power.md
+++ b/docs/docs/main/docs/features/low_power.md
@@ -67,18 +67,18 @@ Two related behaviors are always on:
 - When BLE advertising times out without a connection (after 5 minutes), the keyboard sleeps immediately and waits for a key or pointing event before it advertises again.
 - `NrfAdc` takes a `light_sleep` interval as its last argument. When the analog inputs have been idle for more than 1.2 seconds, the ADC polls at that interval instead of `polling_interval`. A joystick configured in `keyboard.toml` uses 350ms.
 
-### Split central sleep using BLE Connection Subrating (nrf52840 only)
+### Split central sleep using BLE Connection Subrating (tested on nrf52840 only)
 
 To improve central power usage and decrease peripheral latency problems during wake-up you can activate the `subrating` feature in your `Cargo.toml`.
 This enables BLE Connection Subrating which lets the central sleep for longer intervals, while allowing for a quick switch back to the fast connection intervals.
 
-The mean perihperal latency is ~450ms for the first keypress only. The keyboard instantly switches to the active connection settings after that. Depending on your layout and habits this allows to use the sleep feature more agressively. Try to reduce the timeout to get lower battery usage, e.g.:
+The worst perihperal latency is ~450ms for the first keypress only, the mean latency should be half: ~225ms. The keyboard instantly switches to the active connection settings after that. Depending on your layout and habits this allows to use the sleep feature more agressively. Try to reduce the timeout to get lower battery usage, e.g.:
 ```toml
 [rmk]
 split_central_sleep_timeout_seconds = 60
 ```
 
-If the central is not connected to a host, the latency is further increased to ~1867ms which reduces the power consumption of the central to ~20µA, barely more then the peripheral.
+If the central is not connected to a host, the mean latency is further increased to ~472ms which reduces the power consumption of the central to ~22µA, nearly the same as the peripherals: ~21µA.
 
 ## External VCC
 

--- a/docs/docs/main/docs/features/low_power.md
+++ b/docs/docs/main/docs/features/low_power.md
@@ -72,13 +72,13 @@ Two related behaviors are always on:
 To improve central power usage and decrease peripheral latency problems during wake-up you can activate the `subrating` feature in your `Cargo.toml`.
 This enables BLE Connection Subrating which lets the central sleep for longer intervals, while allowing for a quick switch back to the fast connection intervals.
 
-The worst perihperal latency is ~450ms for the first keypress only, the mean latency should be half: ~225ms. The keyboard instantly switches to the active connection settings after that. Depending on your layout and habits this allows to use the sleep feature more agressively. Try to reduce the timeout to get lower battery usage, e.g.:
+The maximum peripheral latency is ~450ms for the first keypress; the mean latency is roughly half (~225ms). The keyboard instantly switches to the active connection settings after that. Depending on your layout and habits this allows to use the sleep feature more aggressively. Try to reduce the timeout to get lower battery usage, e.g.:
 ```toml
 [rmk]
 split_central_sleep_timeout_seconds = 60
 ```
 
-If the central is not connected to a host, the mean latency is further increased to ~472ms which reduces the power consumption of the central to ~22µA, nearly the same as the peripherals: ~21µA.
+If the central is not connected to a host, the mean latency is further increased to ~472ms which reduces the power consumption of the central to ~22µA, nearly the same as the peripheral (~21µA).
 
 ## External VCC
 

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -771,7 +771,7 @@ pub(crate) async fn set_conn_params<
         // Wait 5 seconds before each request to avoid connection drop
         embassy_time::Timer::after_secs(5).await;
 
-        // we neet to let the central sleep for long perios of time when the
+        // We need to let the central sleep for long periods of time when the
         // split connection is subrated to get the power savings.
         #[cfg(feature = "subrating")]
         let max_latency = subrating::HOST_MAX_LATENCY;

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -1,6 +1,6 @@
 use bt_hci::cmd::le::{LeReadLocalSupportedFeatures, LeSetPhy};
 #[cfg(feature = "subrating")]
-use bt_hci::cmd::le::{LeSetHostFeature, LeSubrateRequest, LeSubrateRequestParams};
+use bt_hci::cmd::le::{LeSetHostFeature, LeSubrateRequest};
 use bt_hci::controller::{ControllerCmdAsync, ControllerCmdSync};
 use bt_hci::param::Error as HciError;
 use embassy_futures::join::join3;
@@ -36,6 +36,8 @@ use crate::event::SubscribableEvent;
 use crate::hid::{HidWriterTrait, run_led_reader};
 #[cfg(feature = "split")]
 use crate::split::PeripheralMatrixConfig;
+#[cfg(feature = "subrating")]
+use crate::split::ble::central::subrating;
 #[cfg(feature = "split")]
 use crate::split::ble::central::{run_peripheral_session, scan_and_connect_peripherals};
 use crate::state::set_ble_state;
@@ -768,12 +770,15 @@ pub(crate) async fn set_conn_params<
     for interval in [Duration::from_millis(15), Duration::from_micros(7500)] {
         // Wait 5 seconds before each request to avoid connection drop
         embassy_time::Timer::after_secs(5).await;
-        let max_latency = if cfg!(feature = "subrating") {
-            // Set Central sleep for up to 2.25s to save power when the keyboard is asleep
-            (Duration::from_millis(2250).as_micros() / interval.as_micros()) as u16
-        } else {
-            30
-        };
+
+        // we neet to let the central sleep for long perios of time when the
+        // split connection is subrated to get the power savings.
+        #[cfg(feature = "subrating")]
+        let max_latency = subrating::HOST_MAX_LATENCY;
+
+        #[cfg(not(feature = "subrating"))]
+        let max_latency = 30;
+
         update_conn_params(
             stack,
             conn.raw(),
@@ -963,40 +968,6 @@ pub(crate) async fn update_conn_params<
         }
     }
     warn!("[update_conn_params] controller stayed busy, giving up");
-    false
-}
-
-/// Update the subrate factor.
-///
-/// Returns whether the request reached the controller, so callers that mirror
-/// the parameters in their own state don't record params that never landed.
-#[cfg(feature = "subrating")]
-pub(crate) async fn update_subrate_factor<C: Controller + ControllerCmdAsync<LeSubrateRequest>, P: PacketPool>(
-    stack: &Stack<'_, C, P>,
-    params: LeSubrateRequestParams,
-) -> bool {
-    for _ in 0..10 {
-        let subrate_request = LeSubrateRequest::from(params);
-        match stack.async_command(subrate_request).await {
-            Ok(_) => return true,
-            Err(BleHostError::BleHost(Error::Hci(error))) => {
-                if 0x3A == error.to_status().into_inner() {
-                    info!("[update_subrate_factor] HCI busy: {:?}", error);
-                    embassy_time::Timer::after_millis(100).await;
-                    continue;
-                }
-                error!("[update_subrate_factor] HCI error: {:?}", error);
-                return false;
-            }
-            Err(e) => {
-                #[cfg(feature = "defmt")]
-                let e = defmt::Debug2Format(&e);
-                error!("[update_subrate_factor] BLE host error: {:?}", e);
-                return false;
-            }
-        }
-    }
-    warn!("[update_subrate_factor] controller stayed busy, giving up");
     false
 }
 

--- a/rmk/src/split/ble/central.rs
+++ b/rmk/src/split/ble/central.rs
@@ -293,7 +293,7 @@ pub(crate) mod subrating {
 
     use bt_hci::cmd::le::{LeSubrateRequest, LeSubrateRequestParams};
     use bt_hci::controller::ControllerCmdAsync;
-    use bt_hci::param::{ConnHandle, Duration};
+    use bt_hci::param::{ConnHandle, Duration, Error as HciError};
     use trouble_host::prelude::*;
 
     const CONN_INTERVAL_US: u32 = 7500;
@@ -361,8 +361,10 @@ pub(crate) mod subrating {
             match stack.async_command(subrate_request).await {
                 Ok(_) => return true,
                 Err(BleHostError::BleHost(Error::Hci(error))) => {
-                    if 0x3A == error.to_status().into_inner() {
-                        info!("[update_subrate_factor] HCI busy: {:?}", error);
+                    // A connection runs one link-layer control procedure at a time, and
+                    // a fresh one is still running its own.
+                    if error == HciError::CONTROLLER_BUSY || error == HciError::DIFFERENT_TRANSACTION_COLLISION {
+                        info!("[update_subrate_factor] controller busy, retrying: {:?}", error);
                         embassy_time::Timer::after_millis(100).await;
                         continue;
                     }

--- a/rmk/src/split/ble/central.rs
+++ b/rmk/src/split/ble/central.rs
@@ -298,7 +298,7 @@ pub(crate) mod subrating {
 
     const CONN_INTERVAL_US: u32 = 7500;
     const SLEEP_HOST_CONN_SUBRATE: u16 = 60;
-    const SLEEP_NO_HOST_SUBRATE: u16 = 250;
+    const SLEEP_NO_HOST_SUBRATE: u16 = 125;
     const DEFAULT_MAX_LATENCY: u16 = 300;
     pub(crate) const HOST_MAX_LATENCY: u16 = 300;
 

--- a/rmk/src/split/ble/central.rs
+++ b/rmk/src/split/ble/central.rs
@@ -1,9 +1,7 @@
+#[cfg(feature = "subrating")]
+use bt_hci::cmd::le::LeSubrateRequest;
 use bt_hci::cmd::le::{LeReadLocalSupportedFeatures, LeSetPhy, LeSetScanParams};
-#[cfg(feature = "subrating")]
-use bt_hci::cmd::le::{LeSubrateRequest, LeSubrateRequestParams};
 use bt_hci::controller::{ControllerCmdAsync, ControllerCmdSync};
-#[cfg(feature = "subrating")]
-use bt_hci::param::ConnHandle;
 use embassy_futures::select::{Either, Either3, select, select3};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::channel::Channel;
@@ -15,8 +13,6 @@ use super::GattSplitMessage;
 use crate::ble::adv::Adv;
 use crate::ble::scan::{SPLIT_CENTRAL_SCAN_WINDOW, scan_config, start_scan};
 use crate::ble::sleep::report_activity;
-#[cfg(feature = "subrating")]
-use crate::ble::update_subrate_factor;
 use crate::ble::{update_ble_phy, update_conn_params, wait_for_stack_started};
 use crate::channel::FLASH_CHANNEL;
 use crate::event::{EventSubscriber, SleepStateEvent, SubscribableEvent};
@@ -223,18 +219,6 @@ fn default_central_conn_param() -> RequestedConnParams {
     }
 }
 
-#[cfg(feature = "subrating")]
-fn default_central_subrate_params(handle: ConnHandle) -> LeSubrateRequestParams {
-    LeSubrateRequestParams {
-        handle,
-        subrate_min: 1,
-        subrate_max: 1,
-        max_latency: 300, // 2250ms
-        continuation_number: 0,
-        supervision_timeout: ::bt_hci::param::Duration::from_secs(5),
-    }
-}
-
 /// Parameters for the central -> peripheral link while the central sleeps.
 ///
 /// With a host connected, the central's radio is busy serving the host link
@@ -262,27 +246,139 @@ fn sleep_central_conn_param() -> RequestedConnParams {
 }
 
 #[cfg(feature = "subrating")]
-fn sleep_central_subrate_params(handle: ConnHandle) -> LeSubrateRequestParams {
-    if crate::state::active_transport().is_some() {
-        // Host connected — short subrate so key presses arrive quickly
+pub(crate) mod subrating {
+    // Measurements on nrf52840 for subrate request parameters:
+    //    |   HCL | [ms] |  SF | [ms] | IC [µA] |  KPL [ms]  | IP [µA] |
+    //    |-------+------+-----+------+---------+------------|---------|
+    //    |    60 |  450 |  10 |   75 |      80 |  41 /   82 |      21 |
+    //    |    30 |  225 |  30 |  225 |      75 | 116 /  232 |      21 |
+    //    |    60 |  450 |  30 |  225 |      59 | 116 /  232 |      21 |
+    //    |   180 | 1350 |  30 |  225 |      48 | 116 /  232 |      21 |
+    //    |   300 | 2250 |  30 |  225 |      48 | 116 /  232 |      21 |
+    //    |    30 |  225 |  60 |  450 |      63 | 228 /  457 |      21 |
+    //    |    60 |  450 |  60 |  450 |      48 | 228 /  457 |      21 |
+    //    |   180 | 1350 |  60 |  450 |      39 | 228 /  457 |      21 |
+    // ==>|   300 | 2250 |  60 |  450 |      34 | 228 /  457 |      21 |<== Connected Sleep
+    //    |   300 | 2250 | 120 |  900 |      32 | 453 /  907 |      21 |
+    //    | no HC |      | 100 |  750 |      24 | 378 /  757 |      21 |
+    // ==>| no HC |      | 125 |  937 |      22 | 472 /  945 |      21 |<== Disconnected Sleep
+    //    | no HC |      | 250 | 1875 |      21 | 941 / 1882 |      24 |
+    //    |-------+------+-----+------+---------+------------|---------|
+    //    HCL .. Host Connection max latency
+    //    SF ... Subrate Factor split connection
+    //    IC ... Central average current
+    //    KPL .. Key Press latency (mean/worst)
+    //    IP ... Peripheral average current
+    //
+    // In active mode without pressing any key, the average current is: ~600µA
+    //
+    // Current draw on PERIPHERAL with subrating During Connected Sleep with
+    // subrate factor <250 and a max sleep time of 3.75s is 21µA.
+    //
+    // During Disconnected Sleep with subrate factor set to 250 the average
+    // peripheral current draw increases to 24µA, when the internal low
+    // frequency clock is in use. Due to the long intervals the peripheral needs
+    // to increase the listening window during connection events to compensate
+    // for clock drift. Therefore 125 is selected as the better tradeoff.
+    //
+    //    In active mode without pressing any key, the average current depends on the max
+    //    latency of the split connection:
+    //    | max_latency |  [ms] | min_timeout [ms] | avg. [µA] |
+    //    |-------------+-------+------------------+-----------|
+    //    |          10 |   75. |             165. |        72 |
+    //    |          30 |  225. |             465. |        38 |
+    //    |          60 |  450. |             915. |        30 |
+    // ==>|         300 | 2250. |            4515. |        21 |<== Default Params
+    //    |-------------+-------+------------------+-----------|
+
+    use bt_hci::cmd::le::{LeSubrateRequest, LeSubrateRequestParams};
+    use bt_hci::controller::ControllerCmdAsync;
+    use bt_hci::param::{ConnHandle, Duration};
+    use trouble_host::prelude::*;
+
+    const CONN_INTERVAL_US: u32 = 7500;
+    const SLEEP_HOST_CONN_SUBRATE: u16 = 60;
+    const SLEEP_NO_HOST_SUBRATE: u16 = 250;
+    const DEFAULT_MAX_LATENCY: u16 = 300;
+    pub(crate) const HOST_MAX_LATENCY: u16 = 300;
+
+    // In some cases the subrate request procedure does not run through with only one continuation.
+    const SLEEP_CONTINUATION_NUMBER: u16 = 2;
+
+    const fn calc_max_latency(subrate_max: u16) -> u16 {
+        // BLE spec requires: Subrate_Max * (Max_Latency + 1) <= 500
+        (500 / subrate_max) - 1
+    }
+
+    const fn calc_min_timeout_ms(max_latency: u16, subrate_factor: u16) -> u32 {
+        // BLE spec requires: Connection Interval × Subrate_Max × (Max_Latency + 1) ≤ Supervision_Timeout ÷ 2
+        let effective_interval_us = (subrate_factor as u32) * CONN_INTERVAL_US;
+        let required_timeout_us = 2 * (1 + max_latency as u32) * effective_interval_us;
+        (required_timeout_us + CONN_INTERVAL_US * 2) / 1_000 // add two connection intervals to ensure ≤ holds!
+    }
+
+    pub(super) fn default_central_subrate_params(handle: ConnHandle) -> LeSubrateRequestParams {
+        let subrate = 1;
+        let max_latency = DEFAULT_MAX_LATENCY;
+        let supervision_timeout = Duration::from_millis(calc_min_timeout_ms(max_latency, subrate));
+
         LeSubrateRequestParams {
             handle,
-            subrate_min: 60, // 450ms effective interval → 457.5ms key press latency
-            subrate_max: 60,
-            max_latency: 7,         // 3.6s sleep for peripheral
-            continuation_number: 2, // assure low-latency reset of subrate factor
-            supervision_timeout: ::bt_hci::param::Duration::from_secs(8),
+            subrate_min: subrate,
+            subrate_max: subrate,
+            max_latency,
+            continuation_number: 0,
+            supervision_timeout,
         }
-    } else {
-        // No host — very long interval, peripheral will be unresponsive for ~2s after reconnect
+    }
+
+    pub(super) fn sleep_central_subrate_params(handle: ConnHandle) -> LeSubrateRequestParams {
+        let subrate = if crate::state::active_transport().is_some() {
+            SLEEP_HOST_CONN_SUBRATE
+        } else {
+            SLEEP_NO_HOST_SUBRATE
+        };
+
+        let max_latency = calc_max_latency(subrate);
+        let supervision_timeout = Duration::from_millis(calc_min_timeout_ms(max_latency, subrate));
+
         LeSubrateRequestParams {
             handle,
-            subrate_min: 249, // 1867.5ms effective interval
-            subrate_max: 249,
-            max_latency: 1,         // 3.6s sleep for peripheral
-            continuation_number: 2, // assure low-latency reset of subrate factor
-            supervision_timeout: ::bt_hci::param::Duration::from_secs(8),
+            subrate_min: subrate,
+            subrate_max: subrate,
+            max_latency,
+            continuation_number: SLEEP_CONTINUATION_NUMBER,
+            supervision_timeout,
         }
+    }
+
+    pub(crate) async fn update_subrate_factor<C: Controller + ControllerCmdAsync<LeSubrateRequest>, P: PacketPool>(
+        stack: &Stack<'_, C, P>,
+        params: LeSubrateRequestParams,
+    ) -> bool {
+        for _ in 0..10 {
+            let subrate_request = LeSubrateRequest::from(params);
+            match stack.async_command(subrate_request).await {
+                Ok(_) => return true,
+                Err(BleHostError::BleHost(Error::Hci(error))) => {
+                    if 0x3A == error.to_status().into_inner() {
+                        info!("[update_subrate_factor] HCI busy: {:?}", error);
+                        embassy_time::Timer::after_millis(100).await;
+                        continue;
+                    }
+                    error!("[update_subrate_factor] HCI error: {:?}", error);
+                    return false;
+                }
+                Err(e) => {
+                    #[cfg(feature = "defmt")]
+                    let e = defmt::Debug2Format(&e);
+                    error!("[update_subrate_factor] BLE host error: {:?}", e);
+                    return false;
+                }
+            }
+        }
+        warn!("[update_subrate_factor] controller stayed busy, giving up");
+        false
     }
 }
 
@@ -467,11 +563,11 @@ async fn follow_sleep_state<
         #[cfg(feature = "subrating")]
         {
             let params = if sleeping {
-                sleep_central_subrate_params(conn.handle())
+                subrating::sleep_central_subrate_params(conn.handle())
             } else {
-                default_central_subrate_params(conn.handle())
+                subrating::default_central_subrate_params(conn.handle())
             };
-            if update_subrate_factor(stack, params).await {
+            if subrating::update_subrate_factor(stack, params).await {
                 applied = sleeping;
             }
         }

--- a/rmk/src/split/ble/central.rs
+++ b/rmk/src/split/ble/central.rs
@@ -272,17 +272,17 @@ pub(crate) mod subrating {
     //
     // In active mode without pressing any key, the average current is: ~600µA
     //
-    // Current draw on PERIPHERAL with subrating During Connected Sleep with
-    // subrate factor <250 and a max sleep time of 3.75s is 21µA.
+    // The current draw on the peripheral with subrating during connected sleep
+    // with a subrate factor < 250 and a max sleep time of 3.75s is 21µA.
     //
-    // During Disconnected Sleep with subrate factor set to 250 the average
-    // peripheral current draw increases to 24µA, when the internal low
-    // frequency clock is in use. Due to the long intervals the peripheral needs
+    // During disconnected sleep with the subrate factor set to 250, the average
+    // peripheral current draw increases to 24µA, when the internal low-frequency
+    // clock is in use. Due to the long intervals, the peripheral needs
     // to increase the listening window during connection events to compensate
-    // for clock drift. Therefore 125 is selected as the better tradeoff.
+    // for clock drift. Therefore, 125 is selected as the better trade-off.
     //
-    //    In active mode without pressing any key, the average current depends on the max
-    //    latency of the split connection:
+    // In active mode without pressing any key, the average current depends on the max
+    // latency of the split connection:
     //    | max_latency |  [ms] | min_timeout [ms] | avg. [µA] |
     //    |-------------+-------+------------------+-----------|
     //    |          10 |   75. |             165. |        72 |
@@ -302,7 +302,7 @@ pub(crate) mod subrating {
     const DEFAULT_MAX_LATENCY: u16 = 300;
     pub(crate) const HOST_MAX_LATENCY: u16 = 300;
 
-    // In some cases the subrate request procedure does not run through with only one continuation.
+    // In some cases, the subrate request procedure does not complete with only one continuation.
     const SLEEP_CONTINUATION_NUMBER: u16 = 2;
 
     const fn calc_max_latency(subrate_max: u16) -> u16 {


### PR DESCRIPTION
This pull request:
- adds detailed current draw measurements for central and peripheral during sleep. 
- reduces the subrate factor for host-disconnected sleep from 250 to 125 to balance power consumption between central and peripheral, according to the measurements.
- Add const functions to calculate the optimal latency and timeout parameters for the connections.

@HaoboGu : Sorry for taking so long to respond to the comments in #1008, now the pull request is complete 