### PR TITLE
perf(keyboard): stop one-shot expiry from blocking the keyboard task

### DIFF
--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -142,7 +142,7 @@ impl Runnable for Keyboard<'_> {
     /// The report is sent using `send_report`.
     async fn run(&mut self) -> ! {
         loop {
-            // TODO: Now the unprocessed_events is only used in one-shot keys and clear peer key.
+            // TODO: Now the unprocessed_events is only used in held_for_5s.
             // Maybe it can be removed in the future?
             if !self.unprocessed_events.is_empty() {
                 // Process unprocessed events
@@ -153,13 +153,20 @@ impl Runnable for Keyboard<'_> {
                 // Process buffered held key
                 self.process_buffered_key(key).await
             } else {
-                // If mouse repeat is pending, race subscriber against deadline
-                let event = if let Some(deadline) = self.mouse.next_deadline() {
+                // If a mouse repeat or one-shot expiry is pending, race subscriber against the earliest deadline
+                let deadline = [self.mouse.next_deadline(), self.osm_deadline, self.osl_deadline]
+                    .into_iter()
+                    .flatten()
+                    .min();
+                let event = if let Some(deadline) = deadline {
                     match with_deadline(deadline, self.keyboard_event_subscriber.next_message_pure()).await {
                         Ok(event) => event,
                         Err(_) => {
-                            // Repeat deadline expired, fire repeat
-                            self.fire_mouse_repeat().await;
+                            // Deadline expired: fire pending one-shot expiry and/or mouse repeat
+                            self.fire_oneshot_timeout().await;
+                            if self.mouse.next_deadline().is_some_and(|d| d <= Instant::now()) {
+                                self.fire_mouse_repeat().await;
+                            }
                             continue;
                         }
                     }
@@ -209,8 +216,14 @@ pub struct Keyboard<'a> {
     /// Oneshot Layer state
     osl_state: OneShotState<u8>,
 
+    /// Expiry deadline while the oneshot layer is armed (`Single`)
+    osl_deadline: Option<Instant>,
+
     /// Oneshot Modifier state
     osm_state: OneShotState<ModifierCombination>,
+
+    /// Expiry deadline while the oneshot modifiers are armed (`Single`)
+    osm_deadline: Option<Instant>,
 
     /// Caps Word state machine
     caps_word: CapsWordState,
@@ -264,7 +277,9 @@ impl<'a> Keyboard<'a> {
             keyboard_event_subscriber: KeyboardEvent::subscriber(),
             last_press_time: Instant::now(),
             osl_state: OneShotState::default(),
+            osl_deadline: None,
             osm_state: OneShotState::default(),
+            osm_deadline: None,
             caps_word: CapsWordState::default(),
             with_modifiers: ModifierCombination::default(),
             macro_texting: false,

--- a/rmk/src/keyboard/oneshot.rs
+++ b/rmk/src/keyboard/oneshot.rs
@@ -1,5 +1,4 @@
-use embassy_futures::select::{Either, select};
-use embassy_time::Timer;
+use embassy_time::Instant;
 use rmk_types::modifier::ModifierCombination;
 
 use crate::event::KeyboardEvent;
@@ -35,6 +34,9 @@ impl<'a> Keyboard<'a> {
 
         // Update one shot state
         if event.pressed {
+            // Any pending expiry deadline belongs to a previous `Single` state; the
+            // matching release re-arms a fresh one if the state stays `Single`.
+            self.osm_deadline = None;
             let mut was_active = false;
             // Add new modifier combination to existing one shot or init if none
             self.osm_state = match self.osm_state {
@@ -45,8 +47,6 @@ impl<'a> Keyboard<'a> {
 
                     if was_active {
                         let result = cur_modifiers & !new_modifiers;
-                        // Remove the matching event from unprocessed_events queue
-                        self.unprocessed_events.retain(|e| e.pos != event.pos);
                         // Send report for current osm_state modifiers
                         self.send_keyboard_report_with_resolved_modifiers(true).await;
 
@@ -71,26 +71,11 @@ impl<'a> Keyboard<'a> {
         } else {
             match self.osm_state {
                 OneShotState::Initial(cur_modifiers) | OneShotState::Single(cur_modifiers) => {
+                    // Released before any other key: keep the modifiers armed for the
+                    // next keypress. Expiry is deadline-driven from `run()`, so the
+                    // keyboard task keeps serving other events in the meantime.
                     self.osm_state = OneShotState::Single(cur_modifiers);
-                    let timeout = Timer::after(self.keymap.one_shot_timeout());
-                    match select(timeout, self.keyboard_event_subscriber.next_message_pure()).await {
-                        Either::First(_) => {
-                            // Timeout, release modifiers
-                            self.update_osl(event);
-                            self.osm_state = OneShotState::None;
-
-                            // Send release report because modifiers were held
-                            if activate_on_keypress {
-                                self.send_keyboard_report_with_resolved_modifiers(false).await;
-                            }
-                        }
-                        Either::Second(e) => {
-                            // New event, send it to queue
-                            if self.unprocessed_events.push(e).is_err() {
-                                warn!("Unprocessed event queue is full, dropping event");
-                            }
-                        }
-                    }
+                    self.osm_deadline = Some(Instant::now() + self.keymap.one_shot_timeout());
                 }
                 OneShotState::Held(cur_modifiers) => {
                     let was_active = cur_modifiers & new_modifiers == new_modifiers;
@@ -116,6 +101,9 @@ impl<'a> Keyboard<'a> {
     pub(crate) async fn process_action_osl(&mut self, layer_num: u8, event: KeyboardEvent) {
         // Update one shot state
         if event.pressed {
+            // Any pending expiry deadline belongs to a previous `Single` state
+            self.osl_deadline = None;
+
             // Deactivate old layer if any
             if let Some(&l) = self.osl_state.value() {
                 self.keymap.deactivate_layer(l);
@@ -134,22 +122,11 @@ impl<'a> Keyboard<'a> {
         } else {
             match self.osl_state {
                 OneShotState::Initial(l) | OneShotState::Single(l) => {
+                    // Released before any other key: keep the layer armed for the
+                    // next keypress. Expiry is deadline-driven from `run()`, so the
+                    // keyboard task keeps serving other events in the meantime.
                     self.osl_state = OneShotState::Single(l);
-
-                    let timeout = embassy_time::Timer::after(self.keymap.one_shot_timeout());
-                    match select(timeout, self.keyboard_event_subscriber.next_message_pure()).await {
-                        Either::First(_) => {
-                            // Timeout, deactivate layer
-                            self.keymap.deactivate_layer(layer_num);
-                            self.osl_state = OneShotState::None;
-                        }
-                        Either::Second(e) => {
-                            // New event, send it to queue
-                            if self.unprocessed_events.push(e).is_err() {
-                                warn!("Unprocessed event queue is full, dropping event");
-                            }
-                        }
-                    }
+                    self.osl_deadline = Some(Instant::now() + self.keymap.one_shot_timeout());
                 }
                 OneShotState::Held(layer_num) => {
                     self.osl_state = OneShotState::None;
@@ -173,6 +150,7 @@ impl<'a> Keyboard<'a> {
             // on the pressed report anyway, so the release report is unaffected).
             OneShotState::Single(_) if event.pressed => {
                 self.osm_state = OneShotState::None;
+                self.osm_deadline = None;
                 true
             }
             _ => false,
@@ -183,10 +161,37 @@ impl<'a> Keyboard<'a> {
         match self.osl_state {
             OneShotState::Initial(l) => self.osl_state = OneShotState::Held(l),
             OneShotState::Single(layer_num) if !event.pressed => {
+                self.osl_deadline = None;
                 self.keymap.deactivate_layer(layer_num);
                 self.osl_state = OneShotState::None;
             }
             _ => (),
+        }
+    }
+
+    /// Fire expired one-shot deadlines: disarm timed-out one-shot modifiers and
+    /// deactivate the timed-out one-shot layer. Called from `run()`'s deadline
+    /// race; each deadline is re-checked against the current time, so a call
+    /// before expiry is a no-op.
+    pub(crate) async fn fire_oneshot_timeout(&mut self) {
+        let now = Instant::now();
+
+        if self.osm_deadline.is_some_and(|d| d <= now) {
+            self.osm_deadline = None;
+            self.osm_state = OneShotState::None;
+            // Send release report because modifiers were reported as held on press
+            if self.keymap.one_shot_modifiers_config().activate_on_keypress {
+                self.send_keyboard_report_with_resolved_modifiers(false).await;
+            }
+        }
+
+        if self.osl_deadline.is_some_and(|d| d <= now) {
+            self.osl_deadline = None;
+            // Deactivate the stored layer, not the triggering event's layer
+            if let OneShotState::Single(l) = self.osl_state {
+                self.keymap.deactivate_layer(l);
+            }
+            self.osl_state = OneShotState::None;
         }
     }
 }

--- a/rmk/tests/scenarios/one_shot.toml
+++ b/rmk/tests/scenarios/one_shot.toml
@@ -4,6 +4,9 @@
 #   Layer 0: OSM(LShift)          OSL(1)  A  TH(B, C)  OSM(LCtrl)  WM(B, LGui)
 #   Layer 1: OSM(LShift | LCtrl)  No      C  D         E           F
 #
+# Two more shared-board positions are used below: MouseWheelUp@(0,8) and
+# the plain layer key MO(1)@(3,0).
+#
 # Tests inherit the one-shot defaults (timeout 1000ms, activate_on_keypress and
 # quick_release both false) unless they carry a `behavior.one_shot*` delta.
 
@@ -221,12 +224,64 @@ expect = [
   [],
 ]
 
+# The timeout fires even though other keys were tapped during the armed window.
+# Regression: a layer switch neither cancels nor extends the expiry deadline, so
+# the modifier can't stay armed until some later keypress, potentially minutes
+# after the OSM itself.
+[[test]]
+name = "osm_timeout_survives_intervening_keys"
+behavior.one_shot = { timeout = "150ms" }
+steps = [
+  { tap = { pos = [0, 0], duration = 10 } },  # OSM(LShift)
+  { tap = { pos = [3, 0], duration = 10 } },  # MO(1) down and up
+  { delay = 200 },                            # OSM deadline passes in here
+  { tap = { pos = [0, 2], duration = 10 } },
+]
+expect = [
+  ["A"],  # A without LShift (timed out despite the MO tap)
+  [],
+]
+
+# Mouse wheel repeats keep streaming while a one-shot is armed. Regression: the
+# armed wait must not park the keyboard task, which would freeze held-key
+# repeats (and every other timed behavior) until the next key event or the
+# timeout.
+[[test]]
+name = "osm_armed_does_not_stall_mouse_repeats"
+behavior.one_shot = { timeout = "600ms" }
+steps = [
+  { press = [0, 8] },   # Hold MouseWheelUp: initial delta, first repeat due at +100ms
+  { press = [0, 0] },   # OSM(LShift) down
+  { release = [0, 0] }, # OSM(LShift) up and still armed; repeats must continue regardless
+  { delay = 280 },      # covers the repeat ticks at +100/+180/+260ms
+  { release = [0, 8] },
+  { tap = { pos = [0, 2], duration = 10 } },  # Control: OSM still armed here
+]
+expect = [
+  { mouse = { wheel = -1 } },
+  { mouse = { wheel = -1 } },  # repeat while OSM armed
+  { mouse = { wheel = -1 } },  # repeat while OSM armed
+  { mouse = { wheel = -1 } },  # repeat while OSM armed
+  { mouse = {} },
+  ["LShift", "A"],
+  [],
+]
+
 # Quick-release mode (quick_release = true): the modifier drops on key PRESS,
 # so each key report is followed by an unmodified one.
 #
-# `test_osm_quick_release_rolling` was dropped before this port: OSM combined
-# with a morse/tap-hold key has a known bug where the OSM deadline loop times
-# out before the tap resolves.
+# Rolling into a morse/tap-hold key keeps the modifier applied: the expiry
+# deadline runs alongside the pending tap resolution instead of firing before
+# the tap resolves.
+[[test]]
+name = "osm_quick_release_rolling"
+behavior.one_shot_modifiers = { quick_release = true }
+steps = [
+  { tap = { pos = [0, 0], duration = 10 } },
+  { tap = { pos = [0, 3], duration = 10 } },  # TH(B, C) tapped
+]
+expect = [["LShift", "B"], ["B"], []]
+
 [[test]]
 name = "osm_quick_release_multiple_keys"
 behavior.one_shot_modifiers = { quick_release = true }


### PR DESCRIPTION
When a one-shot modifier or layer was released while armed (Single state), the keyboard task waited inline on `select!(Timer::after(timeout), next_event)` until either the timeout expired or another key arrived. This would park the whole task, so held-key repeats, mouse wheel repeats, and every other timed behavior froze until one of those two things happened.

This PR instead stores the expiry as deadlines on the `Keyboard` struct (`osm_deadline`, `osl_deadline`). The main loop in `run()` already races its subscriber against the mouse-repeat deadline; it now races against the earliest of all pending deadlines and calls `fire_oneshot_timeout()` when a one-shot expires.

It also fixes two behavioral bugs:

- Any key event during the armed window used to replace the timer wait (the event went into `unprocessed_events`), so the modifier stayed armed indefinitely if no further key arrived before the original timeout. Intervening keys no longer touch the deadline.
- Quick-release rolling into a tap-hold key had a documented known bug in `one_shot.toml`: the OSM deadline loop timed out before the tap resolved. The roll now applies the modifier correctly.