### PR TITLE
ci: push release tags one ref per push

### DIFF
--- a/.github/ci/publish.sh
+++ b/.github/ci/publish.sh
@@ -37,6 +37,7 @@ for name in "${RELEASE_CRATES[@]}"; do
 done
 
 log_section "Tagging"
+created_tags=()
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 for name in "${RELEASE_CRATES[@]}"; do
@@ -46,9 +47,14 @@ for name in "${RELEASE_CRATES[@]}"; do
     # A crate that never made it to crates.io must not get a tag saying it did.
     crate_published "$name" "$version" || continue
     git tag -a "$tag" -m "$name $version"
+    created_tags+=("$tag")
     echo "created $tag"
 done
-git push origin --tags
+# One ref per push: the repository ruleset rejects pushes that update more
+# than 5 refs (GH013), which a 9-crate release trips with `--tags`.
+for tag in ${created_tags[@]+"${created_tags[@]}"}; do
+    git push origin "refs/tags/$tag"
+done
 
 log_section "GitHub release"
 version="$(crate_version rmk)"


### PR DESCRIPTION
The resumed v0.9.0 Publish run (33238029609) got all nine crates onto crates.io, then died at `git push origin --tags`: the repository ruleset rejects pushes that update more than 5 refs (GH013), so all 9 tags were refused atomically and the GitHub release was never created.

Push each tag the run creates individually — immune to the ruleset limit and it no longer sweeps up unrelated local tags. After this merges, re-dispatching Publish skips all nine publishes (already on crates.io), creates and pushes the tags, and creates the `rmk-v0.9.0` release (which fires the Discord announcement).