### PR TITLE
ci: create the GitHub release with the App token so dc.yml fires

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,9 +97,6 @@ jobs:
       - id: auth
         uses: rust-lang/crates-io-auth-action@v1
 
-      # Events from the default GITHUB_TOKEN never trigger other workflows, so
-      # a release created with it does not fire dc.yml's Discord announcement.
-      # Create the release with the release App's token instead.
       - id: app-token
         uses: actions/create-github-app-token@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,8 +97,17 @@ jobs:
       - id: auth
         uses: rust-lang/crates-io-auth-action@v1
 
+      # Events from the default GITHUB_TOKEN never trigger other workflows, so
+      # a release created with it does not fire dc.yml's Discord announcement.
+      # Create the release with the release App's token instead.
+      - id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Publish, tag, release
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: .github/ci/publish.sh


### PR DESCRIPTION
The rmk-v0.9.0 GitHub release was created by publish.sh with the workflow's default `GITHUB_TOKEN`, and events from that token never trigger other workflows — so dc.yml's `release: published` Discord announcement did not fire (its last run is still v0.8.2).

Mint a token from the release App (same secrets release-pr.yml already uses) and pass it to publish.sh as `GH_TOKEN`, so `gh release create` produces an event that triggers dc.yml. Tag pushes still use the checkout credentials and are unaffected.