### PR TITLE
fix(macro): clear diagnostics for invalid keyboard.toml keys and arguments

### DIFF
--- a/examples/use_config/esp32_ble_split/Cargo.lock
+++ b/examples/use_config/esp32_ble_split/Cargo.lock
@@ -2342,6 +2342,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum 0.28.0",
  "syn 2.0.118",
 ]

--- a/examples/use_config/esp32c3_ble/Cargo.lock
+++ b/examples/use_config/esp32c3_ble/Cargo.lock
@@ -2302,6 +2302,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum 0.28.0",
  "syn 2.0.118",
 ]

--- a/examples/use_config/esp32c6_ble/Cargo.lock
+++ b/examples/use_config/esp32c6_ble/Cargo.lock
@@ -2312,6 +2312,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum 0.28.0",
  "syn 2.0.118",
 ]

--- a/examples/use_config/esp32h2_ble/Cargo.lock
+++ b/examples/use_config/esp32h2_ble/Cargo.lock
@@ -2308,6 +2308,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum 0.28.0",
  "syn 2.0.118",
 ]

--- a/examples/use_config/esp32s3_ble/Cargo.lock
+++ b/examples/use_config/esp32s3_ble/Cargo.lock
@@ -2338,6 +2338,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum 0.28.0",
  "syn 2.0.118",
 ]

--- a/examples/use_config/nrf52832_ble/Cargo.lock
+++ b/examples/use_config/nrf52832_ble/Cargo.lock
@@ -1936,6 +1936,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/nrf52840_ble/Cargo.lock
+++ b/examples/use_config/nrf52840_ble/Cargo.lock
@@ -1932,6 +1932,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/nrf52840_ble_split/Cargo.lock
+++ b/examples/use_config/nrf52840_ble_split/Cargo.lock
@@ -1932,6 +1932,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/nrf52840_ble_split_direct_pin/Cargo.lock
+++ b/examples/use_config/nrf52840_ble_split_direct_pin/Cargo.lock
@@ -1932,6 +1932,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/nrf52840_ble_split_dongle/Cargo.lock
+++ b/examples/use_config/nrf52840_ble_split_dongle/Cargo.lock
@@ -1932,6 +1932,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/nrf52840_embassy_boot/Cargo.lock
+++ b/examples/use_config/nrf52840_embassy_boot/Cargo.lock
@@ -1968,6 +1968,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/pi_pico_w_ble/Cargo.lock
+++ b/examples/use_config/pi_pico_w_ble/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/pi_pico_w_ble_split/Cargo.lock
+++ b/examples/use_config/pi_pico_w_ble_split/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/rp2040/Cargo.lock
+++ b/examples/use_config/rp2040/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/rp2040_dfu_split/Cargo.lock
+++ b/examples/use_config/rp2040_dfu_split/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/rp2040_direct_pin/Cargo.lock
+++ b/examples/use_config/rp2040_direct_pin/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/rp2040_embassy_boot/Cargo.lock
+++ b/examples/use_config/rp2040_embassy_boot/Cargo.lock
@@ -2148,6 +2148,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/rp2040_oled/Cargo.lock
+++ b/examples/use_config/rp2040_oled/Cargo.lock
@@ -2231,6 +2231,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/rp2040_pointing_modes/Cargo.lock
+++ b/examples/use_config/rp2040_pointing_modes/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/rp2040_rynk/Cargo.lock
+++ b/examples/use_config/rp2040_rynk/Cargo.lock
@@ -2054,6 +2054,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn",
 ]

--- a/examples/use_config/rp2040_split/Cargo.lock
+++ b/examples/use_config/rp2040_split/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/rp2040_split_pio/Cargo.lock
+++ b/examples/use_config/rp2040_split_pio/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/stm32f1/Cargo.lock
+++ b/examples/use_config/stm32f1/Cargo.lock
@@ -1395,6 +1395,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/stm32f4/Cargo.lock
+++ b/examples/use_config/stm32f4/Cargo.lock
@@ -1850,6 +1850,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_config/stm32h7/Cargo.lock
+++ b/examples/use_config/stm32h7/Cargo.lock
@@ -1431,6 +1431,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/custom_renderer/Cargo.lock
+++ b/examples/use_rust/custom_renderer/Cargo.lock
@@ -1354,6 +1354,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn",
 ]

--- a/examples/use_rust/esp32c3_ble/Cargo.lock
+++ b/examples/use_rust/esp32c3_ble/Cargo.lock
@@ -2326,6 +2326,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum 0.28.0",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/esp32c6_ble/Cargo.lock
+++ b/examples/use_rust/esp32c6_ble/Cargo.lock
@@ -2336,6 +2336,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum 0.28.0",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/esp32h2_ble/Cargo.lock
+++ b/examples/use_rust/esp32h2_ble/Cargo.lock
@@ -2332,6 +2332,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum 0.28.0",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/esp32s3_ble/Cargo.lock
+++ b/examples/use_rust/esp32s3_ble/Cargo.lock
@@ -2338,6 +2338,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum 0.28.0",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/nrf52832_ble/Cargo.lock
+++ b/examples/use_rust/nrf52832_ble/Cargo.lock
@@ -1958,6 +1958,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.117",
 ]

--- a/examples/use_rust/nrf52840/Cargo.lock
+++ b/examples/use_rust/nrf52840/Cargo.lock
@@ -1741,6 +1741,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.117",
 ]

--- a/examples/use_rust/nrf52840_ble/Cargo.lock
+++ b/examples/use_rust/nrf52840_ble/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.117",
 ]

--- a/examples/use_rust/nrf52840_ble_split/Cargo.lock
+++ b/examples/use_rust/nrf52840_ble_split/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.117",
 ]

--- a/examples/use_rust/nrf52840_ble_split_dongle/Cargo.lock
+++ b/examples/use_rust/nrf52840_ble_split_dongle/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.117",
 ]

--- a/examples/use_rust/nrf52840_embassy_boot/Cargo.lock
+++ b/examples/use_rust/nrf52840_embassy_boot/Cargo.lock
@@ -1776,6 +1776,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/nrf54l15_ble/Cargo.lock
+++ b/examples/use_rust/nrf54l15_ble/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.117",
 ]

--- a/examples/use_rust/nrf54lm20_ble/Cargo.lock
+++ b/examples/use_rust/nrf54lm20_ble/Cargo.lock
@@ -1910,6 +1910,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/nrf_dongle/central/Cargo.lock
+++ b/examples/use_rust/nrf_dongle/central/Cargo.lock
@@ -1868,6 +1868,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.119",
 ]

--- a/examples/use_rust/nrf_dongle/dongle/Cargo.lock
+++ b/examples/use_rust/nrf_dongle/dongle/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.119",
 ]

--- a/examples/use_rust/nrf_dongle/peripheral/Cargo.lock
+++ b/examples/use_rust/nrf_dongle/peripheral/Cargo.lock
@@ -1867,6 +1867,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.119",
 ]

--- a/examples/use_rust/pi_pico_w_ble/Cargo.lock
+++ b/examples/use_rust/pi_pico_w_ble/Cargo.lock
@@ -2755,6 +2755,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.117",
 ]

--- a/examples/use_rust/pi_pico_w_ble_split/Cargo.lock
+++ b/examples/use_rust/pi_pico_w_ble_split/Cargo.lock
@@ -2755,6 +2755,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.117",
 ]

--- a/examples/use_rust/qemu-riscv-rynk/Cargo.lock
+++ b/examples/use_rust/qemu-riscv-rynk/Cargo.lock
@@ -1202,6 +1202,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn",
 ]

