### PR TITLE
docs: archive v0.9 in the version picker

### DIFF
--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,1 +1,1 @@
-["docs/v0.8", "docs/v0.7.8"]
+["docs/v0.9", "docs/v0.8", "docs/v0.7.8"]


### PR DESCRIPTION
Adds `docs/v0.9` (branched at 986017d, the rmk-v0.9.0 release commit) to the site's version list. A main push after merge redeploys rmk.rs with v0.9 as the newest archived version.