### PR TITLE
ci: install libdbus for the publish verify builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,6 +88,12 @@ jobs:
         with:
           shared-key: publish
 
+      # The rynk-ble verify build links BlueZ through libdbus on the host.
+      - name: Install host system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
+
       - id: auth
         uses: rust-lang/crates-io-auth-action@v1
 


### PR DESCRIPTION
The v0.9.0 Publish run (33237673001) failed at `rynk-ble`'s verify build: `cargo publish` builds each crate with default features on the host, and rynk-ble's BlueZ backend needs `libdbus-1-dev`/`pkg-config`, which `ci.yml` installs but `publish.yml` did not.

Six of nine crates published before the failure (rmk-config 0.8.0, rmk-types 0.4.0, rmk-macro 0.8.0, rmk 0.9.0, rynk 0.3.0, rynk-usb 0.3.0); no tags or GitHub release were created. `publish.sh` skips already-published versions, so after this merges, re-dispatching Publish resumes from rynk-ble and then tags/releases everything.