--- a/examples/use_rust/rp2040/Cargo.lock
+++ b/examples/use_rust/rp2040/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.117",
 ]

--- a/examples/use_rust/rp2040_dfu_split/Cargo.lock
+++ b/examples/use_rust/rp2040_dfu_split/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/rp2040_direct_pin/Cargo.lock
+++ b/examples/use_rust/rp2040_direct_pin/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.117",
 ]

--- a/examples/use_rust/rp2040_embassy_boot/Cargo.lock
+++ b/examples/use_rust/rp2040_embassy_boot/Cargo.lock
@@ -2151,6 +2151,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.117",
 ]

--- a/examples/use_rust/rp2040_embassy_boot_split/Cargo.lock
+++ b/examples/use_rust/rp2040_embassy_boot_split/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/rp2040_oled/Cargo.lock
+++ b/examples/use_rust/rp2040_oled/Cargo.lock
@@ -2098,6 +2098,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/rp2040_pointing_modes/Cargo.lock
+++ b/examples/use_rust/rp2040_pointing_modes/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.117",
 ]

--- a/examples/use_rust/rp2040_split/Cargo.lock
+++ b/examples/use_rust/rp2040_split/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/rp2040_split_pio/Cargo.lock
+++ b/examples/use_rust/rp2040_split_pio/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/rp2350/Cargo.lock
+++ b/examples/use_rust/rp2350/Cargo.lock
@@ -2094,6 +2094,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/stm32f1/Cargo.lock
+++ b/examples/use_rust/stm32f1/Cargo.lock
@@ -1392,6 +1392,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/stm32f4/Cargo.lock
+++ b/examples/use_rust/stm32f4/Cargo.lock
@@ -1850,6 +1850,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/stm32g4/Cargo.lock
+++ b/examples/use_rust/stm32g4/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/examples/use_rust/stm32h7/Cargo.lock
+++ b/examples/use_rust/stm32h7/Cargo.lock
@@ -1846,6 +1846,7 @@ dependencies = [
  "quote",
  "rmk-config",
  "rmk-types",
+ "strsim",
  "strum",
  "syn 2.0.118",
 ]

--- a/rmk-macro/Cargo.toml
+++ b/rmk-macro/Cargo.toml
@@ -18,6 +18,7 @@ proc-macro2 = "1.0"
 darling = "0.23"
 cargo_toml = "1"
 strum = { version = "0.28", default-features = false, features = ["derive"] }
+strsim = "0.11"
 # Simulator scenario parsing only (`_simulator`). Rynk payloads are handed to
 # the test as JSON, so the request type is named once, in the test crate.
 toml = { version = "1", optional = true }

--- a/rmk-macro/src/codegen/action_parser.rs
+++ b/rmk-macro/src/codegen/action_parser.rs
@@ -11,23 +11,13 @@ use rmk_config::resolved::KEYCODE_ALIAS;
 use rmk_config::resolved::behavior::MorseProfile;
 use strum::VariantNames;
 
+#[derive(Default)]
 struct ModifierCombinationMacro {
     right: bool,
     gui: bool,
     alt: bool,
     shift: bool,
     ctrl: bool,
-}
-impl ModifierCombinationMacro {
-    fn new() -> Self {
-        Self {
-            right: false,
-            gui: false,
-            alt: false,
-            shift: false,
-            ctrl: false,
-        }
-    }
 }
 // Allows to use `#modifiers` in the quote
 impl quote::ToTokens for ModifierCombinationMacro {
@@ -46,8 +36,7 @@ impl quote::ToTokens for ModifierCombinationMacro {
 
 /// Get modifier combination, in types of mod1 | mod2 | ...
 fn parse_modifiers(modifiers_str: &str) -> ModifierCombinationMacro {
-    type ModifierSetter = fn(&mut ModifierCombinationMacro);
-    const MODIFIERS: &[(&str, ModifierSetter)] = &[
+    const MODIFIERS: &SetterTable<ModifierCombinationMacro> = &[
         ("LShift", |c| c.shift = true),
         ("LCtrl", |c| c.ctrl = true),
         ("LAlt", |c| c.alt = true),
@@ -70,30 +59,57 @@ fn parse_modifiers(modifiers_str: &str) -> ModifierCombinationMacro {
         }),
     ];
 
-    let mut combination = ModifierCombinationMacro::new();
-    let mut unknown_modifiers = Vec::new();
+    parse_name_list(
+        modifiers_str,
+        "modifier",
+        "modifier combination",
+        MODIFIERS,
+        |w| {
+            KEYCODE_ALIAS
+                .get(w.to_lowercase().as_str())
+                .copied()
+                .unwrap_or(w)
+        },
+    )
+}
+
+/// A name -> setter lookup table for [`parse_name_list`]: each entry maps a
+/// `|`-separated token to a setter applied to the accumulated value.
+pub(crate) type SetterTable<T> = [(&'static str, fn(&mut T))];
+
+/// Resolve each `|`-separated token of `input` against a name->setter table,
+/// applying every match to the returned value. Panics on unknown tokens
+/// (with closest-name hints) and on empty segments between separators.
+pub(crate) fn parse_name_list<T>(
+    input: &str,
+    item: &str,
+    kind: &str,
+    table: &SetterTable<T>,
+    resolve_alias: impl Fn(&str) -> &str,
+) -> T
+where
+    T: Default,
+{
+    let mut value = T::default();
+    let mut unknown_tokens = Vec::new();
     let mut has_empty_segment = false;
-    modifiers_str.split("|").for_each(|w| {
+    input.split("|").for_each(|w| {
         let w = w.trim();
         if w.is_empty() {
             has_empty_segment = true;
             return;
         }
-        let key = KEYCODE_ALIAS
-            .get(w.to_lowercase().as_str())
-            .copied()
-            .unwrap_or(w);
-        match MODIFIERS.iter().find(|(name, _)| *name == key) {
-            Some((_, set)) => set(&mut combination),
-            None => unknown_modifiers.push(w.to_string()),
+        match table.iter().find(|(name, _)| *name == resolve_alias(w)) {
+            Some((_, set)) => set(&mut value),
+            None => unknown_tokens.push(w.to_string()),
         }
     });
 
-    if !unknown_modifiers.is_empty() {
-        let unknown = unknown_modifiers
+    if !unknown_tokens.is_empty() {
+        let unknown = unknown_tokens
             .iter()
             .map(
-                |u| match closest_name(u, MODIFIERS.iter().map(|(name, _)| *name)) {
+                |u| match closest_name(u, table.iter().map(|(name, _)| *name)) {
                     Some(s) => format!("{u} (did you mean {s}?)"),
                     None => u.clone(),
                 },
@@ -101,20 +117,20 @@ fn parse_modifiers(modifiers_str: &str) -> ModifierCombinationMacro {
             .collect::<Vec<_>>()
             .join(", ");
         panic!(
-            "\n❌ keyboard.toml: unknown modifier(s) [{}] in modifier combination '{}'",
+            "\n❌ keyboard.toml: unknown {item}(s) [{}] in {kind} '{}'",
             unknown,
-            modifiers_str.trim()
+            input.trim()
         );
     }
 
     if has_empty_segment {
         panic!(
-            "\n❌ keyboard.toml: modifier combination '{}' contains empty segments between '|' separators",
-            modifiers_str.trim()
+            "\n❌ keyboard.toml: {kind} '{}' contains empty segments between '|' separators",
+            input.trim()
         );
     }
 
-    combination
+    value
 }
 
 /// Suggest the most similar valid name for an unrecognized token, or `None`

--- a/rmk-macro/src/codegen/action_parser.rs
+++ b/rmk-macro/src/codegen/action_parser.rs
@@ -90,15 +90,20 @@ fn parse_modifiers(modifiers_str: &str) -> ModifierCombinationMacro {
     });
 
     if !unknown_modifiers.is_empty() {
+        let unknown = unknown_modifiers
+            .iter()
+            .map(
+                |u| match closest_name(u, MODIFIERS.iter().map(|(name, _)| *name)) {
+                    Some(s) => format!("{u} (did you mean {s}?)"),
+                    None => u.clone(),
+                },
+            )
+            .collect::<Vec<_>>()
+            .join(", ");
         panic!(
-            "\n❌ keyboard.toml: unknown modifier(s) [{}] in modifier combination '{}'. Expected one of: {}",
-            unknown_modifiers.join(", "),
-            modifiers_str.trim(),
-            MODIFIERS
-                .iter()
-                .map(|(name, _)| *name)
-                .collect::<Vec<_>>()
-                .join(", ")
+            "\n❌ keyboard.toml: unknown modifier(s) [{}] in modifier combination '{}'",
+            unknown,
+            modifiers_str.trim()
         );
     }
 
@@ -110,6 +115,20 @@ fn parse_modifiers(modifiers_str: &str) -> ModifierCombinationMacro {
     }
 
     combination
+}
+
+/// Suggest the most similar valid name for an unrecognized token, or `None`
+/// when nothing is close enough to be a plausible typo of it.
+pub(crate) fn closest_name<'a>(
+    input: &str,
+    names: impl Iterator<Item = &'a str>,
+) -> Option<&'a str> {
+    let lowercased = input.to_lowercase();
+    let (distance, name) = names
+        .map(|name| (strsim::levenshtein(&lowercased, &name.to_lowercase()), name))
+        .min_by_key(|&(distance, _)| distance)?;
+    // rustc-style cutoff: allow roughly one edit per three characters
+    (distance <= 1 + input.len() / 3).then_some(name)
 }
 
 pub(crate) fn expand_profile(profile: &MorseProfile) -> proc_macro2::TokenStream {
@@ -181,10 +200,7 @@ pub(crate) fn expand_profile_name(
             let morse_profile = expand_profile(profile);
             quote! { #morse_profile }
         } else {
-            panic!(
-                "\n\u{274c} `{:?}` profile name is not found in behavior.morse.profiles",
-                profile_name
-            );
+            panic_unknown_profile(profile_name, profiles.keys().map(String::as_str));
         }
     } else {
         panic!(
@@ -473,12 +489,25 @@ fn morse_profile(
         .position(|n| n == name)
     {
         Some(pos) => pos as u8,
-        None => panic!(
-            "\n\u{274c} `{:?}` profile name is not found in behavior.morse.profiles",
-            name
+        None => panic_unknown_profile(
+            name,
+            sorted_profile_names(profiles).iter().map(String::as_str),
         ),
     };
     quote! { #idx }
+}
+
+/// Panic for a failed morse-profile lookup, suggesting the nearest defined
+/// name when one plausibly matches.
+fn panic_unknown_profile<'a>(name: &str, known: impl Iterator<Item = &'a str>) -> ! {
+    let hint = match closest_name(name, known) {
+        Some(s) => format!(" (did you mean {s}?)"),
+        None => String::new(),
+    };
+    panic!(
+        "\n\u{274c} keyboard.toml: `{:?}` profile name is not found in behavior.morse.profiles{hint}",
+        name
+    )
 }
 
 /// Parse the single layer-index argument of a call-form layer action, e.g. `MO(1)`.
@@ -672,7 +701,16 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unknown modifier(s) [LCtrol]")]
+    #[should_panic(
+        expected = "`\"home_roww\"` profile name is not found in behavior.morse.profiles (did you mean home_row?)"
+    )]
+    fn morse_profile_suggests_closest_defined_profile() {
+        let profiles = Some(HashMap::from([("home_row".to_string(), profile(None))]));
+        let _ = parse_key("TH(Space, Enter, home_roww)".to_string(), &profiles);
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown modifier(s) [LCtrol (did you mean LCtrl?)]")]
     fn parse_modifiers_rejects_unknown_name_in_list() {
         let _ = parse_modifiers("LShift | LCtrol");
     }

--- a/rmk-macro/src/codegen/action_parser.rs
+++ b/rmk-macro/src/codegen/action_parser.rs
@@ -28,9 +28,6 @@ impl ModifierCombinationMacro {
             ctrl: false,
         }
     }
-    fn is_empty(&self) -> bool {
-        !(self.gui || self.alt || self.shift || self.ctrl)
-    }
 }
 // Allows to use `#modifiers` in the quote
 impl quote::ToTokens for ModifierCombinationMacro {
@@ -75,9 +72,13 @@ fn parse_modifiers(modifiers_str: &str) -> ModifierCombinationMacro {
 
     let mut combination = ModifierCombinationMacro::new();
     let mut unknown_modifiers = Vec::new();
-    let tokens = modifiers_str.split_terminator("|");
-    tokens.for_each(|w| {
+    let mut has_empty_segment = false;
+    modifiers_str.split("|").for_each(|w| {
         let w = w.trim();
+        if w.is_empty() {
+            has_empty_segment = true;
+            return;
+        }
         let key = KEYCODE_ALIAS
             .get(w.to_lowercase().as_str())
             .copied()
@@ -90,7 +91,7 @@ fn parse_modifiers(modifiers_str: &str) -> ModifierCombinationMacro {
 
     if !unknown_modifiers.is_empty() {
         panic!(
-            "\n❌ keyboard.toml: unknown modifier(s) [{}] in modifier combination '{}'. Expected one of: {}.",
+            "\n❌ keyboard.toml: unknown modifier(s) [{}] in modifier combination '{}'. Expected one of: {}",
             unknown_modifiers.join(", "),
             modifiers_str.trim(),
             MODIFIERS
@@ -98,6 +99,13 @@ fn parse_modifiers(modifiers_str: &str) -> ModifierCombinationMacro {
                 .map(|(name, _)| *name)
                 .collect::<Vec<_>>()
                 .join(", ")
+        );
+    }
+
+    if has_empty_segment {
+        panic!(
+            "\n❌ keyboard.toml: modifier combination '{}' contains empty segments between '|' separators",
+            modifiers_str.trim()
         );
     }
 
@@ -239,26 +247,14 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
         return quote! { ::rmk::types::action::Action::No };
     } else if lower.starts_with("mod(") {
         let modifiers = parse_modifiers(strip_call(key));
-        if modifiers.is_empty() {
-            panic!(
-                "\n\u{274c} keyboard.toml: modifier in MOD(modifier) is not valid!"
-            );
-        }
         return quote! { ::rmk::types::action::Action::Modifier(#modifiers) };
     } else if lower.starts_with("wm(") {
         let keys = split_top_level(strip_call(key));
         if keys.len() != 2 {
-            panic!(
-                "\n\u{274c} keyboard.toml: WM(key, modifier) invalid"
-            );
+            panic!("\n\u{274c} keyboard.toml: WM(key, modifier) invalid");
         }
         let ident = get_key_with_alias(keys[0].clone());
         let modifiers = parse_modifiers(&keys[1]);
-        if modifiers.is_empty() {
-            panic!(
-                "\n\u{274c} keyboard.toml: modifier in WM(key, modifier) is not valid!"
-            );
-        }
         return quote! {
             ::rmk::types::action::Action::KeyWithModifier(
                 ::rmk::types::keycode::HidKeyCode::#ident,
@@ -267,26 +263,14 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
         };
     } else if lower.starts_with("osm(") {
         let modifiers = parse_modifiers(strip_call(key));
-        if modifiers.is_empty() {
-            panic!(
-                "\n\u{274c} keyboard.toml: modifier in OSM(modifier) is not valid!"
-            );
-        }
         return quote! { ::rmk::types::action::Action::OneShotModifier(#modifiers) };
     } else if lower.starts_with("lm(") {
         let keys = split_top_level(strip_call(key));
         if keys.len() != 2 {
-            panic!(
-                "\n\u{274c} keyboard.toml: LM(layer, modifier) invalid"
-            );
+            panic!("\n\u{274c} keyboard.toml: LM(layer, modifier) invalid");
         }
         let layer = keys[0].parse::<u8>().unwrap();
         let modifiers = parse_modifiers(&keys[1]);
-        if modifiers.is_empty() {
-            panic!(
-                "\n\u{274c} keyboard.toml: modifier in LM(layer, modifier) is not valid!"
-            );
-        }
         return quote! { ::rmk::types::action::Action::LayerOnWithModifier(#layer, #modifiers) };
     } else if lower.starts_with("mo(") {
         let layer = parse_layer(key);
@@ -312,9 +296,7 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
     } else if lower.starts_with("shifted(") {
         let internal = strip_call(key);
         if internal.is_empty() {
-            panic!(
-                "\n\u{274c} keyboard.toml: SHIFTED(key) invalid"
-            );
+            panic!("\n\u{274c} keyboard.toml: SHIFTED(key) invalid");
         }
         let ident = get_key_with_alias(internal.to_string());
         return quote! {
@@ -420,17 +402,10 @@ pub(crate) fn parse_key(
     if lower.starts_with("mt(") {
         let keys = split_top_level(strip_call(&key));
         if keys.len() < 2 || keys.len() > 3 {
-            panic!(
-                "\n\u{274c} keyboard.toml: MT(key, modifier) invalid"
-            );
+            panic!("\n\u{274c} keyboard.toml: MT(key, modifier) invalid");
         }
         let tap = parse_action(&keys[0]);
         let modifiers = parse_modifiers(&keys[1]);
-        if modifiers.is_empty() {
-            panic!(
-                "\n\u{274c} keyboard.toml: modifier in MT(key, modifier) is not valid!"
-            );
-        }
         let profile = morse_profile(keys.get(2), profiles);
         quote! {
             ::rmk::types::action::KeyAction::TapHold(#tap, ::rmk::types::action::Action::Modifier(#modifiers), #profile)
@@ -438,9 +413,7 @@ pub(crate) fn parse_key(
     } else if lower.starts_with("th(") {
         let keys = split_top_level(strip_call(&key));
         if keys.len() < 2 || keys.len() > 3 {
-            panic!(
-                "\n\u{274c} keyboard.toml: TH(key_tap, key_hold) invalid"
-            );
+            panic!("\n\u{274c} keyboard.toml: TH(key_tap, key_hold) invalid");
         }
         let tap = parse_action(&keys[0]);
         let hold = parse_action(&keys[1]);
@@ -449,9 +422,7 @@ pub(crate) fn parse_key(
     } else if lower.starts_with("lt(") {
         let keys = split_top_level(strip_call(&key));
         if keys.len() < 2 || keys.len() > 3 {
-            panic!(
-                "\n\u{274c} keyboard.toml: LT(layer, key) invalid"
-            );
+            panic!("\n\u{274c} keyboard.toml: LT(layer, key) invalid");
         }
         let layer = keys[0].parse::<u8>().unwrap();
         let tap = parse_action(&keys[1]);
@@ -704,5 +675,17 @@ mod tests {
     #[should_panic(expected = "unknown modifier(s) [LCtrol]")]
     fn parse_modifiers_rejects_unknown_name_in_list() {
         let _ = parse_modifiers("LShift | LCtrol");
+    }
+
+    #[test]
+    #[should_panic(expected = "empty segment")]
+    fn parse_modifiers_rejects_trailing_separator() {
+        let _ = parse_modifiers("LShift |");
+    }
+
+    #[test]
+    #[should_panic(expected = "empty segment")]
+    fn parse_modifiers_rejects_doubled_separator() {
+        let _ = parse_modifiers("LShift || LCtrl");
     }
 }

--- a/rmk-macro/src/codegen/action_parser.rs
+++ b/rmk-macro/src/codegen/action_parser.rs
@@ -49,38 +49,58 @@ impl quote::ToTokens for ModifierCombinationMacro {
 
 /// Get modifier combination, in types of mod1 | mod2 | ...
 fn parse_modifiers(modifiers_str: &str) -> ModifierCombinationMacro {
+    type ModifierSetter = fn(&mut ModifierCombinationMacro);
+    const MODIFIERS: &[(&str, ModifierSetter)] = &[
+        ("LShift", |c| c.shift = true),
+        ("LCtrl", |c| c.ctrl = true),
+        ("LAlt", |c| c.alt = true),
+        ("LGui", |c| c.gui = true),
+        ("RShift", |c| {
+            c.right = true;
+            c.shift = true;
+        }),
+        ("RCtrl", |c| {
+            c.right = true;
+            c.ctrl = true;
+        }),
+        ("RAlt", |c| {
+            c.right = true;
+            c.alt = true;
+        }),
+        ("RGui", |c| {
+            c.right = true;
+            c.gui = true;
+        }),
+    ];
+
     let mut combination = ModifierCombinationMacro::new();
+    let mut unknown_modifiers = Vec::new();
     let tokens = modifiers_str.split_terminator("|");
     tokens.for_each(|w| {
         let w = w.trim();
-        let key = match KEYCODE_ALIAS.get(w.to_lowercase().as_str()) {
-            Some(k) => *k,
-            None => w,
-        };
-        match key {
-            "LShift" => combination.shift = true,
-            "LCtrl" => combination.ctrl = true,
-            "LAlt" => combination.alt = true,
-            "LGui" => combination.gui = true,
-            "RShift" => {
-                combination.right = true;
-                combination.shift = true;
-            }
-            "RCtrl" => {
-                combination.right = true;
-                combination.ctrl = true;
-            }
-            "RAlt" => {
-                combination.right = true;
-                combination.alt = true;
-            }
-            "RGui" => {
-                combination.right = true;
-                combination.gui = true;
-            }
-            _ => (),
+        let key = KEYCODE_ALIAS
+            .get(w.to_lowercase().as_str())
+            .copied()
+            .unwrap_or(w);
+        match MODIFIERS.iter().find(|(name, _)| *name == key) {
+            Some((_, set)) => set(&mut combination),
+            None => unknown_modifiers.push(w.to_string()),
         }
     });
+
+    if !unknown_modifiers.is_empty() {
+        panic!(
+            "\n❌ keyboard.toml: unknown modifier(s) [{}] in modifier combination '{}'. Expected one of: {}.",
+            unknown_modifiers.join(", "),
+            modifiers_str.trim(),
+            MODIFIERS
+                .iter()
+                .map(|(name, _)| *name)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
     combination
 }
 
@@ -221,7 +241,7 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
         let modifiers = parse_modifiers(strip_call(key));
         if modifiers.is_empty() {
             panic!(
-                "\n\u{274c} keyboard.toml: modifier in MOD(modifier) is not valid! Please check the documentation: https://rmk.rs/docs/features/configuration/layout.html"
+                "\n\u{274c} keyboard.toml: modifier in MOD(modifier) is not valid!"
             );
         }
         return quote! { ::rmk::types::action::Action::Modifier(#modifiers) };
@@ -229,14 +249,14 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
         let keys = split_top_level(strip_call(key));
         if keys.len() != 2 {
             panic!(
-                "\n\u{274c} keyboard.toml: WM(key, modifier) invalid, please check the documentation: https://rmk.rs/docs/features/configuration/layout.html"
+                "\n\u{274c} keyboard.toml: WM(key, modifier) invalid"
             );
         }
         let ident = get_key_with_alias(keys[0].clone());
         let modifiers = parse_modifiers(&keys[1]);
         if modifiers.is_empty() {
             panic!(
-                "\n\u{274c} keyboard.toml: modifier in WM(key, modifier) is not valid! Please check the documentation: https://rmk.rs/docs/features/configuration/layout.html"
+                "\n\u{274c} keyboard.toml: modifier in WM(key, modifier) is not valid!"
             );
         }
         return quote! {
@@ -249,7 +269,7 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
         let modifiers = parse_modifiers(strip_call(key));
         if modifiers.is_empty() {
             panic!(
-                "\n\u{274c} keyboard.toml: modifier in OSM(modifier) is not valid! Please check the documentation: https://rmk.rs/docs/features/configuration/layout.html"
+                "\n\u{274c} keyboard.toml: modifier in OSM(modifier) is not valid!"
             );
         }
         return quote! { ::rmk::types::action::Action::OneShotModifier(#modifiers) };
@@ -257,14 +277,14 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
         let keys = split_top_level(strip_call(key));
         if keys.len() != 2 {
             panic!(
-                "\n\u{274c} keyboard.toml: LM(layer, modifier) invalid, please check the documentation: https://rmk.rs/docs/features/configuration/layout.html"
+                "\n\u{274c} keyboard.toml: LM(layer, modifier) invalid"
             );
         }
         let layer = keys[0].parse::<u8>().unwrap();
         let modifiers = parse_modifiers(&keys[1]);
         if modifiers.is_empty() {
             panic!(
-                "\n\u{274c} keyboard.toml: modifier in LM(layer, modifier) is not valid! Please check the documentation: https://rmk.rs/docs/features/configuration/layout.html"
+                "\n\u{274c} keyboard.toml: modifier in LM(layer, modifier) is not valid!"
             );
         }
         return quote! { ::rmk::types::action::Action::LayerOnWithModifier(#layer, #modifiers) };
@@ -293,7 +313,7 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
         let internal = strip_call(key);
         if internal.is_empty() {
             panic!(
-                "\n\u{274c} keyboard.toml: SHIFTED(key) invalid, please check the documentation: https://rmk.rs/docs/features/configuration/layout.html"
+                "\n\u{274c} keyboard.toml: SHIFTED(key) invalid"
             );
         }
         let ident = get_key_with_alias(internal.to_string());
@@ -324,7 +344,7 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
         let number = number_str.parse::<u8>().unwrap_or(255);
         if number > 31 {
             panic!(
-                "\n\u{274c} keyboard.toml: {} is not a valid user key! User keys are numbered 0-31. Please check the documentation: https://rmk.rs/docs/features/configuration/layout.html",
+                "\n\u{274c} keyboard.toml: {} is not a valid user key! User keys are numbered 0-31.",
                 key
             );
         }
@@ -401,14 +421,14 @@ pub(crate) fn parse_key(
         let keys = split_top_level(strip_call(&key));
         if keys.len() < 2 || keys.len() > 3 {
             panic!(
-                "\n\u{274c} keyboard.toml: MT(key, modifier) invalid, please check the documentation: https://rmk.rs/docs/features/configuration/layout.html"
+                "\n\u{274c} keyboard.toml: MT(key, modifier) invalid"
             );
         }
         let tap = parse_action(&keys[0]);
         let modifiers = parse_modifiers(&keys[1]);
         if modifiers.is_empty() {
             panic!(
-                "\n\u{274c} keyboard.toml: modifier in MT(key, modifier) is not valid! Please check the documentation: https://rmk.rs/docs/features/configuration/layout.html"
+                "\n\u{274c} keyboard.toml: modifier in MT(key, modifier) is not valid!"
             );
         }
         let profile = morse_profile(keys.get(2), profiles);
@@ -419,7 +439,7 @@ pub(crate) fn parse_key(
         let keys = split_top_level(strip_call(&key));
         if keys.len() < 2 || keys.len() > 3 {
             panic!(
-                "\n\u{274c} keyboard.toml: TH(key_tap, key_hold) invalid, please check the documentation: https://rmk.rs/docs/features/configuration/layout.html"
+                "\n\u{274c} keyboard.toml: TH(key_tap, key_hold) invalid"
             );
         }
         let tap = parse_action(&keys[0]);
@@ -430,7 +450,7 @@ pub(crate) fn parse_key(
         let keys = split_top_level(strip_call(&key));
         if keys.len() < 2 || keys.len() > 3 {
             panic!(
-                "\n\u{274c} keyboard.toml: LT(layer, key) invalid, please check the documentation: https://rmk.rs/docs/features/configuration/layout.html"
+                "\n\u{274c} keyboard.toml: LT(layer, key) invalid"
             );
         }
         let layer = keys[0].parse::<u8>().unwrap();
@@ -668,5 +688,21 @@ mod tests {
                 .contains("TapHold(::rmk::types::action::Action::Key")
         );
         assert!(squash(&expand("LT(2, Enter)")).contains("Action::LayerOn(2u8)"));
+    }
+
+    #[test]
+    fn parse_modifiers_resolves_canonical_and_alias_names() {
+        let m = parse_modifiers("LCtrl | lcmd | algr");
+        assert!(m.ctrl);
+        assert!(m.gui);
+        assert!(m.alt);
+        assert!(m.right);
+        assert!(!m.shift);
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown modifier(s) [LCtrol]")]
+    fn parse_modifiers_rejects_unknown_name_in_list() {
+        let _ = parse_modifiers("LShift | LCtrol");
     }
 }

--- a/rmk-macro/src/codegen/action_parser.rs
+++ b/rmk-macro/src/codegen/action_parser.rs
@@ -375,31 +375,19 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
         return quote! { ::rmk::types::action::Action::TriggerMacro(#index) };
     }
 
-    // Check if it's a keyboard control, light control, or special key action (case-insensitive).
-    // Use strum::VariantNames to automatically get all enum variants.
-    if let Some(action) = rmk_types::action::KeyboardAction::VARIANTS
-        .iter()
-        .find(|&&a| a.to_lowercase() == lower)
-    {
-        let action_ident = format_ident!("{}", action);
+    // Check if it's a keyboard control, light control, or special key action
+    // (case-insensitive), matching against each enum's variant names.
+    if let Some(action_ident) = match_variant(rmk_types::action::KeyboardAction::VARIANTS, &lower) {
         return quote! {
             ::rmk::types::action::Action::KeyboardControl(::rmk::types::action::KeyboardAction::#action_ident)
         };
     }
-    if let Some(action) = rmk_types::action::LightAction::VARIANTS
-        .iter()
-        .find(|&&a| a.to_lowercase() == lower)
-    {
-        let action_ident = format_ident!("{}", action);
+    if let Some(action_ident) = match_variant(rmk_types::action::LightAction::VARIANTS, &lower) {
         return quote! {
             ::rmk::types::action::Action::Light(::rmk::types::action::LightAction::#action_ident)
         };
     }
-    if let Some(special_key) = rmk_types::keycode::SpecialKey::VARIANTS
-        .iter()
-        .find(|&&k| k.to_lowercase() == lower)
-    {
-        let key_ident = format_ident!("{}", special_key);
+    if let Some(key_ident) = match_variant(rmk_types::keycode::SpecialKey::VARIANTS, &lower) {
         return quote! {
             ::rmk::types::action::Action::Special(::rmk::types::keycode::SpecialKey::#key_ident)
         };
@@ -531,8 +519,37 @@ fn parse_layer(key: &str) -> u8 {
     strip_call(key).trim().parse::<u8>().unwrap()
 }
 
+/// Case-insensitively match a token against an enum's variant names,
+/// expanding the match to that variant's identifier.
+fn match_variant(names: &[&str], lower: &str) -> Option<Ident> {
+    names
+        .iter()
+        .find(|&&v| v.to_lowercase() == lower)
+        .map(|v| format_ident!("{v}"))
+}
+
 pub(crate) fn get_key_with_alias(key: String) -> Ident {
-    format_ident!("{}", resolve_alias(&key))
+    match as_hid_keycode(&key) {
+        Some(ident) => ident,
+        None => unknown_key_panic(&key),
+    }
+}
+
+/// Panic for a key token matching no known form, suggesting the nearest valid
+/// name from any vocabulary. Everything reaching this used to emit an
+/// identifier that only failed deep inside the generated code.
+fn unknown_key_panic(key: &str) -> ! {
+    let names = rmk_types::action::KeyboardAction::VARIANTS
+        .iter()
+        .chain(rmk_types::action::LightAction::VARIANTS.iter())
+        .chain(rmk_types::keycode::SpecialKey::VARIANTS.iter())
+        .chain(rmk_types::keycode::HidKeyCode::VARIANTS.iter())
+        .copied();
+    let hint = match closest_name(key, names) {
+        Some(s) => format!(" (did you mean {s}?)"),
+        None => String::new(),
+    };
+    panic!("\n\u{274c} keyboard.toml: unknown key '{key}'{hint}")
 }
 
 /// The `HidKeyCode` variant a key string names, or `None` when it names a richer
@@ -723,6 +740,40 @@ mod tests {
     fn morse_profile_suggests_closest_defined_profile() {
         let profiles = Some(HashMap::from([("home_row".to_string(), profile(None))]));
         let _ = parse_key("TH(Space, Enter, home_roww)".to_string(), &profiles);
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown key 'Spacee' (did you mean Space?)")]
+    fn unknown_keycode_suggests_closest_key() {
+        let _ = expand("Spacee");
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown key 'Bootloade' (did you mean Bootloader?)")]
+    fn unknown_action_suggests_closest_action() {
+        let _ = expand("Bootloade");
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown key 'Spacee'")]
+    fn composite_action_tap_slot_validates_its_key() {
+        let _ = expand("WM(Spacee, RAlt)");
+    }
+
+    #[test]
+    fn far_off_key_gets_no_hint() {
+        let msg = std::panic::catch_unwind(|| expand("ZqZqZq99"))
+            .unwrap_err()
+            .downcast::<String>()
+            .unwrap();
+        assert!(msg.contains("unknown key 'ZqZqZq99'"), "{msg}");
+        // Nothing within the cutoff, so no fabricated suggestion.
+        assert!(!msg.contains("did you mean"), "{msg}");
+    }
+
+    #[test]
+    fn alias_resolution_survives_validated_lookup() {
+        assert!(squash(&expand("lcmd")).contains("HidKeyCode::LGui"));
     }
 
     #[test]

--- a/rmk-macro/src/codegen/action_parser.rs
+++ b/rmk-macro/src/codegen/action_parser.rs
@@ -301,7 +301,7 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
         if keys.len() != 2 {
             panic!("\n\u{274c} keyboard.toml: LM(layer, modifier) invalid");
         }
-        let layer = keys[0].parse::<u8>().unwrap();
+        let layer = parse_numeric_arg(&keys[0], "layer");
         let modifiers = parse_modifiers(&keys[1]);
         return quote! { ::rmk::types::action::Action::LayerOnWithModifier(#layer, #modifiers) };
     } else if lower.starts_with("mo(") {
@@ -323,7 +323,7 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
         let layer = parse_layer(key);
         return quote! { ::rmk::types::action::Action::DefaultLayer(#layer) };
     } else if lower.starts_with("macro(") {
-        let index = strip_call(key).trim().parse::<u8>().unwrap();
+        let index = parse_numeric_arg(strip_call(key), "macro");
         return quote! { ::rmk::types::action::Action::TriggerMacro(#index) };
     } else if lower.starts_with("shifted(") {
         let internal = strip_call(key);
@@ -371,7 +371,7 @@ pub(crate) fn parse_action(key: &str) -> TokenStream2 {
             .unwrap_or(false)
     {
         // Support Macro0, Macro1, Macro2, etc.
-        let index = key[5..].parse::<u8>().unwrap();
+        let index = parse_numeric_arg(&key[5..], "macro");
         return quote! { ::rmk::types::action::Action::TriggerMacro(#index) };
     }
 
@@ -444,7 +444,7 @@ pub(crate) fn parse_key(
         if keys.len() < 2 || keys.len() > 3 {
             panic!("\n\u{274c} keyboard.toml: LT(layer, key) invalid");
         }
-        let layer = keys[0].parse::<u8>().unwrap();
+        let layer = parse_numeric_arg(&keys[0], "layer");
         let tap = parse_action(&keys[1]);
         let profile = morse_profile(keys.get(2), profiles);
         quote! {
@@ -454,7 +454,7 @@ pub(crate) fn parse_key(
         let layer = parse_layer(&key);
         quote! { ::rmk::tt!(#layer) }
     } else if lower.starts_with("td(") || lower.starts_with("morse(") {
-        let index = strip_call(&key).trim().parse::<u8>().unwrap();
+        let index = parse_numeric_arg(strip_call(&key), "morse");
         quote! { ::rmk::types::action::KeyAction::Morse(#index) }
     } else {
         let action = parse_action(&key);
@@ -516,7 +516,15 @@ fn panic_unknown_profile<'a>(name: &str, known: impl Iterator<Item = &'a str>) -
 
 /// Parse the single layer-index argument of a call-form layer action, e.g. `MO(1)`.
 fn parse_layer(key: &str) -> u8 {
-    strip_call(key).trim().parse::<u8>().unwrap()
+    parse_numeric_arg(strip_call(key), "layer")
+}
+
+/// Parse a numeric action argument (layer or macro/morse index), rejecting
+/// malformed values with context instead of an opaque ParseIntError.
+fn parse_numeric_arg(raw: &str, kind: &str) -> u8 {
+    raw.trim().parse::<u8>().unwrap_or_else(|_| {
+        panic!("\n\u{274c} keyboard.toml: {kind} index must be a number, got '{raw}'")
+    })
 }
 
 /// Case-insensitively match a token against an enum's variant names,
@@ -774,6 +782,24 @@ mod tests {
     #[test]
     fn alias_resolution_survives_validated_lookup() {
         assert!(squash(&expand("lcmd")).contains("HidKeyCode::LGui"));
+    }
+
+    #[test]
+    #[should_panic(expected = "layer index must be a number, got 'two'")]
+    fn invalid_layer_index_is_reported_in_context() {
+        let _ = expand("MO(two)");
+    }
+
+    #[test]
+    #[should_panic(expected = "morse index must be a number, got 'x'")]
+    fn invalid_morse_index_is_reported_in_context() {
+        let _ = expand("TD(x)");
+    }
+
+    #[test]
+    #[should_panic(expected = "macro index must be a number, got '9x'")]
+    fn invalid_macro_number_form_is_reported_in_context() {
+        let _ = expand("Macro9x");
     }
 
     #[test]

--- a/rmk-macro/src/codegen/behavior.rs
+++ b/rmk-macro/src/codegen/behavior.rs
@@ -10,8 +10,8 @@ use rmk_config::resolved::behavior::{
 };
 
 use super::action_parser::{
-    as_hid_keycode, expand_profile, expand_profile_name, get_key_with_alias, parse_action,
-    parse_key, sorted_profile_names,
+    as_hid_keycode, closest_name, expand_profile, expand_profile_name, get_key_with_alias,
+    parse_action, parse_key, sorted_profile_names,
 };
 use super::feature::{get_rmk_features, is_feature_enabled};
 
@@ -503,15 +503,20 @@ fn parse_state_combination(states_str: &str) -> StateBitsMacro {
     });
 
     if !unknown_states.is_empty() {
+        let unknown = unknown_states
+            .iter()
+            .map(
+                |u| match closest_name(u, STATES.iter().map(|(name, _)| *name)) {
+                    Some(s) => format!("{u} (did you mean {s}?)"),
+                    None => u.clone(),
+                },
+            )
+            .collect::<Vec<_>>()
+            .join(", ");
         panic!(
-            "\n❌ keyboard.toml: unknown state(s) [{}] in fork state '{}'. Expected one of: {}",
-            unknown_states.join(", "),
-            states_str.trim(),
-            STATES
-                .iter()
-                .map(|(name, _)| *name)
-                .collect::<Vec<_>>()
-                .join(", ")
+            "\n❌ keyboard.toml: unknown state(s) [{}] in fork state '{}'",
+            unknown,
+            states_str.trim()
         );
     }
 
@@ -648,9 +653,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unknown state(s) [NumLok]")]
+    #[should_panic(expected = "unknown state(s) [NumLok (did you mean NumLock?)]")]
     fn parse_state_combination_rejects_unknown_state() {
         let _ = parse_state_combination("NumLok | LShift");
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown state(s) [capslock (did you mean CapsLock?)]")]
+    fn parse_state_combination_suggests_canonical_casing() {
+        let _ = parse_state_combination("capslock | LShift");
     }
 
     #[test]

--- a/rmk-macro/src/codegen/behavior.rs
+++ b/rmk-macro/src/codegen/behavior.rs
@@ -303,7 +303,7 @@ fn expand_morses(
 
         if let Some(morse_actions) = &morse.morse_actions {
             if morse.tap.is_some() || morse.hold.is_some() || morse.hold_after_tap.is_some() || morse.double_tap.is_some() || morse.tap_actions.is_some() || morse.hold_actions.is_some() {
-                panic!("\n❌ keyboard.toml: `morse_actions` cannot be used together with `tap_actions`, `hold_actions`, `tap`, `hold`, `hold_after_tap`, or `double_tap`. Please check the documentation: https://rmk.rs/docs/features/configuration/behavior.html#morse");
+                panic!("\n❌ keyboard.toml: `morse_actions` cannot be used together with `tap_actions`, `hold_actions`, `tap`, `hold`, `hold_after_tap`, or `double_tap`.");
             }
 
             let actions_def = expand_morse_actions(morse_actions, profiles);
@@ -319,7 +319,7 @@ fn expand_morses(
         } else if morse.tap_actions.is_some() || morse.hold_actions.is_some() {
             // Check first
             if morse.tap.is_some() || morse.hold.is_some() || morse.hold_after_tap.is_some() || morse.double_tap.is_some() {
-                panic!("\n❌ keyboard.toml: `tap_actions` and `hold_actions` cannot be used together with `tap`, `hold`, `hold_after_tap`, or `double_tap`. Please check the documentation: https://rmk.rs/docs/features/configuration/behavior.html#morse");
+                panic!("\n❌ keyboard.toml: `tap_actions` and `hold_actions` cannot be used together with `tap`, `hold`, `hold_after_tap`, or `double_tap`.");
             }
 
             let tap_actions_def = match &morse.tap_actions {
@@ -462,37 +462,54 @@ impl quote::ToTokens for StateBitsMacro {
 
 /// Get modifier combination, in types of mod1 | mod2 | ...
 fn parse_state_combination(states_str: &str) -> StateBitsMacro {
+    type StateBitsSetter = fn(&mut StateBitsMacro);
+    const STATES: &[(&str, StateBitsSetter)] = &[
+        ("LCtrl", |c| c.modifiers_left_ctrl = true),
+        ("LShift", |c| c.modifiers_left_shift = true),
+        ("LAlt", |c| c.modifiers_left_alt = true),
+        ("LGui", |c| c.modifiers_left_gui = true),
+        ("RCtrl", |c| c.modifiers_right_ctrl = true),
+        ("RShift", |c| c.modifiers_right_shift = true),
+        ("RAlt", |c| c.modifiers_right_alt = true),
+        ("RGui", |c| c.modifiers_right_gui = true),
+        ("NumLock", |c| c.leds_num_lock = true),
+        ("CapsLock", |c| c.leds_caps_lock = true),
+        ("ScrollLock", |c| c.leds_scroll_lock = true),
+        ("Compose", |c| c.leds_compose = true),
+        ("Kana", |c| c.leds_kana = true),
+        ("MouseBtn1", |c| c.mouse_button1 = true),
+        ("MouseBtn2", |c| c.mouse_button2 = true),
+        ("MouseBtn3", |c| c.mouse_button3 = true),
+        ("MouseBtn4", |c| c.mouse_button4 = true),
+        ("MouseBtn5", |c| c.mouse_button5 = true),
+        ("MouseBtn6", |c| c.mouse_button6 = true),
+        ("MouseBtn7", |c| c.mouse_button7 = true),
+        ("MouseBtn8", |c| c.mouse_button8 = true),
+    ];
+
     let mut combination = StateBitsMacro::default();
+    let mut unknown_states = Vec::new();
     let tokens = states_str.split_terminator("|");
     tokens.for_each(|w| {
         let w = w.trim();
-        match w {
-            "LCtrl" => combination.modifiers_left_ctrl = true,
-            "LShift" => combination.modifiers_left_shift = true,
-            "LAlt" => combination.modifiers_left_alt = true,
-            "LGui" => combination.modifiers_left_gui = true,
-            "RCtrl" => combination.modifiers_right_ctrl = true,
-            "RShift" => combination.modifiers_right_shift = true,
-            "RAlt" => combination.modifiers_right_alt = true,
-            "RGui" => combination.modifiers_right_gui = true,
-
-            "NumLock" => combination.leds_num_lock = true,
-            "CapsLock" => combination.leds_caps_lock = true,
-            "ScrollLock" => combination.leds_scroll_lock = true,
-            "Compose" => combination.leds_compose = true,
-            "Kana" => combination.leds_kana = true,
-
-            "MouseBtn1" => combination.mouse_button1 = true,
-            "MouseBtn2" => combination.mouse_button2 = true,
-            "MouseBtn3" => combination.mouse_button3 = true,
-            "MouseBtn4" => combination.mouse_button4 = true,
-            "MouseBtn5" => combination.mouse_button5 = true,
-            "MouseBtn6" => combination.mouse_button6 = true,
-            "MouseBtn7" => combination.mouse_button7 = true,
-            "MouseBtn8" => combination.mouse_button8 = true,
-            _ => (),
+        match STATES.iter().find(|(name, _)| *name == w) {
+            Some((_, set)) => set(&mut combination),
+            None => unknown_states.push(w.to_string()),
         }
     });
+
+    if !unknown_states.is_empty() {
+        panic!(
+            "\n❌ keyboard.toml: unknown state(s) [{}] in fork state '{}'. Expected one of: {}.",
+            unknown_states.join(", "),
+            states_str.trim(),
+            STATES
+                .iter()
+                .map(|(name, _)| *name)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
 
     combination
 }
@@ -514,7 +531,7 @@ fn expand_forks(
                 let bindable = fork.bindable;
 
                 if match_any.is_empty() && match_none.is_empty() {
-                    panic!("\n❌ keyboard.toml: fork configuration missing match conditions! Please check the documentation: https://rmk.rs/docs/features/configuration/behavior.html#fork");
+                    panic!("\n❌ keyboard.toml: fork configuration missing match conditions!");
                 }
 
                 quote! { ::rmk::types::fork::Fork::new(#trigger, #negative_output, #positive_output, #match_any, #match_none, #kept.modifiers, #bindable) }
@@ -603,5 +620,25 @@ pub(crate) fn expand_behavior_config(behavior: &Behavior) -> proc_macro2::TokenS
             auto_mouse_layer: #auto_mouse_layer,
             ..Default::default()
         };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_state_combination_sets_bits_for_valid_states() {
+        let s = parse_state_combination("LShift|MouseBtn1 |CapsLock");
+        assert!(s.modifiers_left_shift);
+        assert!(s.mouse_button1);
+        assert!(s.leds_caps_lock);
+        assert!(!s.modifiers_right_ctrl);
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown state(s) [NumLok]")]
+    fn parse_state_combination_rejects_unknown_state() {
+        let _ = parse_state_combination("NumLok | LShift");
     }
 }

--- a/rmk-macro/src/codegen/behavior.rs
+++ b/rmk-macro/src/codegen/behavior.rs
@@ -10,8 +10,8 @@ use rmk_config::resolved::behavior::{
 };
 
 use super::action_parser::{
-    as_hid_keycode, closest_name, expand_profile, expand_profile_name, get_key_with_alias,
-    parse_action, parse_key, sorted_profile_names,
+    SetterTable, as_hid_keycode, expand_profile, expand_profile_name, get_key_with_alias,
+    parse_action, parse_key, parse_name_list, sorted_profile_names,
 };
 use super::feature::{get_rmk_features, is_feature_enabled};
 
@@ -462,8 +462,7 @@ impl quote::ToTokens for StateBitsMacro {
 
 /// Get modifier combination, in types of mod1 | mod2 | ...
 fn parse_state_combination(states_str: &str) -> StateBitsMacro {
-    type StateBitsSetter = fn(&mut StateBitsMacro);
-    const STATES: &[(&str, StateBitsSetter)] = &[
+    const STATES: &SetterTable<StateBitsMacro> = &[
         ("LCtrl", |c| c.modifiers_left_ctrl = true),
         ("LShift", |c| c.modifiers_left_shift = true),
         ("LAlt", |c| c.modifiers_left_alt = true),
@@ -487,47 +486,7 @@ fn parse_state_combination(states_str: &str) -> StateBitsMacro {
         ("MouseBtn8", |c| c.mouse_button8 = true),
     ];
 
-    let mut combination = StateBitsMacro::default();
-    let mut unknown_states = Vec::new();
-    let mut has_empty_segment = false;
-    states_str.split("|").for_each(|w| {
-        let w = w.trim();
-        if w.is_empty() {
-            has_empty_segment = true;
-            return;
-        }
-        match STATES.iter().find(|(name, _)| *name == w) {
-            Some((_, set)) => set(&mut combination),
-            None => unknown_states.push(w.to_string()),
-        }
-    });
-
-    if !unknown_states.is_empty() {
-        let unknown = unknown_states
-            .iter()
-            .map(
-                |u| match closest_name(u, STATES.iter().map(|(name, _)| *name)) {
-                    Some(s) => format!("{u} (did you mean {s}?)"),
-                    None => u.clone(),
-                },
-            )
-            .collect::<Vec<_>>()
-            .join(", ");
-        panic!(
-            "\n❌ keyboard.toml: unknown state(s) [{}] in fork state '{}'",
-            unknown,
-            states_str.trim()
-        );
-    }
-
-    if has_empty_segment {
-        panic!(
-            "\n❌ keyboard.toml: fork state '{}' contains empty segments between '|' separators.",
-            states_str.trim()
-        );
-    }
-
-    combination
+    parse_name_list(states_str, "state", "fork state", STATES, |w| w)
 }
 
 fn expand_forks(

--- a/rmk-macro/src/codegen/behavior.rs
+++ b/rmk-macro/src/codegen/behavior.rs
@@ -489,9 +489,13 @@ fn parse_state_combination(states_str: &str) -> StateBitsMacro {
 
     let mut combination = StateBitsMacro::default();
     let mut unknown_states = Vec::new();
-    let tokens = states_str.split_terminator("|");
-    tokens.for_each(|w| {
+    let mut has_empty_segment = false;
+    states_str.split("|").for_each(|w| {
         let w = w.trim();
+        if w.is_empty() {
+            has_empty_segment = true;
+            return;
+        }
         match STATES.iter().find(|(name, _)| *name == w) {
             Some((_, set)) => set(&mut combination),
             None => unknown_states.push(w.to_string()),
@@ -500,7 +504,7 @@ fn parse_state_combination(states_str: &str) -> StateBitsMacro {
 
     if !unknown_states.is_empty() {
         panic!(
-            "\n❌ keyboard.toml: unknown state(s) [{}] in fork state '{}'. Expected one of: {}.",
+            "\n❌ keyboard.toml: unknown state(s) [{}] in fork state '{}'. Expected one of: {}",
             unknown_states.join(", "),
             states_str.trim(),
             STATES
@@ -508,6 +512,13 @@ fn parse_state_combination(states_str: &str) -> StateBitsMacro {
                 .map(|(name, _)| *name)
                 .collect::<Vec<_>>()
                 .join(", ")
+        );
+    }
+
+    if has_empty_segment {
+        panic!(
+            "\n❌ keyboard.toml: fork state '{}' contains empty segments between '|' separators.",
+            states_str.trim()
         );
     }
 
@@ -640,5 +651,17 @@ mod tests {
     #[should_panic(expected = "unknown state(s) [NumLok]")]
     fn parse_state_combination_rejects_unknown_state() {
         let _ = parse_state_combination("NumLok | LShift");
+    }
+
+    #[test]
+    #[should_panic(expected = "empty segment")]
+    fn parse_state_combination_rejects_trailing_separator() {
+        let _ = parse_state_combination("LShift|");
+    }
+
+    #[test]
+    #[should_panic(expected = "empty segment")]
+    fn parse_state_combination_rejects_doubled_separator() {
+        let _ = parse_state_combination("CapsLock || MouseBtn1");
     }
 }


### PR DESCRIPTION
This branch enhances the macro code generation to add `rustc`-style diagnostics for unknown keycodes, bad layer indexes, and misspelled modifiers or fork states.